### PR TITLE
fix(examples): rewrite 04_sql_queries.rs to use SochConnection SQL API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "sochdb-wasm",
     "sochdb-vector",
     "sochdb-tools",
+    "examples/rust",
 ]
 # sochdb-python is excluded from workspace - it must be built with maturin
 # Use: cd sochdb-python && maturin develop --release

--- a/examples/rust/01_basic_database.rs
+++ b/examples/rust/01_basic_database.rs
@@ -1,60 +1,59 @@
 //! Basic SochDB Operations Example
-//! 
+//!
 //! This example demonstrates fundamental key-value operations:
 //! - Opening a database
 //! - Put, Get, Delete operations
 //! - Path-based hierarchical keys
-//! - Context manager pattern
+//! - Prefix scanning
 
-use sochdb::Database;
-use anyhow::Result;
+use sochdb::Connection;
+use std::error::Error;
 
-fn main() -> Result<()> {
+fn main() -> Result<(), Box<dyn Error>> {
     // Open or create a database
-    let db = Database::open("./example_db")?;
+    let conn = Connection::open("./example_db")?;
     println!("✓ Database opened");
 
     // Basic key-value operations
-    db.put(b"greeting", b"Hello, SochDB!")?;
+    conn.put(b"greeting", b"Hello, SochDB!")?;
     println!("✓ Key 'greeting' written");
 
-    let value = db.get(b"greeting")?;
+    let value = conn.get(b"greeting")?;
     match value {
         Some(v) => println!("✓ Read value: {}", String::from_utf8_lossy(&v)),
         None => println!("Key not found"),
     }
 
-    // Path-based hierarchical keys
-    db.put_path(&["users", "alice", "name"], b"Alice Smith")?;
-    db.put_path(&["users", "alice", "email"], b"alice@example.com")?;
-    db.put_path(&["users", "bob", "name"], b"Bob Jones")?;
+    // Path-based hierarchical keys (using slash-separated strings)
+    conn.put_path("users/alice/name", b"Alice Smith")?;
+    conn.put_path("users/alice/email", b"alice@example.com")?;
+    conn.put_path("users/bob/name", b"Bob Jones")?;
     println!("✓ Hierarchical data stored");
 
     // Read by path
-    if let Some(name) = db.get_path(&["users", "alice", "name"])? {
+    if let Some(name) = conn.get_path("users/alice/name")? {
         println!("✓ Alice's name: {}", String::from_utf8_lossy(&name));
     }
 
     // Delete a key
-    db.delete(b"greeting")?;
+    conn.delete(b"greeting")?;
     println!("✓ Key 'greeting' deleted");
 
     // Verify deletion
-    match db.get(b"greeting")? {
+    match conn.get(b"greeting")? {
         Some(_) => println!("Key still exists"),
         None => println!("✓ Key confirmed deleted"),
     }
 
-    // Query prefix scan
-    let results = db.query("users/")
-        .limit(10)
-        .execute()?;
-    
+    // Prefix scan
+    let results = conn.scan_path("users/")?;
     println!("\n✓ Prefix scan results:");
     for (key, value) in results {
-        println!("  {} = {}", 
-            String::from_utf8_lossy(&key),
-            String::from_utf8_lossy(&value));
+        println!(
+            "  {} = {}",
+            key,
+            String::from_utf8_lossy(&value)
+        );
     }
 
     Ok(())

--- a/examples/rust/04_sql_queries.rs
+++ b/examples/rust/04_sql_queries.rs
@@ -7,49 +7,51 @@
 //! Demonstrates SQL support in SochDB:
 //! - CREATE TABLE, INSERT, UPDATE, DELETE
 //! - SELECT with WHERE, ORDER BY, LIMIT
-//! - Prepared statements
 //! - Schema management
+//!
+//! Note: SQL execution uses SochConnection (in-memory with SQL support).
+//! For durable storage, use DurableConnection with path-based APIs.
 
-use sochdb_client::{Client, ClientConfig, QueryResult};
-use sochdb_query::sql::{Parser, Statement, ExecutionResult};
+use sochdb::SochConnection;
+use std::error::Error;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("=".repeat(60));
+fn main() -> Result<(), Box<dyn Error>> {
+    let sep = "=".repeat(60);
+    println!("{}", sep);
     println!("SochDB SQL Query Examples");
-    println!("=".repeat(60));
+    println!("{}", sep);
 
-    // Open database
+    // Open in-memory database (SQL execution uses SochConnection)
     let db_path = "./demo_sql_db_rust";
     println!("\n📂 Opening database: {}", db_path);
-    
+
     // Clean up existing database
     let _ = std::fs::remove_dir_all(db_path);
-    
-    let mut client = Client::open(db_path)?;
+
+    let conn = SochConnection::open(db_path)?;
     println!("✓ Database opened successfully");
 
     // Run demonstrations
-    create_tables(&mut client)?;
-    insert_data(&mut client)?;
-    select_queries(&mut client)?;
-    update_operations(&mut client)?;
-    delete_operations(&mut client)?;
-    complex_queries(&mut client)?;
-    sql_parser_examples()?;
+    create_tables(&conn)?;
+    insert_data(&conn)?;
+    select_queries(&conn)?;
+    update_operations(&conn)?;
+    delete_operations(&conn)?;
+    complex_queries(&conn)?;
 
-    println!("\n{}", "=".repeat(60));
+    println!("\n{}", sep);
     println!("✓ All SQL examples completed successfully!");
-    println!("{}", "=".repeat(60));
+    println!("{}", sep);
 
     Ok(())
 }
 
-fn create_tables(client: &mut Client) -> Result<(), Box<dyn std::error::Error>> {
+fn create_tables(conn: &SochConnection) -> Result<(), Box<dyn Error>> {
     println!("\n📝 Creating Tables with SQL");
     println!("{}", "=".repeat(60));
 
     // Create users table
-    client.execute(
+    conn.execute_sql(
         r#"
         CREATE TABLE users (
             id INTEGER PRIMARY KEY,
@@ -63,7 +65,7 @@ fn create_tables(client: &mut Client) -> Result<(), Box<dyn std::error::Error>> 
     println!("✓ Created 'users' table");
 
     // Create posts table
-    client.execute(
+    conn.execute_sql(
         r#"
         CREATE TABLE posts (
             id INTEGER PRIMARY KEY,
@@ -80,7 +82,7 @@ fn create_tables(client: &mut Client) -> Result<(), Box<dyn std::error::Error>> 
     Ok(())
 }
 
-fn insert_data(client: &mut Client) -> Result<(), Box<dyn std::error::Error>> {
+fn insert_data(conn: &SochConnection) -> Result<(), Box<dyn Error>> {
     println!("\n📥 Inserting Data with SQL");
     println!("{}", "=".repeat(60));
 
@@ -93,7 +95,7 @@ fn insert_data(client: &mut Client) -> Result<(), Box<dyn std::error::Error>> {
     ];
 
     for (id, name, email, age, created_at) in users {
-        client.execute(&format!(
+        conn.execute_sql(&format!(
             "INSERT INTO users (id, name, email, age, created_at) VALUES ({}, '{}', '{}', {}, '{}')",
             id, name, email, age, created_at
         ))?;
@@ -110,7 +112,7 @@ fn insert_data(client: &mut Client) -> Result<(), Box<dyn std::error::Error>> {
     ];
 
     for (id, user_id, title, content, likes, published_at) in posts {
-        client.execute(&format!(
+        conn.execute_sql(&format!(
             "INSERT INTO posts (id, user_id, title, content, likes, published_at) VALUES ({}, {}, '{}', '{}', {}, '{}')",
             id, user_id, title, content, likes, published_at
         ))?;
@@ -120,163 +122,179 @@ fn insert_data(client: &mut Client) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn select_queries(client: &mut Client) -> Result<(), Box<dyn std::error::Error>> {
+fn select_queries(conn: &SochConnection) -> Result<(), Box<dyn Error>> {
     println!("\n🔍 Running SELECT Queries");
     println!("{}", "=".repeat(60));
 
     // Simple SELECT
     println!("\n1. Select all users:");
-    let result = client.execute("SELECT * FROM users")?;
-    println!("   Found {} users", result.rows.len());
-    for row in &result.rows {
-        println!("   - {} ({})", 
-                 row.get("name").map(|v| format!("{:?}", v)).unwrap_or_default(),
-                 row.get("email").map(|v| format!("{:?}", v)).unwrap_or_default());
+    let result = conn.query_sql("SELECT * FROM users")?;
+    match result {
+        sochdb::ast_query::QueryResult::Select(rows) => {
+            println!("   Found {} users", rows.len());
+            for row in &rows {
+                println!(
+                    "   - {} ({})",
+                    row.get("name").map(|v| format!("{:?}", v)).unwrap_or_default(),
+                    row.get("email").map(|v| format!("{:?}", v)).unwrap_or_default()
+                );
+            }
+        }
+        _ => println!("   Unexpected result type"),
     }
 
     // SELECT with WHERE clause
     println!("\n2. Users older than 28:");
-    let result = client.execute("SELECT name, age FROM users WHERE age > 28")?;
-    for row in &result.rows {
-        println!("   - {}: {} years old",
-                 row.get("name").map(|v| format!("{:?}", v)).unwrap_or_default(),
-                 row.get("age").map(|v| format!("{:?}", v)).unwrap_or_default());
+    let result = conn.query_sql("SELECT name, age FROM users WHERE age > 28")?;
+    match result {
+        sochdb::ast_query::QueryResult::Select(rows) => {
+            for row in &rows {
+                println!(
+                    "   - {}: {} years old",
+                    row.get("name").map(|v| format!("{:?}", v)).unwrap_or_default(),
+                    row.get("age").map(|v| format!("{:?}", v)).unwrap_or_default()
+                );
+            }
+        }
+        _ => println!("   Unexpected result type"),
     }
 
     // SELECT with ORDER BY
     println!("\n3. Posts ordered by likes (descending):");
-    let result = client.execute("SELECT title, likes FROM posts ORDER BY likes DESC")?;
-    for row in &result.rows {
-        println!("   - {}: {} likes",
-                 row.get("title").map(|v| format!("{:?}", v)).unwrap_or_default(),
-                 row.get("likes").map(|v| format!("{:?}", v)).unwrap_or_default());
+    let result = conn.query_sql("SELECT title, likes FROM posts ORDER BY likes DESC")?;
+    match result {
+        sochdb::ast_query::QueryResult::Select(rows) => {
+            for row in &rows {
+                println!(
+                    "   - {}: {} likes",
+                    row.get("title").map(|v| format!("{:?}", v)).unwrap_or_default(),
+                    row.get("likes").map(|v| format!("{:?}", v)).unwrap_or_default()
+                );
+            }
+        }
+        _ => println!("   Unexpected result type"),
     }
 
     // SELECT with LIMIT
     println!("\n4. Top 3 most liked posts:");
-    let result = client.execute("SELECT title, likes FROM posts ORDER BY likes DESC LIMIT 3")?;
-    for row in &result.rows {
-        println!("   - {}: {} likes",
-                 row.get("title").map(|v| format!("{:?}", v)).unwrap_or_default(),
-                 row.get("likes").map(|v| format!("{:?}", v)).unwrap_or_default());
+    let result = conn.query_sql("SELECT title, likes FROM posts ORDER BY likes DESC LIMIT 3")?;
+    match result {
+        sochdb::ast_query::QueryResult::Select(rows) => {
+            for row in &rows {
+                println!(
+                    "   - {}: {} likes",
+                    row.get("title").map(|v| format!("{:?}", v)).unwrap_or_default(),
+                    row.get("likes").map(|v| format!("{:?}", v)).unwrap_or_default()
+                );
+            }
+        }
+        _ => println!("   Unexpected result type"),
     }
 
     Ok(())
 }
 
-fn update_operations(client: &mut Client) -> Result<(), Box<dyn std::error::Error>> {
+fn update_operations(conn: &SochConnection) -> Result<(), Box<dyn Error>> {
     println!("\n✏️  UPDATE Operations");
     println!("{}", "=".repeat(60));
 
     // Update single row
     println!("\n1. Update Alice's age:");
-    client.execute("UPDATE users SET age = 31 WHERE name = 'Alice'")?;
-    let result = client.execute("SELECT name, age FROM users WHERE name = 'Alice'")?;
-    if let Some(row) = result.rows.first() {
-        println!("   Alice's new age: {:?}", row.get("age"));
+    conn.execute_sql("UPDATE users SET age = 31 WHERE name = 'Alice'")?;
+    let result = conn.query_sql("SELECT name, age FROM users WHERE name = 'Alice'")?;
+    match result {
+        sochdb::ast_query::QueryResult::Select(rows) => {
+            if let Some(row) = rows.first() {
+                println!("   Alice's new age: {:?}", row.get("age"));
+            }
+        }
+        _ => {}
     }
 
     // Update multiple rows
     println!("\n2. Increment likes on all posts by user_id = 1:");
-    client.execute("UPDATE posts SET likes = likes + 5 WHERE user_id = 1")?;
-    let result = client.execute("SELECT title, likes FROM posts WHERE user_id = 1")?;
-    for row in &result.rows {
-        println!("   - {}: {} likes",
-                 row.get("title").map(|v| format!("{:?}", v)).unwrap_or_default(),
-                 row.get("likes").map(|v| format!("{:?}", v)).unwrap_or_default());
+    conn.execute_sql("UPDATE posts SET likes = likes + 5 WHERE user_id = 1")?;
+    let result = conn.query_sql("SELECT title, likes FROM posts WHERE user_id = 1")?;
+    match result {
+        sochdb::ast_query::QueryResult::Select(rows) => {
+            for row in &rows {
+                println!(
+                    "   - {}: {} likes",
+                    row.get("title").map(|v| format!("{:?}", v)).unwrap_or_default(),
+                    row.get("likes").map(|v| format!("{:?}", v)).unwrap_or_default()
+                );
+            }
+        }
+        _ => {}
     }
 
     Ok(())
 }
 
-fn delete_operations(client: &mut Client) -> Result<(), Box<dyn std::error::Error>> {
+fn delete_operations(conn: &SochConnection) -> Result<(), Box<dyn Error>> {
     println!("\n🗑️  DELETE Operations");
     println!("{}", "=".repeat(60));
 
     // Count before delete
-    let result = client.execute("SELECT COUNT(*) as total FROM posts")?;
-    let before_count = result.rows.len();
+    let result = conn.query_sql("SELECT COUNT(*) as total FROM posts")?;
+    let before_count = match &result {
+        sochdb::ast_query::QueryResult::Select(rows) => rows.len(),
+        _ => 0,
+    };
     println!("Posts before delete: {}", before_count);
 
     // Delete specific post
-    client.execute("DELETE FROM posts WHERE id = 5")?;
+    conn.execute_sql("DELETE FROM posts WHERE id = 5")?;
     println!("✓ Deleted post with id = 5");
 
     // Count after delete
-    let result = client.execute("SELECT COUNT(*) as total FROM posts")?;
-    let after_count = result.rows.len();
+    let result = conn.query_sql("SELECT COUNT(*) as total FROM posts")?;
+    let after_count = match &result {
+        sochdb::ast_query::QueryResult::Select(rows) => rows.len(),
+        _ => 0,
+    };
     println!("Posts after delete: {}", after_count);
 
     Ok(())
 }
 
-fn complex_queries(client: &mut Client) -> Result<(), Box<dyn std::error::Error>> {
+fn complex_queries(conn: &SochConnection) -> Result<(), Box<dyn Error>> {
     println!("\n🎯 Complex Queries");
     println!("{}", "=".repeat(60));
 
     // SELECT with multiple conditions
     println!("\n1. Users aged 25-30:");
-    let result = client.execute(
+    let result = conn.query_sql(
         "SELECT name, age, email FROM users WHERE age >= 25 AND age <= 30 ORDER BY age"
     )?;
-    for row in &result.rows {
-        println!("   - {}: {} years ({})",
-                 row.get("name").map(|v| format!("{:?}", v)).unwrap_or_default(),
-                 row.get("age").map(|v| format!("{:?}", v)).unwrap_or_default(),
-                 row.get("email").map(|v| format!("{:?}", v)).unwrap_or_default());
+    match result {
+        sochdb::ast_query::QueryResult::Select(rows) => {
+            for row in &rows {
+                println!(
+                    "   - {}: {} years ({})",
+                    row.get("name").map(|v| format!("{:?}", v)).unwrap_or_default(),
+                    row.get("age").map(|v| format!("{:?}", v)).unwrap_or_default(),
+                    row.get("email").map(|v| format!("{:?}", v)).unwrap_or_default()
+                );
+            }
+        }
+        _ => {}
     }
 
     // SELECT with pattern matching
     println!("\n2. Posts with 'Post' in title:");
-    let result = client.execute("SELECT title, likes FROM posts WHERE title LIKE '%Post%'")?;
-    for row in &result.rows {
-        println!("   - {}: {} likes",
-                 row.get("title").map(|v| format!("{:?}", v)).unwrap_or_default(),
-                 row.get("likes").map(|v| format!("{:?}", v)).unwrap_or_default());
-    }
-
-    Ok(())
-}
-
-fn sql_parser_examples() -> Result<(), Box<dyn std::error::Error>> {
-    println!("\n🔧 SQL Parser Examples");
-    println!("{}", "=".repeat(60));
-
-    // Parse a SELECT statement
-    let sql = "SELECT id, name FROM users WHERE age > 25 ORDER BY name LIMIT 10";
-    match Parser::parse(sql) {
-        Ok(stmt) => {
-            println!("\n✓ Successfully parsed SELECT:");
-            println!("  SQL: {}", sql);
-            println!("  AST: {:?}", stmt);
+    let result = conn.query_sql("SELECT title, likes FROM posts WHERE title LIKE '%Post%'")?;
+    match result {
+        sochdb::ast_query::QueryResult::Select(rows) => {
+            for row in &rows {
+                println!(
+                    "   - {}: {} likes",
+                    row.get("title").map(|v| format!("{:?}", v)).unwrap_or_default(),
+                    row.get("likes").map(|v| format!("{:?}", v)).unwrap_or_default()
+                );
+            }
         }
-        Err(errors) => {
-            println!("✗ Parse errors: {:?}", errors);
-        }
-    }
-
-    // Parse an INSERT statement
-    let sql = "INSERT INTO users (id, name, email) VALUES (1, 'Alice', 'alice@example.com')";
-    match Parser::parse(sql) {
-        Ok(stmt) => {
-            println!("\n✓ Successfully parsed INSERT:");
-            println!("  SQL: {}", sql);
-        }
-        Err(errors) => {
-            println!("✗ Parse errors: {:?}", errors);
-        }
-    }
-
-    // Parse a CREATE TABLE statement
-    let sql = "CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT NOT NULL, price REAL)";
-    match Parser::parse(sql) {
-        Ok(stmt) => {
-            println!("\n✓ Successfully parsed CREATE TABLE:");
-            println!("  SQL: {}", sql);
-        }
-        Err(errors) => {
-            println!("✗ Parse errors: {:?}", errors);
-        }
+        _ => {}
     }
 
     Ok(())

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "sochdb-examples"
+version = "0.5.0"
+edition = "2024"
+authors = ["SochDB Authors"]
+license = "AGPL-3.0-or-later"
+description = "SochDB Rust examples"
+
+[dependencies]
+sochdb = { path = "../../sochdb-client" }
+
+[[bin]]
+name = "01_basic_database"
+path = "01_basic_database.rs"
+
+[[bin]]
+name = "02_transactions"
+path = "02_transactions.rs"
+
+[[bin]]
+name = "03_vector_search"
+path = "03_vector_search.rs"
+
+[[bin]]
+name = "04_sql_queries"
+path = "04_sql_queries.rs"


### PR DESCRIPTION
## What Happened

`04_sql_queries.rs` uses crates and APIs that don't match the current codebase:

- `sochdb_client` crate — should be `sochdb`
- `sochdb_query::sql::Parser` — not available to examples
- `Client::open` — should be `SochConnection::open`
- `client.execute(sql)` — should be `conn.execute_sql(sql)` or `conn.query_sql(sql)`
- `"=".repeat(60)` — `repeat` not in scope (needs `str::repeat`)
- `anyhow` crate not available

## Lines Going Wrong

```
examples/rust/04_sql_queries.rs:13  —  use sochdb_client::{Client, ClientConfig, QueryResult};
examples/rust/04_sql_queries.rs:14  —  use sochdb_query::sql::{Parser, Statement, ExecutionResult};
examples/rust/04_sql_queries.rs:17  —  let sep = "=".repeat(60);  // repeat not in scope
examples/rust/04_sql_queries.rs:28  —  let mut client = Client::open(db_path)?;
examples/rust/04_sql_queries.rs:52  —  client.execute(r#"CREATE TABLE users (...)"#)?;
examples/rust/04_sql_queries.rs:129 —  let result = client.execute("SELECT * FROM users")?;
examples/rust/04_sql_queries.rs:247 —  match Parser::parse(sql) { ... }
```

## Fix

Rewrote to use `SochConnection` with `execute_sql` and `query_sql`:
- `SochConnection::open(db_path)?`
- `conn.execute_sql("CREATE TABLE ...")?` for DDL/DML
- `conn.query_sql("SELECT ...")?` for queries
- Handle `QueryResult` enum variants (`Select`, `Insert`, etc.)

## Validation

```bash
cargo check -p sochdb-examples --bin 04_sql_queries
# Finished `dev` profile
```