### PR TITLE
added grpc_health_probe and sochdb-fusion in dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,6 +41,7 @@ COPY sochdb-wasm ./sochdb-wasm
 COPY sochdb-tools ./sochdb-tools
 COPY sochdb-plugin-logging ./sochdb-plugin-logging
 COPY proto ./proto
+COPY sochdb-fusion ./sochdb-fusion
 
 # Build release binary
 RUN cargo build --release --package sochdb-grpc --bin sochdb-grpc-server
@@ -49,7 +50,8 @@ RUN cargo build --release --package sochdb-grpc --bin sochdb-grpc-server
 # Stage 2: Runtime
 # =============================================================================
 FROM debian:bookworm-slim AS runtime
-
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.38 \
+    /ko-app/grpc-health-probe /bin/grpc_health_probe
 # Install minimal runtime dependencies
 RUN apt-get update && apt-get install -y \
     ca-certificates \


### PR DESCRIPTION
 Changes

1. Container had no health status
The Dockerfile already had a HEALTHCHECK directive but `grpc_health_probe` was never installed in the runtime image, so it was failing silently every time. I fixed this by copying the binary from the official 
grpc-health-probe image so the container now correctly reports 
`healthy` once the gRPC server is up.
 2. Image was completely unbuildable from source
When I tried to build the image from a fresh clone I got:

  "failed to load manifest for workspace member /build/sochdb-fusion"
 Added a COPY instructions. to sochdb-fusion in dockerfile 

 3. Dockerfile.slim missing HEALTHCHECK
I noticed the slim variant had no HEALTHCHECK directive at all.
I tried to fix it but ran into a pre-existing build failure:

  "async-trait v0.1.89 does not support x86_64-unknown-linux-musl 
   as a proc-macro target"

This issue i don't know how to solve it so i did n't changed anything in docker.slim file 

 Testing
Built the image locally and ran it — container reports `healthy` 
after startup.

Let me know if I missed anything.