### PR TITLE
Improve Python start-here path, evaluator docs, and packaging guidance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,12 @@ jobs:
             target: aarch64-apple-darwin
             binary_ext: ""
             lib_ext: ".dylib"
+
+          # macOS x86_64 (Intel)
+          - os: macos-13
+            target: x86_64-apple-darwin
+            binary_ext: ""
+            lib_ext: ".dylib"
             
           # Windows x64
           - os: windows-latest
@@ -301,7 +307,7 @@ jobs:
         run: |
           mkdir -p release-assets
           
-          for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu aarch64-apple-darwin x86_64-pc-windows-msvc; do
+          for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu aarch64-apple-darwin x86_64-apple-darwin x86_64-pc-windows-msvc; do
             if [ -d "release-binaries/$target" ]; then
               cd release-binaries
               if [ "$target" = "x86_64-pc-windows-msvc" ]; then
@@ -356,7 +362,8 @@ jobs:
             This release includes pre-built binaries for:
             - Linux x86_64
             - Linux aarch64 (ARM64) — AWS Graviton, Ampere Altra
-            - macOS ARM64 (Apple Silicon) - Intel Macs use Rosetta 2
+            - macOS ARM64 (Apple Silicon)
+            - macOS x86_64 (Intel)
             - Windows x64
             
             See [CHANGELOG.md](https://github.com/sochdb/sochdb/blob/main/CHANGELOG.md) for details.
@@ -401,4 +408,5 @@ jobs:
           echo "- ✅ Linux x86_64" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Linux aarch64 (ARM64)" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ macOS ARM64 (Apple Silicon)" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ macOS x86_64 (Intel)" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Windows x64" >> $GITHUB_STEP_SUMMARY

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,7 +12,9 @@ Complete installation guide for SochDB across different platforms and use cases.
 pip install sochdb
 ```
 
-**Pre-built binaries** are available for Linux (`x86_64`, `aarch64`), macOS (Intel, Apple Silicon), and Windows (`x86_64`).
+**Recommended first path on Apple Silicon:** use a native `arm64` Python environment.
+
+We validated the packaged Python path successfully in a clean native `arm64` macOS environment. If you are on Apple Silicon but your Python reports `x86_64`, you are likely in a Rosetta/Intel environment and should switch to native `arm64` first.
 
 ### Verify Installation
 
@@ -20,8 +22,7 @@ pip install sochdb
 from sochdb import Database
 
 db = Database.open("./test_db")
-with db.transaction() as txn:
-    db.put(b"test", b"hello", txn.id)
+db.put(b"test", b"hello")
 
 value = db.get(b"test")
 print(f"SochDB installed! Value: {value.decode()}")
@@ -162,6 +163,8 @@ python -c "import platform; print(platform.machine())"
 # Should output: arm64
 ```
 
+If this prints `x86_64` on an Apple Silicon Mac, do not treat that as the recommended packaged path. Switch to a native `arm64` Python environment first.
+
 ### Linux
 
 For best performance, ensure your kernel supports `io_uring`:
@@ -191,9 +194,7 @@ from sochdb import Database
 
 # Test basic operations
 db = Database.open("./verify_db")
-
-with db.transaction() as txn:
-    db.put(b"test/key", b"value", txn.id)
+db.put(b"test/key", b"value")
 
 value = db.get(b"test/key")
 assert value == b"value", "Basic KV operations failed"

--- a/docs/getting-started/local-retrieval-start-here.md
+++ b/docs/getting-started/local-retrieval-start-here.md
@@ -8,6 +8,8 @@ This is the clearest current evaluator path for SochDB.
 
 If you want to understand the product quickly and practically, start here instead of trying every feature in the repo.
 
+If you are a Python-first ML or AI engineer, also read [Python / ML / AI Start Here](/getting-started/python-ml-ai-start-here).
+
 ## Who This Path Is For
 
 This path is best for:
@@ -80,16 +82,16 @@ That page helps answer:
 - what you would actually manage locally
 - how SochDB compares to SQLite + FAISS, pgvector, and vector-first tools
 
-### 5. Look at the benchmark summary
+### 5. Look at the benchmark and evaluation notes
 
 Use:
 
-- [Local Retrieval Benchmark Summary](/Users/saisandeepkantareddy/Downloads/sochdb/benchmarks/retrieval/summary.md)
+- [Retrieval Evaluation](/guides/retrieval-evaluation)
 
 That gives you:
 
-- starter benchmark results
-- SciFact public-dataset results
+- benchmark structure and comparison method
+- starter and public-dataset evaluation context
 - SochDB fast and quality presets
 - workflow-complexity interpretation
 
@@ -134,6 +136,7 @@ A good first evaluation asks:
 
 - [Installation](/getting-started/installation)
 - [Python Install Matrix](/getting-started/python-install-matrix)
+- [Python / ML / AI Start Here](/getting-started/python-ml-ai-start-here)
 - [Use SochDB When](/getting-started/use-sochdb-when)
 - [Local Knowledge Retrieval Comparison](/getting-started/local-knowledge-retrieval-comparison)
 - [What Works Today](/getting-started/what-works-today)

--- a/docs/getting-started/python-install-matrix.md
+++ b/docs/getting-started/python-install-matrix.md
@@ -10,7 +10,8 @@ The short version:
 
 - Use `pip install sochdb` for the published package
 - Use `sochdb-python/` + `maturin develop --release` when working from this monorepo
-- On macOS, your Python architecture must match the native extension architecture
+- On Apple Silicon Macs, prefer a native `arm64` Python env for the packaged path
+- Avoid `x86_64` / Rosetta Python envs on Apple Silicon for the packaged path unless you know you need them
 
 ---
 
@@ -21,7 +22,7 @@ The short version:
 | Try SochDB quickly as a Python user | `pip install sochdb` | Recommended |
 | Work on the Python SDK from source | `cd sochdb-python && maturin develop --release` | Recommended |
 | Apple Silicon Mac with native Python | `pip install sochdb` in an `arm64` Python env | Validated |
-| Apple Silicon Mac with Rosetta / Intel Python | Prefer switching to native `arm64` Python first | Use carefully |
+| Apple Silicon Mac with Rosetta / Intel Python | Switch to native `arm64` Python first | Not recommended for the packaged path |
 
 ---
 
@@ -60,6 +61,8 @@ Expected on Apple Silicon:
 ```text
 machine: arm64
 ```
+
+This is the packaged Python path we should recommend first to new users on Apple Silicon Macs.
 
 ### 2. Monorepo source build
 
@@ -119,6 +122,8 @@ Avoid mixing:
 - Intel/Rosetta Python
 - native Apple Silicon builds
 
+In our validation, the published `pip install sochdb` path worked cleanly in a native `arm64` macOS environment. The confusing failures showed up in `x86_64` / Rosetta-style Python envs on Apple Silicon.
+
 ---
 
 ## Quick Troubleshooting
@@ -144,6 +149,8 @@ PY
 
 If this prints `x86_64` on an Apple Silicon Mac, switch to a native `arm64` Python environment.
 
+If you want the simplest first path on Apple Silicon, do not debug the Rosetta env first. Create a native `arm64` venv and retry there.
+
 ### Working from source but imports still look wrong
 
 Make sure you built from the monorepo Python package:
@@ -163,9 +170,7 @@ Then run your demo or script from that same Python environment.
 from sochdb import Database
 
 db = Database.open("./verify_db")
-
-with db.transaction() as txn:
-    db.put(b"test/key", b"value", txn.id)
+db.put(b"test/key", b"value")
 
 value = db.get(b"test/key")
 assert value == b"value"

--- a/docs/getting-started/python-ml-ai-start-here.md
+++ b/docs/getting-started/python-ml-ai-start-here.md
@@ -1,0 +1,138 @@
+---
+sidebar_position: 5
+---
+
+# Python / ML / AI Start Here
+
+If you are a Python-first ML or AI engineer and want to play with SochDB quickly, this is the best current starting point.
+
+The simple recommendation today is:
+
+1. install the published Python package
+2. run one local retrieval workflow
+3. use that to understand the product before exploring broader features
+
+On Apple Silicon Macs, do this in a native `arm64` Python environment.
+
+## The Short Version
+
+Start with:
+
+```bash
+pip install sochdb
+python3 examples/python/07_local_knowledge_search.py
+```
+
+Then read:
+
+- [Local Retrieval Start Here](/getting-started/local-retrieval-start-here)
+- [Use SochDB When](/getting-started/use-sochdb-when)
+- [What Works Today](/getting-started/what-works-today)
+
+## What You Should Expect
+
+For a first evaluation, think of SochDB as:
+
+- a Python-friendly local database path
+- local document storage plus retrieval
+- a good first wedge for lightweight RAG and internal knowledge search
+
+Do **not** start by trying to evaluate every feature or every notebook in the ecosystem at once.
+
+That is where the current product surface gets confusing.
+
+## Best Current User Journey
+
+### 1. Install the published package
+
+Use:
+
+```bash
+pip install sochdb
+```
+
+If you are on Apple Silicon, check that your Python is native first:
+
+```bash
+python - <<'PY'
+import platform
+print(platform.machine())
+PY
+```
+
+Expected:
+
+```text
+arm64
+```
+
+If you hit environment issues, use:
+
+- [Installation](/getting-started/installation)
+- [Python Install Matrix](/getting-started/python-install-matrix)
+
+### 2. Run one narrow local workflow
+
+Run:
+
+```bash
+python3 examples/python/07_local_knowledge_search.py
+```
+
+This is the clearest current path because it shows:
+
+- local records
+- local vector indexing
+- semantic retrieval
+- fetching records back from the same overall system
+
+### 3. Evaluate the local retrieval wedge
+
+Next read:
+
+- [Local Retrieval Start Here](/getting-started/local-retrieval-start-here)
+- [Local Knowledge Retrieval Comparison](/getting-started/local-knowledge-retrieval-comparison)
+- [Retrieval Evaluation](/guides/retrieval-evaluation)
+
+### 4. Use the maturity docs before branching out
+
+Before you try more advanced surfaces, read:
+
+- [Use SochDB When](/getting-started/use-sochdb-when)
+- [What Works Today](/getting-started/what-works-today)
+
+These are important because not every path in the repo ecosystem is equally mature or equally ideal as a first evaluation path.
+
+## Why This Guidance Exists
+
+Right now, a new user can reasonably see multiple Python-related surfaces:
+
+- the published `sochdb` package
+- repo-local Python source/build flows
+- notebooks and examples
+- broader platform and SDK directions
+
+Those are all real parts of the product story, but they are not the same thing.
+
+If your goal is to understand SochDB quickly, the best move is to start with the published Python package and the local retrieval workflow first.
+
+## Recommended First Goal
+
+Your first question should be:
+
+- "Is SochDB a clear and credible way to do local knowledge retrieval in Python?"
+
+Not:
+
+- "Can I validate every platform feature in one sitting?"
+
+If the answer to the first question is yes, then it becomes worth exploring more of the broader product surface.
+
+## Related Docs
+
+- [Installation](/getting-started/installation)
+- [Python Install Matrix](/getting-started/python-install-matrix)
+- [Local Retrieval Start Here](/getting-started/local-retrieval-start-here)
+- [Use SochDB When](/getting-started/use-sochdb-when)
+- [Local Knowledge Retrieval Comparison](/getting-started/local-knowledge-retrieval-comparison)
+- [What Works Today](/getting-started/what-works-today)

--- a/docs/index.md
+++ b/docs/index.md
@@ -151,6 +151,7 @@ Step-by-step guides to get you up and running quickly.
 
 - [Quick Start](/getting-started/quickstart) — 5-minute intro
 - [Installation](/getting-started/installation) — All platforms
+- [Python / ML / AI Start Here](/getting-started/python-ml-ai-start-here) — Best first path if you want `pip install` and a concrete workflow
 - [Local Retrieval Start Here](/getting-started/local-retrieval-start-here) — Best current evaluator path
 - [Use SochDB When](/getting-started/use-sochdb-when) — Decide if SochDB fits your workflow
 - [Local Retrieval Comparison](/getting-started/local-knowledge-retrieval-comparison) — Compare the first local evaluation path


### PR DESCRIPTION
## Summary

This PR tightens the Python-first evaluator path in the main repo and makes the recommended packaged install story much clearer.

It adds a more explicit "ML/AI engineer start here" page, clarifies Apple Silicon guidance, and updates the main release workflow to include a macOS `x86_64` binary path needed for the Python SDK packaging flow.

## Changes

### Docs / evaluator path
- add `docs/getting-started/python-ml-ai-start-here.md`
- update `docs/getting-started/local-retrieval-start-here.md`
- update `docs/getting-started/python-install-matrix.md`
- update `docs/getting-started/installation.md`
- update `docs/index.md`

### Packaging / release support
- add `x86_64-apple-darwin` to the main release binary matrix
- include macOS `x86_64` release archives in packaging/release output

## Why

While testing the actual first-user Python experience, I found a real discrepancy:

- native macOS `arm64` packaged installs work
- fresh macOS `x86_64` conda/Rosetta installs can succeed at `pip install sochdb` but fail at `Database.open()` because the published package path does not currently include the right macOS `x86_64` native library

This PR improves the public guidance immediately and adds the missing main-repo release artifact path that the Python SDK packaging flow needs.

## Validation

### Native packaged path
Validated `pip install sochdb` and a simple `Database.open()/put()/get()` flow in a clean native `arm64` macOS venv.

### Fresh x86 repro
Reproduced the broken first-user path in a brand-new `x86_64` conda env:
- `pip install sochdb` succeeded
- `Database.open()` failed with:
  - `Could not find libsochdb_storage.dylib`

### Release-path validation
Built the new `x86_64-apple-darwin` target locally from the main repo and verified the expected macOS Intel artifacts are produced:
- `libsochdb_storage.dylib`
- `libsochdb_index.dylib`
- `sochdb-bulk`
- `sochdb-server`
- `sochdb-grpc-server`
- `sochdb-mcp`

## Notes

This PR does not by itself publish a fixed Python wheel. The corresponding Python SDK packaging fix is in the separate `sochdb-python-sdk` repo.