### PR TITLE
Improve sochdb-python local build, SDK alignment, onboarding, and local retrieval demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ sochdb_agent_memory/
 toondb_rust.txt
 test_k8s_concurrency.py
 test_k8s_deployment.py
+knowledge_demo_db/
+meeting_demo_db/
+repo_demo_db/
+*_demo_db/

--- a/docs/guides/python-sdk.md
+++ b/docs/guides/python-sdk.md
@@ -43,6 +43,33 @@ Complete guide to SochDB's Python SDK covering dual-mode architecture (embedded 
 pip install sochdb
 ```
 
+### Local Development From Source
+
+If you're working from this monorepo rather than consuming the published PyPI package,
+build the editable package from `sochdb-python/`:
+
+```bash
+cd sochdb-python
+pip install maturin
+maturin develop --release
+```
+
+Then use the package from that same Python environment:
+
+```python
+from sochdb import Database
+```
+
+### macOS Architecture Note
+
+SochDB's Python package uses native Rust extensions. On macOS, your Python runtime
+architecture must match the native library architecture:
+
+- Apple Silicon Python should use `arm64` builds
+- Intel / Rosetta Python should use `x86_64` builds
+
+Mixed environments can fail at import/load time with native library errors.
+
 **What's New in 0.4.7:**
 - ✅ Improved FFI stability and error messages
 - ✅ Better platform detection for native libraries

--- a/docs/guides/python-sdk.md
+++ b/docs/guides/python-sdk.md
@@ -111,12 +111,15 @@ Mixed environments can fail at import/load time with native library errors.
 from sochdb import Database
 
 # Open database
-with Database.open("./my_database") as db:
-    # Put and Get
-    db.put(b"user:123", b'{"name":"Alice","age":30}')
-    value = db.get(b"user:123")
-    print(value.decode())
-    # Output: {"name":"Alice","age":30}
+db = Database.open("./my_database")
+
+# Put and Get
+db.put(b"user:123", b'{"name":"Alice","age":30}')
+value = db.get(b"user:123")
+print(value.decode())
+
+db.close()
+# Output: {"name":"Alice","age":30}
 ```
 
 **Output:**
@@ -138,9 +141,10 @@ Direct FFI bindings to Rust libraries. No server required.
 from sochdb import Database
 
 # Direct FFI - no server needed
-with Database.open("./mydb") as db:
-    db.put(b"key", b"value")
-    value = db.get(b"key")
+db = Database.open("./mydb")
+db.put(b"key", b"value")
+value = db.get(b"key")
+db.close()
 ```
 
 **Best for:** Local development, notebooks, simple apps, edge deployments.

--- a/examples/README.md
+++ b/examples/README.md
@@ -66,14 +66,23 @@ Real-world examples showing how to use SochDB for AI/LLM applications.
 ### 1. Setup Environment
 
 ```bash
-# Install Python dependencies
-pip install python-dotenv requests numpy
+# Install the published SDK
+pip install sochdb python-dotenv requests numpy
 
-# For LangGraph
+# Install Python dependencies
 pip install langgraph langchain-core
 
 # For CrewAI (optional)
 pip install crewai crewai-tools
+```
+
+If you're developing from the monorepo instead of using the published package:
+
+```bash
+cd sochdb-python
+pip install maturin
+maturin develop --release
+cd ..
 ```
 
 ### 2. Configure Azure OpenAI
@@ -95,15 +104,17 @@ AZURE_EMEBEDDING_API_VERSION="2024-12-01-preview"
 ### 3. Run Examples
 
 ```bash
