### PR TITLE
fix: ScratchBuffers exposes pub fields of pub(crate) type FastCandidate

### DIFF
--- a/sochdb-index/src/scratch_buffers.rs
+++ b/sochdb-index/src/scratch_buffers.rs
@@ -214,11 +214,11 @@ pub struct ScratchBuffers {
     /// Candidate priority queue for FastCandidate-based zero-lock paths
     /// (search_layer_zero_flat, search_layer_zero_lock)
     /// Reused instead of per-call BinaryHeap allocation.
-    pub fast_candidates: BinaryHeap<FastCandidate>,
+    pub(crate) fast_candidates: BinaryHeap<FastCandidate>,
 
     /// Results min-heap for FastCandidate-based zero-lock paths
     /// Reused instead of per-call BinaryHeap allocation.
-    pub fast_results_heap: BinaryHeap<Reverse<FastCandidate>>,
+    pub(crate) fast_results_heap: BinaryHeap<Reverse<FastCandidate>>,
 }
 
 impl ScratchBuffers {


### PR DESCRIPTION
# Fix: ScratchBuffers exposes pub fields of pub(crate) type FastCandidate

## What happened

`ScratchBuffers` in `sochdb-index/src/scratch_buffers.rs` declared two fields as
`pub` that expose `FastCandidate` — but `FastCandidate` is `pub(crate)`. This is
a visibility mismatch: the fields claim to be publicly accessible, but the type
they contain is not visible outside the crate. The Rust compiler warns about
this as `private_interfaces`.

## Issue found

```rust
// scratch_buffers.rs
pub struct ScratchBuffers {
    // ...
    pub fast_candidates: BinaryHeap<FastCandidate>,        // pub field
    pub fast_results_heap: BinaryHeap<Reverse<FastCandidate>>, // pub field
}

// hnsw.rs
pub(crate) struct FastCandidate { ... }  // only visible within sochdb-index
```

A downstream crate that depends on `sochdb-index` would see public fields but
could not name, construct, or pattern-match on `FastCandidate`. This is an API
surface inconsistency — the fields claim broader visibility than the type
actually supports.

## Fix

```rust
// AFTER
pub(crate) fast_candidates: BinaryHeap<FastCandidate>,
pub(crate) fast_results_heap: BinaryHeap<Reverse<FastCandidate>>,
```

Tightened both fields from `pub` to `pub(crate)` to match the visibility of
`FastCandidate`. These scratch buffer fields are only consumed by HNSW search
paths (`search_layer_zero_flat`, `search_layer_zero_lock`) within the same
crate, so the broader `pub` visibility was never needed.

## Overall improvement with this PR

- The field visibility now matches the type visibility.
- No breakage — `FastCandidate` was never constructable from
  outside the crate, so no external code could meaningfully use these fields.
- No change — all consumers are within `sochdb-index`.

## To Validate the fix

```bash
cargo build -p sochdb-index
```

The `private_interfaces` warnings for `FastCandidate` now no longer appear.

## File Changed

- `sochdb-index/src/scratch_buffers.rs` — lines 217, 221: `pub` → `pub(crate)`