### PR TITLE
fix(examples): add Cargo.toml infrastructure and fix 01_basic_database.rs API mismatches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "sochdb-wasm",
     "sochdb-vector",
     "sochdb-tools",
+    "examples/rust",
 ]
 # sochdb-python is excluded from workspace - it must be built with maturin
 # Use: cd sochdb-python && maturin develop --release

--- a/examples/rust/01_basic_database.rs
+++ b/examples/rust/01_basic_database.rs
@@ -1,60 +1,59 @@
 //! Basic SochDB Operations Example
-//! 
+//!
 //! This example demonstrates fundamental key-value operations:
 //! - Opening a database
 //! - Put, Get, Delete operations
 //! - Path-based hierarchical keys
-//! - Context manager pattern
+//! - Prefix scanning
 
-use sochdb::Database;
-use anyhow::Result;
+use sochdb::Connection;
+use std::error::Error;
 
-fn main() -> Result<()> {
+fn main() -> Result<(), Box<dyn Error>> {
     // Open or create a database
-    let db = Database::open("./example_db")?;
+    let conn = Connection::open("./example_db")?;
     println!("✓ Database opened");
 
     // Basic key-value operations
-    db.put(b"greeting", b"Hello, SochDB!")?;
+    conn.put(b"greeting", b"Hello, SochDB!")?;
     println!("✓ Key 'greeting' written");
 
-    let value = db.get(b"greeting")?;
+    let value = conn.get(b"greeting")?;
     match value {
         Some(v) => println!("✓ Read value: {}", String::from_utf8_lossy(&v)),
         None => println!("Key not found"),
     }
 
-    // Path-based hierarchical keys
-    db.put_path(&["users", "alice", "name"], b"Alice Smith")?;
-    db.put_path(&["users", "alice", "email"], b"alice@example.com")?;
-    db.put_path(&["users", "bob", "name"], b"Bob Jones")?;
+    // Path-based hierarchical keys (using slash-separated strings)
+    conn.put_path("users/alice/name", b"Alice Smith")?;
+    conn.put_path("users/alice/email", b"alice@example.com")?;
+    conn.put_path("users/bob/name", b"Bob Jones")?;
     println!("✓ Hierarchical data stored");
 
     // Read by path
-    if let Some(name) = db.get_path(&["users", "alice", "name"])? {
+    if let Some(name) = conn.get_path("users/alice/name")? {
         println!("✓ Alice's name: {}", String::from_utf8_lossy(&name));
     }
 
     // Delete a key
-    db.delete(b"greeting")?;
+    conn.delete(b"greeting")?;
     println!("✓ Key 'greeting' deleted");
 
     // Verify deletion
-    match db.get(b"greeting")? {
+    match conn.get(b"greeting")? {
         Some(_) => println!("Key still exists"),
         None => println!("✓ Key confirmed deleted"),
     }
 
-    // Query prefix scan
-    let results = db.query("users/")
-        .limit(10)
-        .execute()?;
-    
+    // Prefix scan
+    let results = conn.scan_path("users/")?;
     println!("\n✓ Prefix scan results:");
     for (key, value) in results {
-        println!("  {} = {}", 
-            String::from_utf8_lossy(&key),
-            String::from_utf8_lossy(&value));
+        println!(
+            "  {} = {}",
+            key,
+            String::from_utf8_lossy(&value)
+        );
     }
 
     Ok(())

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "sochdb-examples"
+version = "0.5.0"
+edition = "2024"
+authors = ["SochDB Authors"]
+license = "AGPL-3.0-or-later"
+description = "SochDB Rust examples"
+
+[dependencies]
+sochdb = { path = "../../sochdb-client" }
+
+[[bin]]
+name = "01_basic_database"
+path = "01_basic_database.rs"
+
+[[bin]]
+name = "02_transactions"
+path = "02_transactions.rs"
+
+[[bin]]
+name = "03_vector_search"
+path = "03_vector_search.rs"
+
+[[bin]]
+name = "04_sql_queries"
+path = "04_sql_queries.rs"


### PR DESCRIPTION
## What Happened

The `examples/rust/` directory contained orphaned `.rs` files with no `Cargo.toml`, so they couldn't be compiled at all. Additionally, `01_basic_database.rs` was written against a non-existent API surface:

- `sochdb::Database` — type doesn't exist (should be `sochdb::Connection`)
- `anyhow::Result` — `anyhow` is not a dependency
- `put_path(&["users", "alice", "name"], ...)` — takes `&str` not `&[&str]`
- `query("users/")` — no such method on `DurableConnection`; use `scan_path` instead

## Lines Going Wrong

```
examples/rust/01_basic_database.rs:9   —  use sochdb::Database;
examples/rust/01_basic_database.rs:10  —  use anyhow::Result;
examples/rust/01_basic_database.rs:14  —  let db = Database::open("./example_db")?;
examples/rust/01_basic_database.rs:28  —  db.put_path(&["users", "alice", "name"], b"Alice Smith")?;
examples/rust/01_basic_database.rs:34  —  if let Some(name) = db.get_path(&["users", "alice", "name"])? {
examples/rust/01_basic_database.rs:49  —  let results = db.query("users/")
```

## Fix

1. Added `examples/rust/Cargo.toml` workspace member with `sochdb` path dependency
2. Added `"examples/rust"` to workspace `members` in root `Cargo.toml`
3. Rewrote example to use actual API:
   - `Connection::open` instead of `Database::open`
   - `std::error::Error` instead of `anyhow`
   - `put_path("users/alice/name", ...)` with slash-separated `&str`
   - `scan_path("users/")` for prefix scanning

## Validation

```bash
cargo check -p sochdb-examples --bin 01_basic_database
# Finished `dev` profile
```