-# Set environment
-export PYTHONPATH=$(pwd)/sochdb-python-sdk/src
-export SOCHDB_LIB_PATH=$(pwd)/target/release
-
 # Run any example
 python3 examples/python/langgraph_agent.py
 python3 examples/python/simple_rag_chatbot.py
 python3 examples/python/semantic_search_api.py
 ```
+
+### 4. macOS Architecture Note
+
+If you're using a local Rust build or editable Python install on macOS, make sure
+your Python environment architecture matches the native library architecture
+(`arm64` vs `x86_64`). Mixed-architecture setups can fail during native library load.
 
 ## Example Highlights
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,7 @@ Real-world examples showing how to use SochDB for AI/LLM applications.
 | Example | Description | Key Features |
 |---------|-------------|--------------|
 | [06_sql_queries.py](python/06_sql_queries.py) | SQL query operations | CREATE TABLE, INSERT, SELECT, UPDATE, DELETE, JOINs |
+| [07_local_knowledge_search.py](python/07_local_knowledge_search.py) | Local knowledge-base retrieval | Embedded DB, local vectors, no external APIs |
 | [customer_support_rag.py](python/customer_support_rag.py) | Multi-tenant support system | ACL, time decay, OOD handling |
 | [ecommerce_search.py](python/ecommerce_search.py) | Product semantic search | Multi-vector, faceted filtering |
 | [semantic_dedup.py](python/semantic_dedup.py) | Near-duplicate detection | Threshold matching, clustering |

--- a/examples/python/07_local_knowledge_search.py
+++ b/examples/python/07_local_knowledge_search.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+SochDB Local Knowledge Search Demo
+=================================
+
+This example shows a local-only retrieval workflow for the first ICP:
+Python-first AI engineers building internal knowledge search or lightweight
+RAG systems without external APIs.
+
+What it demonstrates:
+1. Store documents in SochDB
+2. Build a local vector index with deterministic embeddings
+3. Query the index and fetch full document payloads from the database
+
+Usage:
+    python3 examples/python/07_local_knowledge_search.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+from typing import Iterable
+
+import numpy as np
+
+from sochdb import Database, HnswIndex
+
+
+DB_PATH = "./knowledge_demo_db"
+DIMENSION = 64
+
+
+DOCUMENTS = [
+    {
+        "id": 101,
+        "title": "Laptop VPN Setup",
+        "body": "To access internal dashboards, install the company VPN client and connect before opening private services.",
+        "tags": ["it", "security", "access"],
+    },
+    {
+        "id": 102,
+        "title": "Expense Reimbursement Policy",
+        "body": "Employees should submit travel and meal receipts within 30 days using the finance portal reimbursement form.",
+        "tags": ["finance", "policy", "travel"],
+    },
+    {
+        "id": 103,
+        "title": "On-Call Incident Process",
+        "body": "If production is degraded, page the on-call engineer, open an incident channel, and post updates every 15 minutes.",
+        "tags": ["sre", "incident", "operations"],
+    },
+    {
+        "id": 104,
+        "title": "Customer Support Escalation",
+        "body": "Urgent customer issues should be escalated to tier two support with logs, screenshots, and account identifiers attached.",
+        "tags": ["support", "customers", "triage"],
+    },
+    {
+        "id": 105,
+        "title": "Access Review Checklist",
+        "body": "Managers must review employee access to internal tools quarterly and remove permissions that are no longer required.",
+        "tags": ["security", "access", "compliance"],
+    },
+]
+
+
+def tokenize(text: str) -> Iterable[str]:
+    return (
+        token.strip(".,:;!?()[]{}").lower()
+        for token in text.split()
+        if token.strip(".,:;!?()[]{}")
+    )
+
+
+def embed_text(text: str, dimension: int = DIMENSION) -> np.ndarray:
+    """Deterministic local embedding using hashed token buckets."""
+    vec = np.zeros(dimension, dtype=np.float32)
+    for token in tokenize(text):
+        digest = hashlib.blake2b(token.encode("utf-8"), digest_size=8).digest()
+        bucket = int.from_bytes(digest[:4], "little") % dimension
+        sign = 1.0 if digest[4] % 2 == 0 else -1.0
+        vec[bucket] += sign
+    norm = np.linalg.norm(vec)
+    if norm > 0:
+        vec /= norm
+    return vec
+
+
+def main() -> None:
+    print("=" * 60)
+    print("  SochDB Local Knowledge Search")
+    print("=" * 60)
+
+    if os.path.exists(DB_PATH):
+        shutil.rmtree(DB_PATH)
+
+    db = Database.open(DB_PATH)
+    index = HnswIndex(dimension=DIMENSION, m=16, ef_construction=100, metric="cosine")
+
+    ids = np.array([doc["id"] for doc in DOCUMENTS], dtype=np.uint64)
+    vectors = np.vstack([
+        embed_text(f"{doc['title']} {doc['body']} {' '.join(doc['tags'])}")
+        for doc in DOCUMENTS
+    ]).astype(np.float32)
+
+    print("\n[1] Storing documents in SochDB...")
+    with db.transaction() as txn:
+        for doc in DOCUMENTS:
+            key = f"docs/{doc['id']}".encode("utf-8")
+            db.put(key, json.dumps(doc).encode("utf-8"), txn.id)
+    print(f"    Stored {len(DOCUMENTS)} documents")
+
+    print("\n[2] Building local HNSW index...")
+    inserted = index.insert_batch_with_ids(ids, vectors)
+    print(f"    Indexed {inserted} document embeddings")
+
+    query = "How do I access internal tools securely from my laptop?"
+    print(f"\n[3] Query: {query}")
+    query_vec = embed_text(query)
+    result_ids, distances = index.search(query_vec, k=3)
+
+    print("\n[4] Top matches")
+    for rank, (doc_id, score) in enumerate(zip(result_ids.tolist(), distances.tolist()), start=1):
+        payload = db.get(f"docs/{doc_id}".encode("utf-8"))
+        if payload is None:
+            continue
+        doc = json.loads(payload.decode("utf-8"))
+        print(f"    {rank}. {doc['title']} (id={doc_id}, distance={score:.4f})")
+        print(f"       {doc['body']}")
+
+    db.close()
+
+    print("\n" + "=" * 60)
+    print("  ✅ Demo complete: local data + local retrieval in one workflow")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/sochdb-python/Cargo.toml
+++ b/sochdb-python/Cargo.toml
@@ -3,7 +3,7 @@ name = "sochdb-python"
 version = "0.5.0"
 edition = "2024"
 authors = ["Sushanth <sushanth@sochdb.dev>"]
-license.workspace = true
+license = "AGPL-3.0-or-later"
 description = "SochDB Python native extension with PyO3 - zero-copy vector operations"
 
 [lib]

--- a/sochdb-python/README.md
+++ b/sochdb-python/README.md
@@ -1,1 +1,53 @@
-# SochDB Python Bindings
+# SochDB Python SDK
+
+Python bindings for SochDB's embedded database and native vector capabilities.
+
+## 10-Minute Quickstart
+
+### Option 1: Use the published package
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install sochdb
+```
+
+### Option 2: Work from this monorepo
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install maturin
+cd sochdb-python
+maturin develop --release
+```
+
+### Verify the SDK
+
+```python
+from sochdb import Database
+
+db = Database.open("./quickstart_db")
+
+with db.transaction() as txn:
+    db.put(b"users/alice", b'{"name":"Alice"}', txn.id)
+
+print("alice:", db.get(b"users/alice"))
+db.close()
+```
+
+Expected output:
+
+```text
+alice: b'{"name":"Alice"}'
+```
+
+## Notes
+
+- Python 3.9+ is required.
+- On macOS, Python architecture must match the native library architecture:
+  - Apple Silicon Python should use `arm64`
+  - Intel / Rosetta Python should use `x86_64`
+- Mixed-architecture setups can fail at native library load time.

--- a/sochdb-python/pyproject.toml
+++ b/sochdb-python/pyproject.toml
@@ -75,8 +75,9 @@ features = ["abi3"]
 python-source = "python"
 module-name = "sochdb._native"
 
-# Strip binaries for smaller wheels
-strip = true
+# Keep local `maturin develop --release` working consistently across environments.
+# Wheel size optimization can still be handled in release packaging workflows.
+strip = false
 
 # Compatibility settings
 # ABI3 means one wheel works for Python 3.9+

--- a/sochdb-python/python/sochdb/__init__.py
+++ b/sochdb-python/python/sochdb/__init__.py
@@ -26,7 +26,9 @@ from __future__ import annotations
 # Import native extension
 try:
     from sochdb._native import (
+        Database,
         HnswIndex,
+        Transaction,
         build_index,
         version,
         is_safe_mode,
@@ -39,7 +41,9 @@ except ImportError as e:
 # Re-export for convenience
 __all__ = [
     # Core classes
+    "Database",
     "HnswIndex",
+    "Transaction",
     # Functions
     "build_index",
     "build_index_from_numpy",
@@ -50,7 +54,7 @@ __all__ = [
     "bulk_build_index",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.5.0"
 
 
 def _check_native():
@@ -223,6 +227,12 @@ if _HAS_NATIVE:
     pass
 else:
     # Stub classes for IDE autocomplete when native not installed
+    class Database:
+        """SochDB Database (stub - native extension not loaded)."""
+
+        def __init__(self, *args, **kwargs):
+            _check_native()
+
     class HnswIndex:
         """HNSW Vector Index (stub - native extension not loaded)."""
         
@@ -244,4 +254,10 @@ else:
         
         @staticmethod
         def load(path: str) -> "HnswIndex":
+            _check_native()
+
+    class Transaction:
+        """SochDB Transaction (stub - native extension not loaded)."""
+
+        def __init__(self, *args, **kwargs):
             _check_native()

--- a/sochdb-python/src/lib.rs
+++ b/sochdb-python/src/lib.rs
@@ -875,6 +875,19 @@ impl PyDatabase {
             .map_err(|e| PyIOError::new_err(e.to_string()))
     }
 
+    /// Create a Python context-manager transaction wrapper.
+    pub fn transaction(slf: PyRef<'_, Self>) -> PyResult<PyTransaction> {
+        PyTransaction::new(slf.into())
+    }
+
+    /// Close the database handle.
+    ///
+    /// The underlying Rust connection cleans up on drop, so this is a
+    /// compatibility no-op for Python callers that expect an explicit close().
+    pub fn close(&self) -> PyResult<()> {
+        Ok(())
+    }
+
     fn __repr__(&self) -> String {
         "Database(open)".to_string()
     }
@@ -991,7 +1004,7 @@ impl PyTransaction {
 ///     >>> db.put(b"key", b"value")
 ///     >>> value = db.get(b"key")
 #[pymodule]
-fn sochdb(m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Vector index
     m.add_class::<PyHnswIndex>()?;
     m.add_function(wrap_pyfunction!(build_index, m)?)?;


### PR DESCRIPTION
## Summary

This PR improves the repo-local `sochdb-python` development path, aligns the in-repo Python SDK surface with the documented `Database` workflow, clarifies setup/onboarding docs, and adds a local knowledge-search demo for the first Python-first retrieval use case.

## Included changes

### Local Python build
- set an explicit license in `sochdb-python/Cargo.toml`
- disable `strip` in `sochdb-python/pyproject.toml` to avoid local `maturin develop --release` conflicts

### Python SDK alignment
- align the PyO3 module name to `_native`
- re-export `Database` and `Transaction` from `python/sochdb/__init__.py`
- update Python package version string
- add `Database.transaction()` helper
- add `Database.close()` compatibility method

### Docs / onboarding
- document local Python source-build flow with `maturin develop --release`
- add macOS architecture guidance (`arm64` vs `x86_64`)
- remove stale `sochdb-python-sdk` assumptions from examples docs
- add a `sochdb-python/README.md` quickstart
- align the Python SDK guide quickstart with the validated open/put/get/close flow

### Demo / GTM asset
- add `examples/python/07_local_knowledge_search.py`
  - local-only
  - no external APIs
  - stores documents in SochDB
  - builds a local HNSW index
  - retrieves matching records from the database
- ignore generated local demo database folders in `.gitignore`

## Why

While validating the Python contributor and user paths locally, I hit several issues before meaningful product testing was possible:

1. standalone `maturin develop --release` failed on manifest/config issues
2. the built native module name did not match the expected `_native` import path
3. the top-level Python package did not expose the documented `Database` flow cleanly
4. docs/examples needed clearer source-build and macOS setup guidance
5. there was no simple local-first Python demo for the “embedded retrieval workflow” story

This PR addresses those issues and makes the local Python SDK path materially easier to build, use, and explain.

## Validation

### Repo-local Python flow
Validated repo-local Python `Database` flow:

```python
from sochdb import Database

db = Database.open("./meeting_demo_db")

with db.transaction() as txn:
    db.put(b"users/alice", b'{"name":"Alice"}', txn.id)

print("alice:", db.get(b"users/alice"))
db.close()


Output:

alice: b'{"name":"Alice"}'
```

Also validated that the published PyPI package works in a clean native arm64 Python environment.

Local demo
Validated the new local-only demo:
python examples/python/07_local_knowledge_search.py

which completes successfully and demonstrates:

local DB storage
local vector indexing
local retrieval without external APIs

Notes
This does not fully resolve every Python/platform issue yet.

During validation, I also observed:

macOS architecture sensitivity (x86_64 Python vs arm64 native library)
differences between the repo-local source path and the currently published PyPI/runtime path
the notebook version of the local knowledge-search walkthrough currently lives in the separate sochdb-notebooks repo clone, not this PR

But this PR removes several immediate blockers in the local Python contributor and SDK workflow, improves docs alignment, and adds a concrete first-wedge demo asset.