### PR TITLE
Improve gRPC retrieval benchmark quality tuning

### DIFF
--- a/benchmarks/retrieval/embed.py
+++ b/benchmarks/retrieval/embed.py
@@ -5,6 +5,9 @@ Generate reproducible embeddings for the retrieval benchmark corpus and queries.
 Preferred backend:
     sentence-transformers/all-MiniLM-L6-v2
 
+Server-friendly alternative:
+    fastembed (for example: BAAI/bge-small-en-v1.5)
+
 Fallback backend:
     scikit-learn TF-IDF + TruncatedSVD
 """
@@ -29,6 +32,7 @@ DEFAULT_DATASET_DIR = ROOT
 DEFAULT_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 DEFAULT_BACKEND = "auto"
 FALLBACK_MODEL = "tfidf-svd"
+FASTEMBED_DEFAULT_MODEL = "BAAI/bge-small-en-v1.5"
 DEFAULT_BATCH_SIZE = 128
 
 
@@ -124,6 +128,39 @@ def encode_with_sentence_transformers(
     return doc_embeddings, query_embeddings, model_name
 
 
+def encode_with_fastembed(
+    model_name: str,
+    doc_texts: list[str],
+    query_texts: list[str],
+    batch_size: int,
+) -> tuple[np.ndarray, np.ndarray, str]:
+    from fastembed import TextEmbedding
+
+    print(f"Loading fastembed model: {model_name}")
+    model = TextEmbedding(model_name=model_name)
+
+    def encode_batches(texts: list[str], label: str) -> np.ndarray:
+        total = len(texts)
+        if total == 0:
+            return np.zeros((0, 0), dtype=np.float32)
+
+        print(f"Embedding {total} {label} with fastembed (batch_size={batch_size})...")
+        batches: list[np.ndarray] = []
+        total_batches = (total + batch_size - 1) // batch_size
+        for batch_idx, start in enumerate(range(0, total, batch_size), start=1):
+            end = min(start + batch_size, total)
+            print(f"  {label} batch {batch_idx}/{total_batches}: rows {start}-{end - 1}")
+            batch_vectors = list(model.embed(texts[start:end]))
+            batch_embeddings = normalize_rows(np.vstack(batch_vectors).astype(np.float32))
+            batches.append(batch_embeddings)
+        return np.vstack(batches)
+
+    doc_embeddings = encode_batches(doc_texts, "corpus documents")
+    query_embeddings = encode_batches(query_texts, "queries")
+
+    return doc_embeddings, query_embeddings, model_name
+
+
 def encode_with_tfidf_svd(
     doc_texts: list[str],
     query_texts: list[str],
@@ -162,7 +199,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--backend",
-        choices=["auto", "sentence-transformers", "tfidf-svd"],
+        choices=["auto", "sentence-transformers", "fastembed", "tfidf-svd"],
         default=DEFAULT_BACKEND,
         help="Embedding backend to use",
     )
@@ -221,6 +258,8 @@ def main() -> None:
 
     backend_used = args.backend
     model_name = args.model
+    doc_embeddings = None
+    query_embeddings = None
 
     if args.backend in {"auto", "sentence-transformers"}:
         try:
@@ -245,7 +284,30 @@ def main() -> None:
                 svd_dim=args.svd_dim,
             )
             backend_used = "tfidf-svd"
-    else:
+
+    if doc_embeddings is None and args.backend in {"auto", "fastembed"}:
+        try:
+            fastembed_model = (
+                FASTEMBED_DEFAULT_MODEL
+                if args.backend == "auto" and args.model == DEFAULT_MODEL
+                else args.model
+            )
+            doc_embeddings, query_embeddings, model_name = encode_with_fastembed(
+                fastembed_model,
+                doc_texts,
+                query_texts,
+                args.batch_size,
+            )
+            backend_used = "fastembed"
+        except Exception as exc:
+            if args.backend == "fastembed":
+                raise
+            print(
+                "fastembed backend unavailable; "
+                f"falling back to TF-IDF + SVD ({exc.__class__.__name__}: {exc})"
+            )
+
+    if doc_embeddings is None:
         doc_embeddings, query_embeddings, model_name = encode_with_tfidf_svd(
             doc_texts,
             query_texts,

--- a/benchmarks/retrieval/run_sochdb_grpc.py
+++ b/benchmarks/retrieval/run_sochdb_grpc.py
@@ -18,10 +18,15 @@ from typing import Any
 import grpc
 import numpy as np
 
+from evaluate import evaluate_run
+
 
 ROOT = Path(__file__).resolve().parent
 DEFAULT_OUTPUT = ROOT / "results" / "sochdb_grpc.json"
 DEFAULT_K = 5
+DEFAULT_M = 16
+DEFAULT_EF_CONSTRUCTION = 100
+DEFAULT_EF_SEARCH = 64
 
 
 def load_jsonl(path: Path) -> list[dict[str, Any]]:
@@ -65,21 +70,40 @@ def main() -> None:
     )
     parser.add_argument("--k", type=int, default=DEFAULT_K, help="Top-k results")
     parser.add_argument(
+        "--m",
+        type=int,
+        default=DEFAULT_M,
+        help="HNSW max connections per node",
+    )
+    parser.add_argument(
+        "--ef-construction",
+        type=int,
+        default=DEFAULT_EF_CONSTRUCTION,
+        help="HNSW construction search depth",
+    )
+    parser.add_argument(
+        "--ef-search",
+        type=int,
+        default=DEFAULT_EF_SEARCH,
+        help="HNSW search breadth used for index config and query-time search",
+    )
+    parser.add_argument(
         "--index-name",
         default=f"bench_{int(time.time())}",
         help="Remote index name to create for this run",
     )
     args = parser.parse_args()
 
-    generated_dir = Path(__file__).resolve().parents[2] / "sochdb-sdk" / "python" / "sochdb_sdk" / "generated"
+    sdk_python_dir = Path(__file__).resolve().parents[2] / "sochdb-sdk" / "python"
+    generated_dir = sdk_python_dir / "sochdb_sdk" / "generated"
     if not generated_dir.exists():
         raise SystemExit(
             "Generated Python stubs not found. Run: cd sochdb-sdk && ./generate.sh python"
         )
 
-    sys.path.insert(0, str(generated_dir))
-    import sochdb_pb2  # type: ignore
-    import sochdb_pb2_grpc  # type: ignore
+    sys.path.insert(0, str(sdk_python_dir))
+    from sochdb_sdk.generated import sochdb_pb2  # type: ignore
+    from sochdb_sdk.generated import sochdb_pb2_grpc  # type: ignore
 
     corpus = load_jsonl(args.dataset_dir / "corpus.jsonl")
     queries = load_jsonl(args.dataset_dir / "queries.jsonl")
@@ -111,9 +135,9 @@ def main() -> None:
             dimension=int(doc_embeddings.shape[1]),
             metric=sochdb_pb2.DISTANCE_METRIC_COSINE,
             config=sochdb_pb2.HnswConfig(
-                max_connections=16,
-                ef_construction=100,
-                ef_search=64,
+                max_connections=args.m,
+                ef_construction=args.ef_construction,
+                ef_search=args.ef_search,
             ),
         )
     )
@@ -149,7 +173,7 @@ def main() -> None:
                 index_name=args.index_name,
                 query=query_vec.astype(np.float32).tolist(),
                 k=args.k,
-                ef=64,
+                ef=args.ef_search,
             )
         )
         query_elapsed = time.perf_counter() - query_start
@@ -198,9 +222,9 @@ def main() -> None:
             "index_create_time_ms": round(create_elapsed * 1000, 3),
             "insert_time_ms": round(insert_elapsed * 1000, 3),
             "indexed_vectors": int(insert_resp.inserted_count),
-            "m": 16,
-            "ef_construction": 100,
-            "ef_search": 64,
+            "m": args.m,
+            "ef_construction": args.ef_construction,
+            "ef_search": args.ef_search,
         },
         "query_latency": {
             "p50_ms": round(percentile(query_timings, 50) * 1000, 3),
@@ -209,6 +233,7 @@ def main() -> None:
         },
         "queries": query_results,
     }
+    output["quality"] = evaluate_run(output, args.k)
 
     args.output.write_text(json.dumps(output, indent=2), encoding="utf-8")
     print(f"Saved benchmark results to {args.output}")

--- a/benchmarks/retrieval/run_sochdb_grpc.py
+++ b/benchmarks/retrieval/run_sochdb_grpc.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+Run the retrieval benchmark against a local or remote SochDB 2.0 gRPC server.
+
+This script intentionally writes the same high-level result shape as the
+embedded benchmark harness so the existing evaluator can be reused.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import grpc
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parent
+DEFAULT_OUTPUT = ROOT / "results" / "sochdb_grpc.json"
+DEFAULT_K = 5
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            records.append(json.loads(line))
+    return records
+
+
+def percentile(values: list[float], p: float) -> float:
+    if not values:
+        return 0.0
+    return float(np.percentile(np.array(values, dtype=np.float64), p))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1", help="SochDB gRPC host")
+    parser.add_argument("--port", type=int, default=50051, help="SochDB gRPC port")
+    parser.add_argument(
+        "--dataset-dir",
+        type=Path,
+        required=True,
+        help="Directory containing corpus.jsonl and queries.jsonl",
+    )
+    parser.add_argument(
+        "--embedding-dir",
+        type=Path,
+        required=True,
+        help="Directory containing doc/query embedding outputs",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Result JSON path",
+    )
+    parser.add_argument("--k", type=int, default=DEFAULT_K, help="Top-k results")
+    parser.add_argument(
+        "--index-name",
+        default=f"bench_{int(time.time())}",
+        help="Remote index name to create for this run",
+    )
+    args = parser.parse_args()
+
+    generated_dir = Path(__file__).resolve().parents[2] / "sochdb-sdk" / "python" / "sochdb_sdk" / "generated"
+    if not generated_dir.exists():
+        raise SystemExit(
+            "Generated Python stubs not found. Run: cd sochdb-sdk && ./generate.sh python"
+        )
+
+    sys.path.insert(0, str(generated_dir))
+    import sochdb_pb2  # type: ignore
+    import sochdb_pb2_grpc  # type: ignore
+
+    corpus = load_jsonl(args.dataset_dir / "corpus.jsonl")
+    queries = load_jsonl(args.dataset_dir / "queries.jsonl")
+
+    doc_embeddings = np.load(args.embedding_dir / "doc_embeddings.npy")
+    query_embeddings = np.load(args.embedding_dir / "query_embeddings.npy")
+    doc_ids = json.loads((args.embedding_dir / "doc_ids.json").read_text(encoding="utf-8"))
+    query_ids = json.loads((args.embedding_dir / "query_ids.json").read_text(encoding="utf-8"))
+    metadata = json.loads((args.embedding_dir / "embedding_metadata.json").read_text(encoding="utf-8"))
+
+    if len(corpus) != len(doc_ids) or len(corpus) != len(doc_embeddings):
+        raise SystemExit("Corpus length does not match embedding outputs")
+    if len(queries) != len(query_ids) or len(queries) != len(query_embeddings):
+        raise SystemExit("Query length does not match embedding outputs")
+
+    channel = grpc.insecure_channel(f"{args.host}:{args.port}")
+    stub = sochdb_pb2_grpc.VectorIndexServiceStub(channel)
+
+    # Best-effort cleanup from previous failed runs.
+    try:
+        stub.DropIndex(sochdb_pb2.DropIndexRequest(name=args.index_name))
+    except grpc.RpcError:
+        pass
+
+    create_start = time.perf_counter()
+    create_resp = stub.CreateIndex(
+        sochdb_pb2.CreateIndexRequest(
+            name=args.index_name,
+            dimension=int(doc_embeddings.shape[1]),
+            metric=sochdb_pb2.DISTANCE_METRIC_COSINE,
+            config=sochdb_pb2.HnswConfig(
+                max_connections=16,
+                ef_construction=100,
+                ef_search=64,
+            ),
+        )
+    )
+    create_elapsed = time.perf_counter() - create_start
+    if not create_resp.success:
+        raise SystemExit(f"CreateIndex failed: {create_resp.error}")
+
+    numeric_ids = np.arange(1, len(doc_ids) + 1, dtype=np.uint64)
+    numeric_to_doc_id = {
+        int(numeric_id): doc_id for numeric_id, doc_id in zip(numeric_ids.tolist(), doc_ids)
+    }
+    id_to_record = {record["id"]: record for record in corpus}
+
+    insert_start = time.perf_counter()
+    insert_resp = stub.InsertBatch(
+        sochdb_pb2.InsertBatchRequest(
+            index_name=args.index_name,
+            ids=numeric_ids.tolist(),
+            vectors=doc_embeddings.astype(np.float32).reshape(-1).tolist(),
+        )
+    )
+    insert_elapsed = time.perf_counter() - insert_start
+    if insert_resp.error:
+        raise SystemExit(f"InsertBatch failed: {insert_resp.error}")
+
+    query_timings: list[float] = []
+    query_results: list[dict[str, Any]] = []
+
+    for query_record, query_id, query_vec in zip(queries, query_ids, query_embeddings):
+        query_start = time.perf_counter()
+        search_resp = stub.Search(
+            sochdb_pb2.SearchRequest(
+                index_name=args.index_name,
+                query=query_vec.astype(np.float32).tolist(),
+                k=args.k,
+                ef=64,
+            )
+        )
+        query_elapsed = time.perf_counter() - query_start
+        query_timings.append(query_elapsed)
+
+        if search_resp.error:
+            raise SystemExit(f"Search failed for query {query_id}: {search_resp.error}")
+
+        ranked = []
+        for result in search_resp.results:
+            doc_id = numeric_to_doc_id.get(int(result.id))
+            if doc_id is None:
+                continue
+            ranked.append(
+                {
+                    "doc_id": doc_id,
+                    "distance": float(result.distance),
+                    "title": id_to_record.get(doc_id, {}).get("title"),
+                }
+            )
+
+        query_results.append(
+            {
+                "query_id": query_id,
+                "query": query_record["query"],
+                "relevant_ids": query_record["relevant_ids"],
+                "results": ranked,
+                "latency_ms": round(query_elapsed * 1000, 3),
+            }
+        )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    output = {
+        "system": "sochdb-2.0-grpc",
+        "corpus_size": len(corpus),
+        "query_count": len(queries),
+        "embedding_model": metadata["model_name"],
+        "embedding_dimension": metadata["dimension"],
+        "top_k": args.k,
+        "storage": {
+            "endpoint": f"{args.host}:{args.port}",
+            "index_name": args.index_name,
+            "dataset_dir": str(args.dataset_dir),
+        },
+        "build": {
+            "index_create_time_ms": round(create_elapsed * 1000, 3),
+            "insert_time_ms": round(insert_elapsed * 1000, 3),
+            "indexed_vectors": int(insert_resp.inserted_count),
+            "m": 16,
+            "ef_construction": 100,
+            "ef_search": 64,
+        },
+        "query_latency": {
+            "p50_ms": round(percentile(query_timings, 50) * 1000, 3),
+            "p95_ms": round(percentile(query_timings, 95) * 1000, 3),
+            "mean_ms": round(float(np.mean(query_timings)) * 1000, 3),
+        },
+        "queries": query_results,
+    }
+
+    args.output.write_text(json.dumps(output, indent=2), encoding="utf-8")
+    print(f"Saved benchmark results to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/guides/local-2-0-dev-loop.md
+++ b/docs/guides/local-2-0-dev-loop.md
@@ -1,0 +1,115 @@
+# Local 2.0 Dev Loop
+
+This is the smallest reproducible local workflow for working on the SochDB 2.0
+client/server path.
+
+It is intended for contributors who want to:
+
+- start the local gRPC server
+- generate Python client stubs
+- run a minimal vector insert/search flow
+
+## What This Covers
+
+This workflow exercises the `2.0` server/client path:
+
+- `sochdb-grpc-server`
+- generated Python gRPC stubs
+- vector index creation
+- batch insert
+- k-NN search
+
+It is different from the embedded/local `Database.open(...)` path.
+
+## Prerequisites
+
+- Rust toolchain
+- `protoc`
+- Python 3
+- `grpcio` and `grpcio-tools`
+
+On macOS:
+
+```bash
+brew install protobuf
+```
+
+Create a temporary Python venv for SDK codegen/testing:
+
+```bash
+python3 -m venv /tmp/sochdb2-sdk-venv
+source /tmp/sochdb2-sdk-venv/bin/activate
+pip install grpcio grpcio-tools
+```
+
+## 1. Start the Local gRPC Server
+
+From the repo root:
+
+```bash
+cargo run -p sochdb-grpc --bin sochdb-grpc-server -- \
+  --host 127.0.0.1 \
+  --port 50051 \
+  --metrics-port 0 \
+  --ws-port 0 \
+  --pg-port 0
+```
+
+This keeps the first local loop focused on the gRPC vector path only.
+
+## 2. Generate Python Stubs
+
+In another shell:
+
+```bash
+source /tmp/sochdb2-sdk-venv/bin/activate
+cd sochdb-sdk
+./generate.sh python
+```
+
+Generated files land in:
+
+- `sochdb-sdk/python/sochdb_sdk/generated/sochdb_pb2.py`
+- `sochdb-sdk/python/sochdb_sdk/generated/sochdb_pb2_grpc.py`
+
+## 3. Run the Minimal Quickstart
+
+From the repo root:
+
+```bash
+source /tmp/sochdb2-sdk-venv/bin/activate
+python examples/python/07_grpc_vector_quickstart.py
+```
+
+Expected output:
+
+```text
+create_index: True ok
+insert_batch: 3 ok
+search: ok
+  id=1 distance=0.0000
+  id=3 distance=1.0000
+```
+
+## Files Involved
+
+- [`examples/python/07_grpc_vector_quickstart.py`](/private/tmp/sochdb-2.0/examples/python/07_grpc_vector_quickstart.py)
+- [`sochdb-sdk/generate.sh`](/private/tmp/sochdb-2.0/sochdb-sdk/generate.sh)
+- [`sochdb-sdk/python/sochdb_sdk/client.py`](/private/tmp/sochdb-2.0/sochdb-sdk/python/sochdb_sdk/client.py)
+- [`sochdb-grpc/proto/sochdb.proto`](/private/tmp/sochdb-2.0/sochdb-grpc/proto/sochdb.proto)
+
+## Current Rough Edges
+
+- The generated Python stubs are the most reliable path right now.
+- The thin `sochdb_sdk` wrapper exists, but it should be checked against the
+  current proto/service surface before treating it as the default example path.
+- This loop assumes a contributor workflow, not a polished packaged install
+  story yet.
+
+## Best Next Steps
+
+After this loop works locally:
+
+1. Align the thin Python SDK wrapper with the current proto surface.
+2. Add a small server-side benchmark runner using this local setup.
+3. Write a short note clarifying `embedded/local` vs `2.0 client/server`.

--- a/examples/python/07_grpc_vector_quickstart.py
+++ b/examples/python/07_grpc_vector_quickstart.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+Minimal local gRPC vector quickstart for SochDB 2.0.
+
+This example assumes:
+1. The local gRPC server is already running:
+   cargo run -p sochdb-grpc --bin sochdb-grpc-server -- \
+     --host 127.0.0.1 --port 50051 --metrics-port 0 --ws-port 0 --pg-port 0
+2. Python stubs have been generated:
+   cd sochdb-sdk && ./generate.sh python
+
+Usage:
+    python3 examples/python/07_grpc_vector_quickstart.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import grpc
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GENERATED_DIR = REPO_ROOT / "sochdb-sdk" / "python" / "sochdb_sdk" / "generated"
+
+if not GENERATED_DIR.exists():
+    raise SystemExit(
+        "Generated Python stubs not found. Run: cd sochdb-sdk && ./generate.sh python"
+    )
+
+sys.path.insert(0, str(GENERATED_DIR))
+
+import sochdb_pb2  # type: ignore  # noqa: E402
+import sochdb_pb2_grpc  # type: ignore  # noqa: E402
+
+
+def main() -> None:
+    channel = grpc.insecure_channel("127.0.0.1:50051")
+    stub = sochdb_pb2_grpc.VectorIndexServiceStub(channel)
+
+    index_name = "quickstart_local_index"
+
+    create_resp = stub.CreateIndex(
+        sochdb_pb2.CreateIndexRequest(
+            name=index_name,
+            dimension=4,
+            metric=sochdb_pb2.DISTANCE_METRIC_COSINE,
+            config=sochdb_pb2.HnswConfig(
+                max_connections=16,
+                ef_construction=100,
+                ef_search=64,
+            ),
+        )
+    )
+    print("create_index:", create_resp.success, create_resp.error or "ok")
+
+    insert_resp = stub.InsertBatch(
+        sochdb_pb2.InsertBatchRequest(
+            index_name=index_name,
+            ids=[1, 2, 3],
+            vectors=[
+                1.0, 0.0, 0.0, 0.0,
+                0.0, 1.0, 0.0, 0.0,
+                0.0, 0.0, 1.0, 0.0,
+            ],
+        )
+    )
+    print("insert_batch:", insert_resp.inserted_count, insert_resp.error or "ok")
+
+    search_resp = stub.Search(
+        sochdb_pb2.SearchRequest(
+            index_name=index_name,
+            query=[1.0, 0.0, 0.0, 0.0],
+            k=2,
+            ef=64,
+        )
+    )
+    print("search:", search_resp.error or "ok")
+    for result in search_resp.results:
+        print(f"  id={result.id} distance={result.distance:.4f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add configurable HNSW tuning parameters to the gRPC retrieval benchmark runner
- include quality metrics directly in benchmark outputs
- preserve the updated gRPC benchmark import path for generated Python stubs
- add a server-friendly `fastembed` embedding backend for retrieval benchmarking

## Why
This makes the retrieval benchmark quality-focused instead of latency-only. We can now compare recall and nDCG across HNSW settings without changing the evaluation shape, and we have a lighter server-side path for embedding generation without depending on a strong GPU.

## Validation
- `python3 -m py_compile benchmarks/retrieval/run_sochdb_grpc.py benchmarks/retrieval/evaluate.py benchmarks/retrieval/embed.py`
- ran a SciFact HNSW quality sweep on the benchmark server and confirmed the new result payload shape works
- started a server-side embedding bakeoff path using `fastembed`
