### PR TITLE
fix: l2_squared_threshold_avx2 early-abort discards remainder distances

### DIFF
--- a/sochdb-index/src/simd_distance.rs
+++ b/sochdb-index/src/simd_distance.rs
@@ -768,7 +768,7 @@ unsafe fn l2_squared_threshold_avx2(a: &[f32], b: &[f32], threshold_squared: f32
         }
         
         // Check if we've exceeded threshold
-        let sum_scalar = unsafe {
+        let mut sum_scalar = unsafe {
             let sum_high = _mm256_extractf128_ps(sum, 1);
             let sum_low = _mm256_castps256_ps128(sum);
             let sum128 = _mm_add_ps(sum_low, sum_high);
@@ -781,7 +781,7 @@ unsafe fn l2_squared_threshold_avx2(a: &[f32], b: &[f32], threshold_squared: f32
             // Add remainder and return (we know we've exceeded threshold)
             for i in (end_chunk * 8)..n {
                 let diff = a[i] - b[i];
-                sum_scalar + diff * diff;
+                sum_scalar += diff * diff;
             }
             return sum_scalar;
         }


### PR DESCRIPTION
# Fix: L2 threshold early-abort silently discards remainder distances

## Summary

`l2_squared_threshold_avx2` in `sochdb-index/src/simd_distance.rs` had a logic bug
where `sum_scalar + diff * diff` was computed but never assigned back — the result
was silently discarded on every iteration of the remainder loop. This meant that
when the distance exceeded the threshold mid-chunk, the early-abort path would
return the partial sum **without** including the remaining element contributions,
producing an underestimate of the actual squared L2 distance.

## Bug

```rust
// BEFORE (simd_distance.rs:782-785)
for i in (end_chunk * 8)..n {
    let diff = a[i] - b[i];
    sum_scalar + diff * diff;  // computed but never assigned!
}
return sum_scalar;
```

The expression `sum_scalar + diff * diff` creates a value that is immediately
discarded — it does **not** mutate `sum_scalar`. The Rust compiler flags this
with `unused_must_use` (arithmetic on integers/floats), which is how it was
discovered.

## Fix

```rust
// AFTER
let mut sum_scalar = unsafe { ... };  // note: added `mut`

for i in (end_chunk * 8)..n {
    let diff = a[i] - b[i];
    sum_scalar += diff * diff;  // accumulate into sum_scalar
}
return sum_scalar;
```

Two changes:
1. `let sum_scalar` → `let mut sum_scalar` so it can be mutated.
2. `sum_scalar + diff * diff;` → `sum_scalar += diff * diff;` to actually accumulate.

## Impact

- The early-abort path in `l2_squared_threshold_avx2` now
  correctly includes remainder elements in its distance estimate. Previously
  it would return a value **strictly less than** the true squared L2 distance,
  which could cause the threshold check to miss vectors that should have been
  pruned.

- No performance regression — the same number of operations
  is performed, just correctly accumulated.

## To Validate the fix

```bash
cargo build
cargo test -p sochdb-index
```

The fix compiles cleanly and the existing threshold tests pass. A targeted test
for the remainder path should be added separately if one does not already exist.

## File Changed

- `sochdb-index/src/simd_distance.rs` — line 784: assign-and-discard → compound-add