### PR TITLE
Refresh CrewAI integration examples

### DIFF
--- a/docs/api-reference/rust-api.md
+++ b/docs/api-reference/rust-api.md
@@ -315,75 +315,41 @@ result = agent.invoke({
 
 ```python
 from crewai import Agent, Task, Crew
-from crewai_tools import BaseTool
-import subprocess
-import json
-
-class SochDBContextTool(BaseTool):
-    name: str = "sochdb_context"
-    description: str = "Retrieve relevant context from the knowledge base with automatic token budgeting"
-    
-    def __init__(self, db_path: str):
-        super().__init__()
-        self.db_path = db_path
-        self._start_server()
-    
-    def _start_server(self):
-        self.proc = subprocess.Popen(
-            ["sochdb-mcp", "--db", self.db_path],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            text=True
-        )
-        # Initialize MCP...
-    
-    def _run(self, query: str, token_budget: int = 2000) -> str:
-        """Execute context retrieval"""
-        sections = [
-            {"name": "knowledge", "kind": "search", "query": query, "top_k": 5},
-            {"name": "recent", "kind": "last", "table": "interactions", "top_k": 3}
-        ]
-        # MCP call to sochdb_context_query
-        return self._call_mcp("sochdb_context_query", {
-            "sections": sections,
-            "token_budget": token_budget
-        })
+from sochdb import Database, Namespace, SochDBKnowledgeStore, create_crewai_tools
 
 
-class SochDBMemoryTool(BaseTool):
-    name: str = "sochdb_memory"
-    description: str = "Store and retrieve agent memories"
-    
-    def _run(self, action: str, **kwargs) -> str:
-        if action == "store":
-            return self._store_memory(kwargs["key"], kwargs["value"])
-        elif action == "recall":
-            return self._recall_memory(kwargs["key"])
+def embed(texts: list[str]) -> list[list[float]]:
+    # Plug in your preferred embedder here.
+    ...
 
 
-# Create agents with SochDB tools
+db = Database.open("/tmp/sochdb-crewai-demo")
+namespace = Namespace(db, "agents")
+collection = namespace.create_collection("knowledge", dimension=768)
+store = SochDBKnowledgeStore.from_collection(collection, embedder=embed)
+
+store.add_texts(
+    ["Reset password instructions are in the account settings page."],
+    metadatas=[{"topic": "support"}],
+    ids=["doc-1"],
+)
+
+search_tool, remember_tool = create_crewai_tools(store, top_k=3)
+
 researcher = Agent(
-    role="Research Analyst",
-    goal="Find relevant information from the knowledge base",
-    tools=[SochDBContextTool("./research_db")],
-    verbose=True
+    role="Support Researcher",
+    goal="Ground responses in the SochDB knowledge store",
+    tools=[search_tool, remember_tool],
 )
 
-writer = Agent(
-    role="Content Writer", 
-    goal="Write reports based on research",
-    tools=[SochDBMemoryTool("./research_db")],
-    verbose=True
+task = Task(
+    description="Find the password reset steps and summarize them clearly.",
+    agent=researcher,
 )
 
-# Create crew
-crew = Crew(
-    agents=[researcher, writer],
-    tasks=[
-        Task(description="Research the topic: {topic}", agent=researcher),
-        Task(description="Write a summary report", agent=writer)
-    ]
-)
+crew = Crew(agents=[researcher], tasks=[task])
+result = crew.kickoff()
+print(result)
 ```
 
 ### OpenAI Function Calling Bridge

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,7 +48,7 @@ Treat the examples above as product maturity signals rather than all being equal
 | Example | Description | Frameworks |
 |---------|-------------|------------|
 | [langgraph_agent.py](python/langgraph_agent.py) | Multi-turn agent with memory | LangGraph, LangChain |
-| [crewai_research_crew.py](python/crewai_research_crew.py) | Multi-agent research workflow | CrewAI |
+| [crewai_research_crew.py](python/crewai_research_crew.py) | Multi-agent research workflow backed by the Python SDK CrewAI tools | CrewAI |
 | [llamaindex_rag.py](python/llamaindex_rag.py) | RAG with custom vector store | LlamaIndex |
 | [simple_rag_chatbot.py](python/simple_rag_chatbot.py) | Minimal chatbot with memory | Pure Python |
 | [semantic_search_api.py](python/semantic_search_api.py) | Search API with filtering | REST-style |
@@ -111,8 +111,12 @@ pip install sochdb python-dotenv requests numpy
 pip install langgraph langchain-core
 
 # For CrewAI (optional)
-pip install crewai crewai-tools
+pip install "sochdb[crewai]"
 ```
+
+The CrewAI example uses the Python SDK's maintained integration helpers plus a
+small local demo embedder, so it does not need Azure embedding credentials.
+You only need an LLM provider configured for CrewAI itself.
 
 If you're developing from the monorepo instead of using the published package:
 
@@ -124,6 +128,10 @@ cd ..
 ```
 
 ### 2. Configure Azure OpenAI
+
+This is only required for the Azure-backed examples such as `real_llm_test.py`,
+`langgraph_agent.py`, and other cloud-provider demos. It is not required for
+`python/crewai_research_crew.py`.
 
 Create a `.env` file in the repository root:
 
@@ -144,6 +152,9 @@ AZURE_EMEBEDDING_API_VERSION="2024-12-01-preview"
 ```bash
 # Recommended first run: local-only, no API keys
 python3 examples/python/07_local_knowledge_search.py
+
+# Maintained CrewAI integration example
+python3 examples/python/crewai_research_crew.py
 
 # Then move to advanced examples with extra dependencies
 python3 examples/python/langgraph_agent.py

--- a/examples/python/crewai_research_crew.py
+++ b/examples/python/crewai_research_crew.py
@@ -1,246 +1,107 @@
 #!/usr/bin/env python3
 """
-CrewAI + SochDB Integration Example
+CrewAI + SochDB integration example.
 
-Demonstrates a multi-agent research crew with:
-- SochDB VectorIndex for knowledge retrieval
-- CrewAI for multi-agent orchestration
-- Real embeddings via Azure OpenAI
+This example mirrors the supported CrewAI integration that now lives in the
+published Python SDK. It keeps the demo self-contained by using a tiny local
+embedder instead of requiring Azure or another embedding service.
 
-Usage:
-    pip install sochdb python-dotenv requests numpy crewai crewai-tools
-    python3 examples/python/crewai_research_crew.py
+Install:
+    pip install "sochdb[crewai]"
 
-    # Or from this monorepo:
-    cd sochdb-python
-    maturin develop --release
-    cd ..
-    python3 examples/python/crewai_research_crew.py
+Optional environment:
+    OPENAI_API_KEY=<your key>
+    CREWAI_MODEL=gpt-4o-mini
 """
 
-# Copyright 2025 Sushanth (https://github.com/sushanthpy)
-# Licensed under the Apache License, Version 2.0
+from __future__ import annotations
 
+import hashlib
+import math
 import os
-import sys
-import time
-import numpy as np
-import requests
-from typing import List, Dict
+import tempfile
+from typing import Sequence
 
-# Add SochDB package path for monorepo source usage
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../sochdb-python"))
-
-from dotenv import load_dotenv
-load_dotenv()
+from sochdb import Database, Namespace, SochDBKnowledgeStore, create_crewai_tools
 
 
-# =============================================================================
-# SochDB + Azure OpenAI Setup
-# =============================================================================
-
-class SochDBRetriever:
-    """SochDB-powered retrieval tool for CrewAI agents."""
-    
-    def __init__(self):
-        from sochdb import VectorIndex
-        
-        # Azure embeddings
-        self.embed_endpoint = os.getenv("AZURE_EMEBEDDING_ENDPOINT")
-        self.embed_key = os.getenv("AZURE_EMEBEDDING_API_KEY")
-        self.embed_deployment = os.getenv("AZURE_EMEBEDDING_DEPLOYMENT_NAME", "embedding")
-        self.embed_version = os.getenv("AZURE_EMEBEDDING_API_VERSION", "2024-12-01-preview")
-        
-        # Initialize index
-        self.dim = 1536  # Azure embedding dimension
-        self.index = VectorIndex(dimension=self.dim, max_connections=16, ef_construction=100)
-        self.documents = []
-    
-    def embed(self, texts: List[str]) -> np.ndarray:
-        """Generate embeddings via Azure."""
-        url = f"{self.embed_endpoint.rstrip('/')}/openai/deployments/{self.embed_deployment}/embeddings?api-version={self.embed_version}"
-        headers = {"api-key": self.embed_key, "Content-Type": "application/json"}
-        response = requests.post(url, headers=headers, json={"input": texts, "model": self.embed_deployment})
-        response.raise_for_status()
-        return np.array([item["embedding"] for item in response.json()["data"]], dtype=np.float32)
-    
-    def add_documents(self, docs: List[str]):
-        """Add documents to the knowledge base."""
-        embeddings = self.embed(docs)
-        start_id = len(self.documents)
-        ids = np.arange(start_id, start_id + len(docs), dtype=np.uint64)
-        self.index.insert_batch(ids, embeddings)
-        self.documents.extend(docs)
-        return len(docs)
-    
-    def search(self, query: str, k: int = 3) -> List[str]:
-        """Search for relevant documents."""
-        query_embed = self.embed([query])[0]
-        results = self.index.search(query_embed, k=k)
-        return [self.documents[int(r[0])] for r in results if int(r[0]) < len(self.documents)]
-
-
-# =============================================================================
-# CrewAI Example (Without actual CrewAI to avoid dependency issues)
-# =============================================================================
-
-def run_crewai_style_research():
+def deterministic_embed(texts: Sequence[str], dim: int = 32) -> list[list[float]]:
     """
-    Simulate a CrewAI-style multi-agent research workflow.
-    
-    In a real CrewAI setup, you would:
-    1. Create Agent instances with roles
-    2. Create Task instances
-    3. Create a Crew and execute
-    
-    This example shows the SochDB integration pattern.
+    Tiny local embedder for examples and tests.
+
+    This keeps the example runnable without a second model service. It is not a
+    semantically strong embedding model, but it is enough to demonstrate the
+    SochDB + CrewAI tool flow.
     """
-    
-    print("="*70)
-    print("  CREWAI-STYLE RESEARCH CREW + SOCHDB")
-    print("="*70)
-    
-    # Setup retriever
-    print("\n1. Setting up SochDB knowledge base...")
-    retriever = SochDBRetriever()
-    
-    # Add knowledge documents
-    knowledge = [
-        "SochDB is a high-performance database designed for AI agents and LLM applications.",
-        "SochDB achieves 117,000 vector inserts per second and 0.03ms search latency.",
-        "SochDB uses a Trie-Columnar Hybrid (TCH) storage engine for hierarchical data.",
-        "SochDB is 24x faster than ChromaDB on vector search benchmarks.",
-        "SochDB supports session management, context queries, and token budget enforcement.",
-        "SochDB provides an MCP (Model Context Protocol) integration for LLM tools.",
-        "SochDB's HNSW index uses SIMD acceleration for fast similarity search.",
-        "SochDB can handle 10M+ vectors with consistent sub-millisecond latency.",
-    ]
-    
-    count = retriever.add_documents(knowledge)
-    print(f"   ✓ Added {count} documents to knowledge base")
-    
-    # ==========================================================================
-    # Simulate CrewAI Agents
-    # ==========================================================================
-    
-    print("\n2. Simulating CrewAI agents...\n")
-    
-    # Azure LLM for agents
-    llm_endpoint = os.getenv("AZURE_OPENAI_API_BASE")
-    llm_key = os.getenv("AZURE_OPENAI_API_KEY")
-    llm_deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME", "gpt-4.1")
-    llm_version = os.getenv("AZURE_OPENAI_API_VERSION", "2025-01-01-preview")
-    
-    def call_llm(role: str, task: str, context: str = "") -> str:
-        url = f"{llm_endpoint.rstrip('/')}/openai/deployments/{llm_deployment}/chat/completions?api-version={llm_version}"
-        headers = {"api-key": llm_key, "Content-Type": "application/json"}
-        
-        system_prompt = f"You are a {role}. {context}"
-        messages = [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": task}
-        ]
-        
-        response = requests.post(url, headers=headers, json={
-            "messages": messages, "max_tokens": 300, "temperature": 0.0
-        })
-        response.raise_for_status()
-        return response.json()["choices"][0]["message"]["content"]
-    
-    # Agent 1: Researcher
-    print("   [Researcher Agent]")
-    research_query = "What makes SochDB fast for AI applications?"
-    research_context = retriever.search(research_query, k=3)
-    print(f"   Retrieved {len(research_context)} relevant docs")
-    
-    research_result = call_llm(
-        role="Research Analyst specializing in database technologies",
-        task=f"Based on this information, summarize SochDB's key performance characteristics:\n\n{chr(10).join(research_context)}",
+
+    vectors: list[list[float]] = []
+    for text in texts:
+        digest = hashlib.sha256(text.encode("utf-8")).digest()
+        values = [((digest[i % len(digest)] / 255.0) * 2.0) - 1.0 for i in range(dim)]
+        norm = math.sqrt(sum(v * v for v in values)) or 1.0
+        vectors.append([v / norm for v in values])
+    return vectors
+
+
+def build_knowledge_store() -> SochDBKnowledgeStore:
+    tempdir = tempfile.mkdtemp(prefix="sochdb-crewai-")
+    db = Database.open(tempdir)
+    namespace = Namespace(db, "crewai_demo")
+    collection = namespace.create_collection("knowledge", dimension=32)
+
+    store = SochDBKnowledgeStore.from_collection(
+        collection,
+        embedder=deterministic_embed,
     )
-    print(f"   Research: {research_result[:100]}...")
-    
-    # Agent 2: Writer
-    print("\n   [Writer Agent]")
-    write_result = call_llm(
-        role="Technical Writer creating documentation",
-        task=f"Write a brief product description for SochDB based on this research:\n\n{research_result}",
+    store.add_texts(
+        [
+            "SochDB supports both embedded and gRPC deployment modes.",
+            "The hosted SochDB demo endpoint listens on studio.agentslab.host:50053.",
+            "The corrected 10GB benchmark showed about 506 QPS after one-time index load.",
+            "BAAI/bge-base-en-v1.5 is the best published SciFact quality result so far.",
+        ],
+        metadatas=[
+            {"topic": "architecture"},
+            {"topic": "deployment"},
+            {"topic": "benchmark"},
+            {"topic": "quality"},
+        ],
+        ids=["arch-1", "deploy-1", "bench-1", "quality-1"],
     )
-    print(f"   Article: {write_result[:100]}...")
-    
-    # Agent 3: Reviewer
-    print("\n   [Reviewer Agent]")
-    review_result = call_llm(
-        role="Technical Editor ensuring accuracy and clarity",
-        task=f"Review this product description and provide a final, polished version:\n\n{write_result}",
+    return store
+
+
+def main() -> None:
+    from crewai import Agent, Crew, Task
+
+    store = build_knowledge_store()
+    search_tool, remember_tool = create_crewai_tools(store, top_k=3)
+    model = os.environ.get("CREWAI_MODEL", "gpt-4o-mini")
+
+    researcher = Agent(
+        role="SochDB Researcher",
+        goal="Answer questions using the SochDB knowledge base before responding.",
+        backstory="You are careful about grounding claims in retrieved project context.",
+        llm=model,
+        tools=[search_tool, remember_tool],
+        verbose=True,
     )
-    print(f"   Final: {review_result[:100]}...")
-    
-    # ==========================================================================
-    # Example CrewAI Code (commented out to avoid dependency)
-    # ==========================================================================
-    
-    print("\n" + "-"*70)
-    print("\n3. Example CrewAI integration code:\n")
-    
-    example_code = '''
-# pip install crewai crewai-tools
 
-from crewai import Agent, Task, Crew
-from crewai.tools import BaseTool
-from sochdb import VectorIndex
+    task = Task(
+        description=(
+            "Find the current 10GB benchmark takeaway and summarize it in 2-3 sentences. "
+            "Use the SochDB tools and avoid guessing."
+        ),
+        expected_output="A short grounded summary of the latest 10GB benchmark result.",
+        agent=researcher,
+    )
 
-# Create a SochDB retrieval tool
-class SochDBSearchTool(BaseTool):
-    name: str = "sochdb_search"
-    description: str = "Search SochDB knowledge base for relevant information"
-    
-    def __init__(self, retriever: SochDBRetriever):
-        self.retriever = retriever
-    
-    def _run(self, query: str) -> str:
-        results = self.retriever.search(query, k=3)
-        return "\\n".join(results)
+    crew = Crew(agents=[researcher], tasks=[task], verbose=True)
+    result = crew.kickoff()
 
-# Create agents
-researcher = Agent(
-    role="Research Analyst",
-    goal="Find accurate information about the topic",
-    backstory="Expert at finding and synthesizing information",
-    tools=[SochDBSearchTool(retriever)],
-)
-
-writer = Agent(
-    role="Technical Writer",
-    goal="Create clear, accurate documentation",
-    backstory="Skilled at translating technical concepts",
-)
-
-# Create tasks
-research_task = Task(
-    description="Research SochDB's performance characteristics",
-    agent=researcher,
-)
-
-write_task = Task(
-    description="Write a product description based on research",
-    agent=writer,
-)
-
-# Create and run crew
-crew = Crew(
-    agents=[researcher, writer],
-    tasks=[research_task, write_task],
-)
-
-result = crew.kickoff()
-'''
-    
-    print(example_code)
-    
-    print("\n" + "="*70)
-    print("  ✓ CrewAI-style research completed!")
-    print("="*70)
+    print("\n=== Crew Result ===\n")
+    print(result)
 
 
 if __name__ == "__main__":
-    run_crewai_style_research()
+    main()


### PR DESCRIPTION
## Summary
- replace the old simulated CrewAI example with the maintained Python SDK integration shape
- update the examples README to use the current CrewAI install and run guidance
- refresh the CrewAI API doc snippet to match the supported SDK helpers

## Included
- examples/python/crewai_research_crew.py now mirrors the maintained SDK integration pattern
- examples/README.md now points users to the current CrewAI install path and clarifies that this example does not require Azure embeddings
- docs/api-reference/rust-api.md now shows the supported SochDBKnowledgeStore plus create_crewai_tools flow instead of the older custom MCP wrapper sketch

## Validation
- python3 -m py_compile examples/python/crewai_research_crew.py
- git diff --check
