### PR TITLE
docs: fix stale Rust version and crate version in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ If you prefer manual setup or `make setup` fails:
 
 | Requirement | Version | Check | Install |
 |-------------|---------|-------|---------|
-| **Rust** | ≥1.75.0 (2024 edition) | `rustc --version` | [rustup.rs](https://rustup.rs/) |
+| **Rust** | ≥1.85.0 (2024 edition) | `rustc --version` | [rustup.rs](https://rustup.rs/) |
 | **Git** | Any recent | `git --version` | OS package manager |
 | **Clang** | ≥14 (optional, for SIMD) | `clang --version` | OS package manager |
 | **Python** | ≥3.9 (for SDK) | `python --version` | OS package manager |

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Choose your preferred SDK:
 
 ```bash
 # Rust - add to Cargo.toml
-sochdb = "0.2"
+sochdb = "0.5"
 ```
 
 ### SDK Repositories


### PR DESCRIPTION
## What Happened

Two version strings in documentation are outdated:
1. CONTRIBUTING.md states Rust ≥1.75.0, but the workspace requires edition 2024 which needs Rust ≥1.85.0
2. README.md Quick Start shows `sochdb = "0.2"`, but the current version is 0.5.0

New contributors following CONTRIBUTING.md would install an older Rust that can't compile the project, and users copying the README snippet would get an outdated crate version.

## Lines That Need Fixes

```
CONTRIBUTING.md:57  —  | **Rust** | ≥1.75.0 (2024 edition) | `rustc --version` | [rustup.rs](https://rustup.rs/) |
README.md:207         —  sochdb = "0.2"
```

Proof:
- `Cargo.toml` workspace: `edition = "2024"` and `rust-version = "1.85"`
- `Cargo.toml` workspace: `version = "0.5.0"`

## Fix

```diff
-CONTRIBUTING.md:57:  | **Rust** | ≥1.75.0 (2024 edition) | `rustc --version` | [rustup.rs](https://rustup.rs/) |
+CONTRIBUTING.md:57:  | **Rust** | ≥1.85.0 (2024 edition) | `rustc --version` | [rustup.rs](https://rustup.rs/) |

-README.md:207:  sochdb = "0.2"
+README.md:207:  sochdb = "0.5"
```

## Validation

```bash
grep "1.75" CONTRIBUTING.md
# (empty — no stale version)

grep '"0.2"' README.md
# (empty — no stale crate version)

grep "1.85" CONTRIBUTING.md
# | **Rust** | ≥1.85.0 (2024 edition) |  ✓

grep '"0.5"' README.md
# sochdb = "0.5"  ✓

cargo check --workspace
# Finished `dev` profile
```