### PR TITLE
Fix SIMD function name mismatches in HNSW implementation

### DIFF
--- a/sochdb-index/src/hnsw.rs
+++ b/sochdb-index/src/hnsw.rs
@@ -6013,7 +6013,7 @@ impl HnswIndex {
         
         #[cfg(target_arch = "x86_64")]
         unsafe {
-            simd_distance::cosine_distance_avx2_fused(a, b)
+            simd_distance::cosine_distance_fast(a, b)
         }
         #[cfg(target_arch = "aarch64")]
         unsafe {
@@ -6033,7 +6033,7 @@ impl HnswIndex {
         
         #[cfg(target_arch = "x86_64")]
         unsafe {
-            simd_distance::cosine_distance_avx2_fused(a, b)
+            simd_distance::cosine_distance_fast(a, b)
         }
         #[cfg(target_arch = "aarch64")]
         unsafe {
@@ -6173,7 +6173,7 @@ impl HnswIndex {
         
         #[cfg(target_arch = "x86_64")]
         unsafe {
-            simd_distance::l2_distance_avx2_fused(a, b)
+            simd_distance::l2_distance_fast(a, b)
         }
         #[cfg(target_arch = "aarch64")]
         unsafe {
@@ -6193,7 +6193,7 @@ impl HnswIndex {
         
         #[cfg(target_arch = "x86_64")]
         unsafe {
-            simd_distance::l2_distance_avx2_fused(a, b)
+            simd_distance::l2_distance_fast(a, b)
         }
         #[cfg(target_arch = "aarch64")]
         unsafe {
@@ -6333,7 +6333,7 @@ impl HnswIndex {
         
         #[cfg(target_arch = "x86_64")]
         unsafe {
-            simd_distance::dot_product_avx2_fused(a, b)
+            simd_distance::dot_product_avx2(a, b)
         }
         #[cfg(target_arch = "aarch64")]
         unsafe {
@@ -6353,7 +6353,7 @@ impl HnswIndex {
         
         #[cfg(target_arch = "x86_64")]
         unsafe {
-            simd_distance::dot_product_avx2_fused(a, b)
+            simd_distance::dot_product_avx2(a, b)
         }
         #[cfg(target_arch = "aarch64")]
         unsafe {


### PR DESCRIPTION
- Replace cosine_distance_avx2_fused with cosine_distance_fast
- Replace l2_distance_avx2_fused with l2_distance_fast
- Replace dot_product_avx2_fused with dot_product_avx2
- Resolves 6 compilation errors on x86_64 Linux CI