### PR TITLE
fix(core,kernel): replace 3.14 literal with 3.15 to eliminate clippy approx_constant errors

### DIFF
--- a/sochdb-core/src/columnar.rs
+++ b/sochdb-core/src/columnar.rs
@@ -1255,9 +1255,9 @@ mod tests {
 
         // Float64
         let mut fcol = TypedColumn::new_float64();
-        fcol.push_f64(Some(3.14));
+        fcol.push_f64(Some(3.15));
         fcol.push_f64(None);
-        assert_eq!(fcol.value_at(0), SochValue::Float(3.14));
+        assert_eq!(fcol.value_at(0), SochValue::Float(3.15));
         assert_eq!(fcol.value_at(1), SochValue::Null);
 
         // Text

--- a/sochdb-kernel/examples/02_wasm_plugin.rs
+++ b/sochdb-kernel/examples/02_wasm_plugin.rs
@@ -69,8 +69,8 @@ fn main() {
     let result = instance.call("get_metrics", &[]).unwrap();
     println!("   get_metrics() returned: {:?}", result);
 
-    let result = instance.call("transform", &[WasmValue::F64(3.14)]).unwrap();
-    println!("   transform(3.14) returned: {:?}", result);
+    let result = instance.call("transform", &[WasmValue::F64(3.15)]).unwrap();
+    println!("   transform(3.15) returned: {:?}", result);
     println!();
 
     // Step 4: Check plugin statistics


### PR DESCRIPTION
## What Happened

`cargo clippy` flagged two files with `approx_constant` lint errors. The literal `3.14` in test/example code triggers clippy's `approx_constant` lint because it's close enough to PI that it's likely a mistake. This causes `make check` (which runs `cargo clippy --all -- -D warnings`) to fail.

## Lines That Are Going Wrong

```
sochdb-core/src/columnar.rs:1258  —  fcol.push_f64(Some(3.14));
sochdb-core/src/columnar.rs:1260  —  assert_eq!(fcol.value_at(0), SochValue::Float(3.14));
sochdb-kernel/examples/02_wasm_plugin.rs:72  —  let result = instance.call("transform", &[WasmValue::F64(3.14)]).unwrap();
sochdb-kernel/examples/02_wasm_plugin.rs:73  —  println!("   transform(3.14) returned: {:?}", result);
```

## Fix

Replace `3.14` with `3.15` in all 4 lines. The value is just a test/example float — not an intentional PI constant. Changing to `3.15` eliminates the false-positive while preserving test semantics.

## Validation

```bash
cargo clippy -p sochdb-core -p sochdb-kernel --all-targets 2>&1 | grep approx_constant
# (empty — no more approx_constant errors)

cargo test -p sochdb-core -- columnar
# test result: ok. 13 passed; 0 failed

cargo check --workspace
# Finished `dev` profile
```