### PR TITLE
Fix/hnsw recall sql aggregate bugfixes

### DIFF
--- a/sochdb-grpc/src/collection_server.rs
+++ b/sochdb-grpc/src/collection_server.rs
@@ -213,10 +213,12 @@ impl CollectionService for CollectionServer {
         let key = Self::collection_key(&req.namespace, &req.name);
 
         match self.collections.remove(&key) {
-            Some(_) => {
-                // Decrement collection count in namespace stats
+            Some((_, removed)) => {
+                // Decrement collection AND vector counts in namespace stats —
+                // dropping a collection releases every vector it held.
                 if let Some(ref ns) = self.ns_server {
                     ns.decrement_collection_count(&req.namespace);
+                    ns.decrement_vector_count(&req.namespace, removed.documents.len() as u64);
                 }
                 Ok(Response::new(DeleteCollectionResponse {
                     success: true,
@@ -248,7 +250,11 @@ impl CollectionService for CollectionServer {
 
         match self.collections.get(&key) {
             Some(data) => {
-                let added_count = req.documents.len() as u64;
+                // Count only genuinely-new documents: a duplicate id (within
+                // the batch or already present) overwrites via DashMap::insert
+                // rather than adding a row, so counting req.documents.len()
+                // over-counted the quota and leaked capacity on every re-upsert.
+                let mut added_count = 0u64;
                 let mut ids = Vec::new();
                 for doc in req.documents {
                     let id = if doc.id.is_empty() {
@@ -260,7 +266,9 @@ impl CollectionService for CollectionServer {
 
                     let mut stored_doc = doc;
                     stored_doc.id = id.clone();
-                    data.documents.insert(id, stored_doc);
+                    if data.documents.insert(id, stored_doc).is_none() {
+                        added_count += 1;
+                    }
                 }
 
                 // Track vectors added in namespace stats
@@ -399,10 +407,16 @@ impl CollectionService for CollectionServer {
 
         match self.collections.get(&key) {
             Some(data) => match data.documents.remove(&req.document_id) {
-                Some(_) => Ok(Response::new(DeleteDocumentResponse {
-                    success: true,
-                    error: String::new(),
-                })),
+                Some(_) => {
+                    // Release the vector-quota slot this document held.
+                    if let Some(ref ns) = self.ns_server {
+                        ns.decrement_vector_count(&req.namespace, 1);
+                    }
+                    Ok(Response::new(DeleteDocumentResponse {
+                        success: true,
+                        error: String::new(),
+                    }))
+                }
                 None => Ok(Response::new(DeleteDocumentResponse {
                     success: false,
                     error: format!("Document '{}' not found", req.document_id),

--- a/sochdb-grpc/src/namespace_server.rs
+++ b/sochdb-grpc/src/namespace_server.rs
@@ -121,6 +121,18 @@ impl NamespaceServer {
         }
     }
 
+    /// Decrement the vector count for a namespace (on document/collection
+    /// deletion). Without this the quota counter only ever rose, so a
+    /// namespace that repeatedly added and deleted documents would
+    /// permanently exhaust its vector quota despite holding nothing.
+    pub fn decrement_vector_count(&self, namespace: &str, count: u64) {
+        if let Some(mut ns) = self.namespaces.get_mut(namespace) {
+            if let Some(ref mut stats) = ns.stats {
+                stats.vector_count = stats.vector_count.saturating_sub(count);
+            }
+        }
+    }
+
     /// Increment the storage bytes for a namespace.
     pub fn increment_storage_bytes(&self, namespace: &str, bytes: u64) {
         if let Some(mut ns) = self.namespaces.get_mut(namespace) {

--- a/sochdb-index/src/hnsw.rs
+++ b/sochdb-index/src/hnsw.rs
@@ -85,8 +85,16 @@ use crate::vector_quantized::{
 };
 use crate::vector_storage::VectorStorage;
 
-/// Maximum connections per node (inline storage size for SmallVec)
-const MAX_M: usize = 32;
+/// Inline storage size (SmallVec capacity) for a node's neighbor list. Sized
+/// to hold the default layer-0 degree (max_connections_layer0 = 64) inline, so
+/// neighbor lists don't heap-spill on every node at the default config.
+/// Measured: raising the default degree from m=16/m0=32 to m=32/m0=64 lifts
+/// recall@10 on deep-1M from 0.967 to 0.988 (>=95%); keeping m0 inline avoids a
+/// per-node heap allocation on the hot path.
+///
+/// Single source of truth — `persistence.rs` imports this so the serialized
+/// neighbor-list inline size cannot drift from the in-memory one.
+pub(crate) const MAX_M: usize = 64;
 
 // ==================== Task #11: Performance Cost Model Types ====================
 
@@ -2005,10 +2013,19 @@ pub struct HnswConfig {
 impl Default for HnswConfig {
     fn default() -> Self {
         Self {
-            max_connections: 16,
-            max_connections_layer0: 32,
-            level_multiplier: 1.0 / (16.0_f32).ln(),
-            ef_construction: 200,
+            // m=32 / m0=64 (standard m0=2*m). Higher graph degree is the
+            // dominant recall lever at scale: measured recall@10 on deep-1M
+            // rose 0.967 (m=16/m0=32) -> 0.988 (m=32) -> 0.990 (m=48). m=32 is
+            // the recall/build-cost sweet spot and clears 95% out of the box;
+            // callers can still lower it for memory/speed. MAX_M is sized to
+            // keep m0=64 neighbor lists inline.
+            max_connections: 32,
+            max_connections_layer0: 64,
+            level_multiplier: 1.0 / (32.0_f32).ln(),
+            // ef_construction raised 200 -> 256: a richer build improves the
+            // graph the search must navigate (especially on hard, high-dim real
+            // embeddings like Cohere where m alone left recall ~0.90).
+            ef_construction: 256,
             ef_search: 500,
             metric: DistanceMetric::Cosine,
             quantization_precision: Some(Precision::F32),
@@ -2333,6 +2350,16 @@ pub struct HnswIndex {
     /// TODO(T7): migrate to `ShardedVectorStore` (64 independent shard locks).
     /// Expected improvement: 3–5× under mixed read/write workloads.
     pub(crate) vector_store: Arc<RwLock<Vec<QuantizedVector>>>,
+    /// Serializes the graph-MUTATING path (insert / insert_batch*). Concurrent
+    /// inserts previously deadlocked: the connect phase holds vector_store /
+    /// internal_nodes reads while taking per-node layer locks, and another
+    /// insert's phase-1 vector_store.write() cross-blocks under parking_lot's
+    /// writer preference (confirmed via thread sampling: many threads parked in
+    /// lock_exclusive_slow/lock_shared_slow). This index uses a single-writer /
+    /// concurrent-reader discipline: one insert mutates at a time, while
+    /// searches (which never take this lock) stay fully concurrent. Parallelism
+    /// WITHIN a single batch (rayon connect) is preserved.
+    pub(crate) insert_lock: parking_lot::Mutex<()>,
     /// Per-node metadata for filtered search, indexed by dense_index.
     /// Stored as pre-serialized key-value pairs for O(1) filter matching.
     pub(crate) metadata_store: Arc<RwLock<Vec<Option<Vec<(String, String)>>>>>,
@@ -2408,6 +2435,7 @@ impl HnswIndex {
             next_dense_index: AtomicUsize::new(0),
             dense_to_id: Arc::new(RwLock::new(Vec::new())),
             vector_store: Arc::new(RwLock::new(Vec::new())),
+            insert_lock: parking_lot::Mutex::new(()),
             metadata_store: Arc::new(RwLock::new(Vec::new())),
             internal_nodes: Arc::new(RwLock::new(Vec::new())),
             flat_neighbors: Arc::new(RwLock::new(Vec::new())),
@@ -2454,6 +2482,7 @@ impl HnswIndex {
             next_dense_index: AtomicUsize::new(0),
             dense_to_id: Arc::new(RwLock::new(Vec::new())),
             vector_store: Arc::new(RwLock::new(Vec::new())),
+            insert_lock: parking_lot::Mutex::new(()),
             metadata_store: Arc::new(RwLock::new(Vec::new())),
             internal_nodes: Arc::new(RwLock::new(Vec::new())),
             flat_neighbors: Arc::new(RwLock::new(Vec::new())),
@@ -2789,7 +2818,16 @@ impl HnswIndex {
         new_node_dense: u32,
         new_node_vector: &QuantizedVector,
     ) -> bool {
-        let vector_store = self.vector_store.read();
+        // read_recursive(): this runs while the caller (connect_node_fast /
+        // repair paths) already holds a vector_store read on this thread.
+        // parking_lot's plain read() defers to queued writers, so if a
+        // concurrent batch's phase-1 vector_store.write() parks between the
+        // outer read and this one, this read would park behind it forever —
+        // the confirmed concurrent-insert deadlock. read_recursive() acquires
+        // shared access without deferring to writers, breaking the cycle.
+        // Safe: this path only reads vector_store (writes go to node-layer
+        // locks), so there is no read->write self-upgrade.
+        let vector_store = self.vector_store.read_recursive();
         let neighbor_vector = vector_store
             .get(neighbor_node.vector_index as usize)
             .unwrap_or(&neighbor_node.vector);
@@ -2844,7 +2882,10 @@ impl HnswIndex {
 
         // Look up the node's vector from vector_store (node.vector may be empty
         // for batch-inserted nodes where we use QuantizedVector::empty() to save memory).
-        let vector_store = self.vector_store.read();
+        // read_recursive(): called while connect_node_fast holds an outer
+        // vector_store read; see try_replace_worst_neighbor for the deadlock
+        // rationale (reentrant read must not defer to a queued writer).
+        let vector_store = self.vector_store.read_recursive();
         let node_vector = vector_store
             .get(node.vector_index as usize)
             .unwrap_or(&node.vector);
@@ -2969,8 +3010,12 @@ impl HnswIndex {
         }
 
         // At capacity - replace worst neighbor with source
-        // Calculate distance to source
-        let vector_store = self.vector_store.read();
+        // Calculate distance to source.
+        // read_recursive(): reached from ensure_minimum_degree_layer0 /
+        // connect paths that already hold a vector_store read on this thread;
+        // a plain read() could deadlock behind a concurrent writer (see
+        // try_replace_worst_neighbor). Read-only path, so recursive read safe.
+        let vector_store = self.vector_store.read_recursive();
         let target_vector = vector_store
             .get(target_node.vector_index as usize)
             .unwrap_or(&target_node.vector);
@@ -3015,6 +3060,8 @@ impl HnswIndex {
     /// This method can now be called concurrently from multiple threads
     /// Vectors are automatically normalized during ingestion for cosine similarity optimization
     pub fn insert(&self, id: u128, vector: Vec<f32>) -> Result<(), String> {
+        // Single-writer discipline: serialize graph mutation (see insert_lock).
+        let _insert_guard = self.insert_lock.lock();
         let _timer = metrics::INSERT_LATENCY.start_timer();
         metrics::INSERT_COUNT.inc();
 
@@ -3109,13 +3156,25 @@ impl HnswIndex {
             && ep_id != id
             && let Some(ep_node) = self.nodes.get(&ep_id)
         {
-            // Search from top layer down to target layer
-            let vector_store = self.vector_store.read();
-            let ep_vector = vector_store
-                .get(ep_node.vector_index as usize)
-                .unwrap_or(&ep_node.vector);
+            // DEADLOCK FIX: hold the vector_store read ONLY to compute the
+            // entry-point distance, then drop it before the connect loops.
+            // Previously this read was held across the entire connect (which
+            // takes node-layer write locks and re-reads vector_store); under
+            // concurrent inserts that long-held read starved every other
+            // insert's phase-1 vector_store.write() — a writer-starvation
+            // deadlock (threads parked in lock_exclusive_slow). The connect
+            // below re-acquires vector_store via search_layer_concurrent /
+            // the add-connection helpers (all read_recursive), so the outer
+            // guard is not needed past this point.
+            let init_distance = {
+                let vector_store = self.vector_store.read_recursive();
+                let ep_vector = vector_store
+                    .get(ep_node.vector_index as usize)
+                    .unwrap_or(&ep_node.vector);
+                self.calculate_distance(&node.vector, ep_vector)
+            };
             let mut curr_nearest = vec![SearchCandidate {
-                distance: self.calculate_distance(&node.vector, ep_vector),
+                distance: init_distance,
                 id: ep_id,
             }];
 
@@ -3343,12 +3402,26 @@ impl HnswIndex {
         if batch.is_empty() {
             return Ok(0);
         }
+        // Single-writer discipline: serialize graph mutation (see insert_lock).
+        // Rayon parallelism WITHIN this batch is unaffected (the guard is held
+        // by this thread; rayon tasks never take insert_lock).
+        let _insert_guard = self.insert_lock.lock();
 
         // Phase 1: Create all nodes (parallel)
         let precision = self.config.quantization_precision.unwrap_or(Precision::F32);
         let normalize_cosine = matches!(self.config.metric, DistanceMetric::Cosine)
             && self.config.rng_optimization.normalize_at_ingest;
-        let node_ids: Result<Vec<_>, String> = batch
+        // DEADLOCK FIX: do NOT acquire vector_store.write() inside this
+        // par_iter. The map runs on the global rayon pool; grabbing the write
+        // lock per task means that when several insert_batch_bulk calls run
+        // concurrently, rayon workers park on the write lock (lock_exclusive)
+        // while other workers hold phase-3 connect reads — the shared pool is
+        // exhausted by lock-waiters and no task can progress (confirmed: 18
+        // threads parked in lock_exclusive_slow). Instead: quantize in parallel
+        // with NO lock, then push every vector under ONE brief write taken on
+        // the calling thread (outside rayon), mirroring
+        // insert_batch_contiguous_bulk. Workers never block on the global lock.
+        let quantized: Result<Vec<(u128, u32, usize, QuantizedVector)>, String> = batch
             .par_iter()
             .map(|(id, vector)| {
                 let quantized = if normalize_cosine {
@@ -3363,41 +3436,43 @@ impl HnswIndex {
                 let dense_index =
                     self.next_dense_index.fetch_add(1, AtomicOrdering::Relaxed) as u32;
                 self.record_dense_id(dense_index, *id);
-
-                let vector_index = {
-                    let mut store = self.vector_store.write();
-                    let idx = store.len() as u32;
-                    store.push(quantized); // move, not clone
-                    idx
-                };
-                let node = HnswNode {
-                    id: *id,
-                    dense_index,
-                    vector_index,
-                    vector: QuantizedVector::empty(),
-                    layer,
-                    layers: (0..=layer)
-                        .map(|_| {
-                            RwLock::new(VersionedNeighbors {
-                                neighbors: SmallVec::new(),
-                                version: 0,
-                            })
-                        })
-                        .collect(),
-                    storage_id: None,
-                };
-
-                // Insert node into storage
-                let node = Arc::new(node);
-                self.nodes.insert(*id, node.clone());
-                // O(1) hot path storage
-                self.store_internal_node(dense_index, node);
-
-                Ok(*id)
+                Ok((*id, dense_index, layer, quantized))
             })
             .collect();
+        let quantized = quantized?;
 
-        let node_ids = node_ids?;
+        // Single batched write: push all vectors and publish all nodes under
+        // one lock acquisition (no rayon task holds the write lock).
+        let node_ids: Vec<u128> = {
+            let mut store = self.vector_store.write();
+            store.reserve(quantized.len());
+            quantized
+                .into_iter()
+                .map(|(id, dense_index, layer, quantized)| {
+                    let vector_index = store.len() as u32;
+                    store.push(quantized); // move, not clone
+                    let node = Arc::new(HnswNode {
+                        id,
+                        dense_index,
+                        vector_index,
+                        vector: QuantizedVector::empty(),
+                        layer,
+                        layers: (0..=layer)
+                            .map(|_| {
+                                RwLock::new(VersionedNeighbors {
+                                    neighbors: SmallVec::new(),
+                                    version: 0,
+                                })
+                            })
+                            .collect(),
+                        storage_id: None,
+                    });
+                    self.nodes.insert(id, node.clone());
+                    self.store_internal_node(dense_index, node);
+                    id
+                })
+                .collect()
+        };
 
         // Phase 2: Compute independent waves for parallel connection
         let waves = compute_independent_waves(
@@ -3666,6 +3741,8 @@ impl HnswIndex {
         vectors: &[f32],
         dimension: usize,
     ) -> Result<usize, String> {
+        // Single-writer discipline: serialize graph mutation (see insert_lock).
+        let _insert_guard = self.insert_lock.lock();
         use crate::profiling::is_profiling_enabled;
         use rayon::prelude::*;
 
@@ -5203,8 +5280,15 @@ impl HnswIndex {
                 }
 
                 // Get neighbors from FLAT array - O(1), NO LOCKS!
+                // Bounds-checked: if the flat cache was built before this
+                // dense_index existed (cache predates a later insert), the
+                // computed range would be out of bounds and an unchecked slice
+                // would panic. Skip such a node instead of crashing the query.
                 let base = (curr.dense_index as usize) * slots_per_node;
-                let neighbor_slice = &flat_neighbors[base..base + slots_per_node];
+                let neighbor_slice = match flat_neighbors.get(base..base + slots_per_node) {
+                    Some(s) => s,
+                    None => continue,
+                };
 
                 // Prefetch next cache line
                 #[cfg(target_arch = "aarch64")]
@@ -6140,19 +6224,25 @@ impl HnswIndex {
             id: ep_id,
         }];
 
-        // Navigate upper layers with ef=1, layer 1 with wider beam
+        // Scale the upper-layer / layer-1 seed beam with ef. Previously the
+        // upper layers used ef=1 (pure greedy) and layer 1 was hard-capped at
+        // 5, so a large ef widened only the layer-0 beam CAPACITY but never the
+        // seed set feeding it — on hard/multi-cluster data this limited how
+        // much extra recall a big ef could buy. A wider, ef-proportional seed
+        // set lets layer 0 start from more diverse entry points.
+        let upper_ef = (ef / 64).clamp(1, 8);
         for lc in (2..=max_layer).rev() {
             curr_nearest = self.search_layer_ref(
                 &query_quantized,
                 &curr_nearest,
-                1,
+                upper_ef,
                 lc,
                 &vector_store,
                 &internal_nodes,
             );
         }
         if max_layer >= 1 {
-            let layer1_ef = 5usize.min(ef.max(k));
+            let layer1_ef = (ef / 4).clamp(8, 64).min(ef.max(k));
             curr_nearest = self.search_layer_ref(
                 &query_quantized,
                 &curr_nearest,
@@ -7220,8 +7310,17 @@ impl HnswIndex {
         num_to_return: usize,
         layer: usize,
     ) -> Vec<SearchCandidate> {
-        let vector_store = self.vector_store.read();
-        let internal_nodes = self.internal_nodes.read();
+        // read_recursive(): the insert/connect path (e.g. line ~3129) holds an
+        // outer vector_store.read() on this thread and then calls this fn for
+        // each layer. A plain read() here defers to a queued writer (another
+        // batch's phase-1 vector_store.write()), parking this reentrant read
+        // behind it forever — the confirmed concurrent-insert deadlock.
+        // read_recursive() acquires shared access without deferring to writers.
+        // Read-only path (writes go to node-layer locks), so it is sound; and
+        // it is harmless on the standalone search path where no outer read is
+        // held. internal_nodes is reentrant-read for the same reason.
+        let vector_store = self.vector_store.read_recursive();
+        let internal_nodes = self.internal_nodes.read_recursive();
         // Rec 9: local id→dense cache eliminates DashMap from hot loop
         let mut id_to_dense: std::collections::HashMap<u128, u32> =
             std::collections::HashMap::with_capacity(num_to_return * 2);
@@ -9902,6 +10001,30 @@ impl HnswIndex {
 
         let m0 = self.config.max_connections_layer0;
 
+        // SCALE GUARD: the exact path below is O(N^2) in time and materializes
+        // every vector as full f32 (`raw_vectors: Vec<Vec<f32>>`), so its cost
+        // explodes with N. Measured: a 1M build calling this OOM'd a 55 GB box
+        // and burned ~18h of CPU; the same build skipping it succeeded in 195s
+        // using a few GB at recall@10=0.968.
+        //
+        // Exact rebuild is a *small-index* recall booster. Above the cap it is
+        // intentionally a NO-OP: the as-built HNSW graph is already good, and
+        // an approximate large-N substitute (re-querying each node and
+        // overwriting its layer-0 edges) was measured to *degrade* recall to
+        // 0.935 — it discards the heuristic-selected, reverse-symmetric edges
+        // the build produced. So we never replace a good graph with a worse
+        // one; we simply skip, preserving the as-built recall.
+        const EXACT_MAX_N: usize = 50_000;
+        if n > EXACT_MAX_N {
+            tracing::info!(
+                n,
+                cap = EXACT_MAX_N,
+                "rebuild_layer0_exact skipped: index exceeds exact-rebuild cap; \
+                 preserving as-built graph (exact O(N^2) rebuild would OOM/stall)"
+            );
+            return 0;
+        }
+
         // Step 1: Snapshot all node data into contiguous arrays
         let node_ids: Vec<u128> = self.nodes.iter().map(|e| *e.key()).collect();
         let dense_indices: Vec<u32> = node_ids
@@ -9994,6 +10117,7 @@ impl HnswIndex {
         self.invalidate_flat_cache();
         updated
     }
+
 
     /// Prune connections — intentionally a no-op.
     ///
@@ -10243,6 +10367,66 @@ mod tests {
     }
 
     #[test]
+    fn test_rebuild_layer0_exact_preserves_recall_small_n() {
+        // Regression for the O(N^2)/OOM `optimize()` bug. Below EXACT_MAX_N the
+        // exact rebuild runs and must (a) repopulate every node's layer-0 edges
+        // and (b) never degrade self-query recall. (The large-N branch is a
+        // deliberate no-op — covered by the 1M integration run, since a 50k+
+        // unit test would be slow — so here we lock in the small-N contract.)
+        let config = HnswConfig {
+            metric: DistanceMetric::Euclidean,
+            ..HnswConfig::default()
+        };
+        let index = HnswIndex::new(16, config);
+
+        let n = 600usize;
+        assert!(n <= 50_000, "must stay under EXACT_MAX_N to hit the exact path");
+        for i in 0..n {
+            let mut v = vec![0.0f32; 16];
+            v[i % 16] = (i as f32) + 1.0;
+            v[(i * 7 + 3) % 16] += (i as f32) * 0.5;
+            index.insert(i as u128, v).unwrap();
+        }
+
+        let probe = |idx: &HnswIndex| {
+            let mut hits = 0;
+            for i in 0..n {
+                let mut q = vec![0.0f32; 16];
+                q[i % 16] = (i as f32) + 1.0;
+                q[(i * 7 + 3) % 16] += (i as f32) * 0.5;
+                if let Ok(r) = idx.search(&q, 1) {
+                    if r.first().map(|h| h.0) == Some(i as u128) {
+                        hits += 1;
+                    }
+                }
+            }
+            hits
+        };
+        let before = probe(&index);
+
+        let updated = index.rebuild_layer0_exact();
+        assert_eq!(updated, n, "exact rebuild should update every node at small N");
+
+        for i in 0..n {
+            let node = index.nodes.get(&(i as u128)).unwrap();
+            assert!(
+                !node.layers[0].read().neighbors.is_empty(),
+                "node {} lost all layer-0 edges after exact rebuild",
+                i
+            );
+        }
+
+        let after = probe(&index);
+        assert!(
+            after >= before,
+            "exact rebuild degraded recall: before={} after={}",
+            before,
+            after
+        );
+        assert!(after >= n * 9 / 10, "recall too low after rebuild: {}/{}", after, n);
+    }
+
+    #[test]
     fn test_hnsw_stats() {
         let config = HnswConfig::default();
         let index = HnswIndex::new(64, config);
@@ -10469,5 +10653,94 @@ mod tests {
         );
         // Sanity: some work was done
         assert!(total_checks > 10, "Too few checks: {}", total_checks);
+    }
+
+    /// Regression for bug #5: concurrent inserts from multiple threads into the
+    /// same index used to DEADLOCK. The connect phase holds vector_store.read()
+    /// while a helper (try_replace_worst_neighbor / ensure_minimum_degree_layer0
+    /// / force_add_reverse_edge) re-acquired vector_store.read(); when another
+    /// thread's phase-1 vector_store.write() queued between them, parking_lot's
+    /// writer-preference parked the reentrant read forever. The fix uses
+    /// read_recursive() for those inner reads. This test runs concurrent
+    /// insert_batch from several threads with a watchdog: before the fix it
+    /// hangs (watchdog fires); after, it completes.
+    #[test]
+    fn test_concurrent_inserts_do_not_deadlock() {
+        use std::sync::Arc;
+        use std::sync::mpsc;
+        use std::thread;
+        use std::time::Duration;
+
+        let config = HnswConfig {
+            metric: DistanceMetric::Euclidean,
+            ..HnswConfig::default()
+        };
+        let index = Arc::new(HnswIndex::new(16, config));
+
+        // Seed so the graph has a neighborhood and the worst-neighbor-replace
+        // path (the reentrant read) is exercised during the concurrent phase.
+        let mut seed = Vec::new();
+        for i in 0..200u128 {
+            let mut v = vec![0.0f32; 16];
+            v[(i as usize) % 16] = i as f32 + 1.0;
+            seed.push((i, v));
+        }
+        index.insert_batch(&seed).unwrap();
+
+        let n_threads = 6;
+        let per = 400usize;
+        let (tx, rx) = mpsc::channel();
+        let mut handles = Vec::new();
+        for t in 0..n_threads {
+            let idx = Arc::clone(&index);
+            let tx = tx.clone();
+            handles.push(thread::spawn(move || {
+                let base = 1000 + t * per;
+                let mut batch = Vec::with_capacity(per);
+                for j in 0..per {
+                    let id = (base + j) as u128;
+                    let mut v = vec![0.0f32; 16];
+                    v[(id as usize) % 16] = (id as f32) * 0.5 + 1.0;
+                    v[(id as usize * 3) % 16] += (id as f32) * 0.25;
+                    batch.push((id, v));
+                }
+                // Many small batches → maximal phase1-write / phase3-read overlap.
+                for c in batch.chunks(20) {
+                    idx.insert_batch(c).unwrap();
+                }
+                tx.send(t).unwrap();
+            }));
+        }
+        drop(tx);
+
+        // Watchdog: all threads must finish well within the timeout. A deadlock
+        // would leave fewer than n_threads completions.
+        let mut done = 0;
+        let deadline = Duration::from_secs(60);
+        loop {
+            match rx.recv_timeout(deadline) {
+                Ok(_) => {
+                    done += 1;
+                    if done == n_threads {
+                        break;
+                    }
+                }
+                Err(_) => panic!(
+                    "concurrent inserts DEADLOCKED: only {}/{} threads finished within {:?}",
+                    done, n_threads, deadline
+                ),
+            }
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // All vectors present and the index is still searchable.
+        assert!(index.len() >= 200 + n_threads * per, "missing inserts: {}", index.len());
+        let mut q = vec![0.0f32; 16];
+        q[1100 % 16] = 1100.0 * 0.5 + 1.0;
+        q[(1100 * 3) % 16] += 1100.0 * 0.25;
+        let res = index.search(&q, 5).unwrap();
+        assert!(!res.is_empty(), "search returned nothing after concurrent inserts");
     }
 }

--- a/sochdb-index/src/persistence.rs
+++ b/sochdb-index/src/persistence.rs
@@ -36,15 +36,13 @@
 //! └─────────────────────────────────────────────────────────────┘
 //! ```
 
-use crate::hnsw::{HnswConfig, HnswIndex};
+use crate::hnsw::{HnswConfig, HnswIndex, MAX_M};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Write};
 use std::path::Path;
 use std::time::SystemTime;
-
-const MAX_M: usize = 32;
 
 /// Serializable snapshot of HNSW index state
 #[derive(Serialize, Deserialize)]

--- a/sochdb-index/src/unified_quant.rs
+++ b/sochdb-index/src/unified_quant.rs
@@ -543,77 +543,35 @@ impl UnifiedScorer {
 // F16/BF16 conversion utilities
 // ============================================================================
 
+// f16/bf16 conversions delegate to the `half` crate (already a dependency,
+// also used by vector_quantized.rs/compression.rs). The previous hand-rolled
+// converters mangled NaN: `f32_to_f16` did `0x7C00 | (frac >> 13)`, turning
+// any NaN whose payload lived in the low 13 bits (e.g. 0x7F800001) into +Inf,
+// and `f32_to_bf16`'s plain `>> 16` truncation turned low-payload NaN into
+// +Inf likewise. half's conversions preserve NaN and round correctly.
+
 /// Convert f32 to f16 (IEEE 754 half-precision).
 #[inline]
 fn f32_to_f16(x: f32) -> u16 {
-    let bits = x.to_bits();
-    let sign = (bits >> 31) as u16;
-    let exp = ((bits >> 23) & 0xFF) as i32;
-    let frac = bits & 0x7FFFFF;
-
-    if exp == 0xFF {
-        // Inf or NaN
-        (sign << 15) | 0x7C00 | ((frac >> 13) as u16)
-    } else if exp > 142 {
-        // Overflow to infinity
-        (sign << 15) | 0x7C00
-    } else if exp < 113 {
-        // Underflow to zero or subnormal
-        if exp < 103 {
-            sign << 15
-        } else {
-            let frac = frac | 0x800000;
-            let shift = 126 - exp;
-            (sign << 15) | ((frac >> shift) as u16)
-        }
-    } else {
-        let new_exp = ((exp - 127 + 15) as u16) << 10;
-        let new_frac = (frac >> 13) as u16;
-        (sign << 15) | new_exp | new_frac
-    }
+    half::f16::from_f32(x).to_bits()
 }
 
 /// Convert f16 to f32.
 #[inline]
 fn f16_to_f32(x: u16) -> f32 {
-    let sign = ((x >> 15) as u32) << 31;
-    let exp = ((x >> 10) & 0x1F) as u32;
-    let frac = (x & 0x3FF) as u32;
-
-    let bits = if exp == 0 {
-        if frac == 0 {
-            sign
-        } else {
-            // Subnormal
-            let mut frac = frac;
-            let mut exp = 1u32;
-            while (frac & 0x400) == 0 {
-                frac <<= 1;
-                exp -= 1;
-            }
-            frac &= 0x3FF;
-            sign | ((exp + 127 - 15) << 23) | (frac << 13)
-        }
-    } else if exp == 31 {
-        // Inf or NaN
-        sign | 0x7F800000 | (frac << 13)
-    } else {
-        sign | ((exp + 127 - 15) << 23) | (frac << 13)
-    };
-
-    f32::from_bits(bits)
+    half::f16::from_bits(x).to_f32()
 }
 
 /// Convert f32 to bf16 (Brain float).
 #[inline]
 fn f32_to_bf16(x: f32) -> u16 {
-    (x.to_bits() >> 16) as u16
+    half::bf16::from_f32(x).to_bits()
 }
 
 /// Convert bf16 to f32.
 #[inline]
 fn bf16_to_f32(x: u16) -> f32 {
-    f32::from_bits((x as u32) << 16)
+    half::bf16::from_bits(x).to_f32()
 }
 
 #[cfg(test)]
@@ -625,6 +583,33 @@ mod tests {
         assert!(QuantLevel::F32 < QuantLevel::I8);
         assert!(QuantLevel::I8 < QuantLevel::PQ);
         assert!(QuantLevel::PQ < QuantLevel::BPS);
+    }
+
+    #[test]
+    fn test_f16_bf16_preserve_nan_not_infinity() {
+        // Regression: the old hand-rolled converters turned a NaN whose payload
+        // lived in the low bits (e.g. 0x7F800001) into +Infinity. half-crate
+        // delegation must keep NaN as NaN for both f16 and bf16.
+        for payload in [0x7F800001u32, 0x7F801000, 0x7FC00000, 0xFF800042] {
+            let x = f32::from_bits(payload);
+            assert!(x.is_nan(), "test input must be NaN");
+            assert!(
+                f16_to_f32(f32_to_f16(x)).is_nan(),
+                "f16 round-trip turned NaN 0x{:08X} into {:?}",
+                payload,
+                f16_to_f32(f32_to_f16(x))
+            );
+            assert!(
+                bf16_to_f32(f32_to_bf16(x)).is_nan(),
+                "bf16 round-trip turned NaN 0x{:08X} into {:?}",
+                payload,
+                bf16_to_f32(f32_to_bf16(x))
+            );
+        }
+        // Sanity: finite + inf still round-trip sensibly.
+        assert_eq!(f16_to_f32(f32_to_f16(1.5)), 1.5);
+        assert!(f16_to_f32(f32_to_f16(f32::INFINITY)).is_infinite());
+        assert!(bf16_to_f32(f32_to_bf16(f32::NEG_INFINITY)).is_infinite());
     }
 
     #[test]

--- a/sochdb-memory/src/store.rs
+++ b/sochdb-memory/src/store.rs
@@ -117,7 +117,16 @@ impl MemoryStore {
     pub fn write_episode(&self, write: EpisodeWrite) -> MemoryResult<WriteResult> {
         let start = Instant::now();
         let t_created = self.hlc.next();
-        let t_valid = write.t_valid_from.unwrap_or(t_created);
+        // Default validity-start to wall-clock unix milliseconds, matching the
+        // `as_of=<unix_ms>` query contract. `t_created` is a raw HLC tick
+        // (`physical_micros << 16 | logical`, ~1e21), so defaulting to it made
+        // the bi-temporal filter `t_valid_from <= as_of` always false for any
+        // realistic `as_of` — silently returning zero results for every
+        // episode written without an explicit validity time (the common case).
+        // Callers that pass `t_valid_from` keep their own time domain.
+        let t_valid = write
+            .t_valid_from
+            .unwrap_or_else(|| HybridLogicalClock::physical_time(t_created) / 1000);
 
         let mut namespaces = self.namespaces.write();
         let ns = namespaces

--- a/sochdb-python/src/lib.rs
+++ b/sochdb-python/src/lib.rs
@@ -518,7 +518,7 @@ impl PyHnswIndex {
         py: Python<'py>,
         queries: PyReadonlyArray2<'py, f32>,
         k: usize,
-        ef_search: Option<usize>, // TODO: Support runtime ef_search override
+        ef_search: Option<usize>,
     ) -> PyResult<(Py<PyArray2<u64>>, Py<PyArray2<f32>>)> {
         let shape = queries.shape();
         let num_queries = shape[0];
@@ -546,7 +546,15 @@ impl PyHnswIndex {
                     let start = i * d;
                     let end = start + d;
                     let query = &queries_vec[start..end];
-                    inner.search(query, k).unwrap_or_default()
+                    // Honor the runtime ef_search override when supplied: a
+                    // higher ef widens the beam → better recall at lower QPS,
+                    // which is exactly the recall/QPS tradeoff curve ANN
+                    // benchmarks sweep. Without an override, fall back to the
+                    // index's configured/adaptive ef via `search`.
+                    match ef_search {
+                        Some(ef) => inner.search_with_ef(query, k, ef).unwrap_or_default(),
+                        None => inner.search(query, k).unwrap_or_default(),
+                    }
                 })
                 .collect::<Vec<_>>()
         });

--- a/sochdb-query/Cargo.toml
+++ b/sochdb-query/Cargo.toml
@@ -26,6 +26,7 @@ sochdb-core = { version = "2.0.3", path = "../sochdb-core" }
 sochdb-storage = { version = "2.0.3", path = "../sochdb-storage" }
 sochdb-index = { version = "2.0.3", path = "../sochdb-index" }
 ndarray = "0.15"
+rayon = "1.10" # Parallel partitioned GROUP BY aggregation
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/sochdb-query/src/sql/aggregate.rs
+++ b/sochdb-query/src/sql/aggregate.rs
@@ -1,0 +1,1688 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SochDB - LLM-Optimized Embedded Database
+// Copyright (C) 2026 Sushanth Reddy Vanagala (https://github.com/sushanthpy)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! # SQL Aggregation Executor
+//!
+//! Hash-aggregation operator for `GROUP BY` and aggregate functions.
+//!
+//! Supported aggregates: `COUNT(*)`, `COUNT(col)`, `COUNT(DISTINCT col)`,
+//! `SUM`, `AVG`, `MIN`, `MAX`, `MEDIAN`, `STDDEV` (sample, n-1, matching
+//! R's `sd()` and DuckDB's `stddev`).
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! input rows (post-WHERE)
+//!   └─> group keys evaluated per row ──> hash table of group states
+//!         └─> accumulators updated per row
+//!               └─> finalize: one synthesized row per group
+//!                     └─> HAVING filter ─> ORDER BY ─> OFFSET/LIMIT ─> projection
+//! ```
+//!
+//! Semantics notes:
+//! - NULL inputs are skipped by all aggregates except `COUNT(*)` (SQL standard).
+//! - An ungrouped aggregate over zero rows yields exactly one row
+//!   (`COUNT` = 0, other aggregates NULL); a grouped aggregate over zero
+//!   rows yields zero rows.
+//! - Non-aggregate SELECT columns that are not in `GROUP BY` resolve to the
+//!   first value seen in the group (lenient mode, like SQLite / MySQL with
+//!   `ONLY_FULL_GROUP_BY` disabled).
+
+use super::ast::*;
+use super::bridge::ExecutionResult;
+use super::error::SqlResult;
+use rayon::prelude::*;
+use sochdb_core::SochValue;
+use std::collections::{HashMap, HashSet};
+
+/// Row count above which grouped accumulation runs on the rayon pool.
+const PARALLEL_THRESHOLD: usize = 100_000;
+
+// ============================================================================
+// Aggregate function identification
+// ============================================================================
+
+/// Recognized aggregate functions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AggFn {
+    Count,
+    Sum,
+    Avg,
+    Min,
+    Max,
+    Median,
+    Stddev,
+}
+
+impl AggFn {
+    /// Recognize an aggregate function by name (case-insensitive).
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name.to_ascii_uppercase().as_str() {
+            "COUNT" => Some(Self::Count),
+            "SUM" => Some(Self::Sum),
+            "AVG" | "MEAN" => Some(Self::Avg),
+            "MIN" => Some(Self::Min),
+            "MAX" => Some(Self::Max),
+            "MEDIAN" => Some(Self::Median),
+            "STDDEV" | "STDDEV_SAMP" | "STDEV" | "SD" => Some(Self::Stddev),
+            _ => None,
+        }
+    }
+}
+
+/// One aggregate call discovered in the query, e.g. `sum(v1)`.
+#[derive(Debug, Clone)]
+struct AggSpec {
+    /// Canonical key, e.g. `"sum(v1)"` — used to bind HAVING / ORDER BY
+    /// references back to the computed value.
+    key: String,
+    func: AggFn,
+    /// Argument expression (`None` for `COUNT(*)`).
+    arg: Option<Expr>,
+    distinct: bool,
+}
+
+/// Returns true if the SELECT needs the aggregation operator.
+pub fn is_aggregate_query(select: &SelectStmt) -> bool {
+    if !select.group_by.is_empty() {
+        return true;
+    }
+    select
+        .columns
+        .iter()
+        .any(|item| matches!(item, SelectItem::Expr { expr, .. } if contains_aggregate(expr)))
+}
+
+/// Recursively check whether an expression contains an aggregate call.
+fn contains_aggregate(expr: &Expr) -> bool {
+    match expr {
+        Expr::Function(f) => {
+            AggFn::from_name(f.name.name()).is_some()
+                || f.args.iter().any(contains_aggregate)
+        }
+        Expr::BinaryOp { left, right, .. } => {
+            contains_aggregate(left) || contains_aggregate(right)
+        }
+        Expr::UnaryOp { expr, .. } => contains_aggregate(expr),
+        Expr::IsNull { expr, .. } => contains_aggregate(expr),
+        Expr::Case {
+            operand,
+            conditions,
+            else_result,
+        } => {
+            operand.as_deref().map(contains_aggregate).unwrap_or(false)
+                || conditions
+                    .iter()
+                    .any(|(w, t)| contains_aggregate(w) || contains_aggregate(t))
+                || else_result
+                    .as_deref()
+                    .map(contains_aggregate)
+                    .unwrap_or(false)
+        }
+        _ => false,
+    }
+}
+
+/// Collect all distinct aggregate calls from SELECT, HAVING and ORDER BY.
+fn collect_agg_specs(select: &SelectStmt) -> Vec<AggSpec> {
+    let mut specs: Vec<AggSpec> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+
+    let walk = |expr: &Expr, specs: &mut Vec<AggSpec>, seen: &mut HashSet<String>| {
+        collect_from_expr(expr, specs, seen);
+    };
+
+    for item in &select.columns {
+        if let SelectItem::Expr { expr, .. } = item {
+            walk(expr, &mut specs, &mut seen);
+        }
+    }
+    if let Some(h) = &select.having {
+        walk(h, &mut specs, &mut seen);
+    }
+    for ob in &select.order_by {
+        walk(&ob.expr, &mut specs, &mut seen);
+    }
+    specs
+}
+
+fn collect_from_expr(expr: &Expr, specs: &mut Vec<AggSpec>, seen: &mut HashSet<String>) {
+    match expr {
+        Expr::Function(f) => {
+            if let Some(func) = AggFn::from_name(f.name.name()) {
+                let arg = f.args.first().cloned();
+                let is_star =
+                    matches!(arg.as_ref(), Some(Expr::Column(c)) if c.column == "*");
+                let arg = if is_star { None } else { arg };
+                let key = render_agg_key(func, arg.as_ref(), f.distinct);
+                if seen.insert(key.clone()) {
+                    specs.push(AggSpec {
+                        key,
+                        func,
+                        arg,
+                        distinct: f.distinct,
+                    });
+                }
+            } else {
+                for a in &f.args {
+                    collect_from_expr(a, specs, seen);
+                }
+            }
+        }
+        Expr::BinaryOp { left, right, .. } => {
+            collect_from_expr(left, specs, seen);
+            collect_from_expr(right, specs, seen);
+        }
+        Expr::UnaryOp { expr, .. } => collect_from_expr(expr, specs, seen),
+        Expr::IsNull { expr, .. } => collect_from_expr(expr, specs, seen),
+        Expr::Case {
+            operand,
+            conditions,
+            else_result,
+        } => {
+            if let Some(op) = operand {
+                collect_from_expr(op, specs, seen);
+            }
+            for (w, t) in conditions {
+                collect_from_expr(w, specs, seen);
+                collect_from_expr(t, specs, seen);
+            }
+            if let Some(e) = else_result {
+                collect_from_expr(e, specs, seen);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Canonical name for an aggregate call: `sum(v1)`, `count(*)`,
+/// `count(distinct id)`. Lowercased so lookups are case-insensitive.
+fn render_agg_key(func: AggFn, arg: Option<&Expr>, distinct: bool) -> String {
+    let fname = match func {
+        AggFn::Count => "count",
+        AggFn::Sum => "sum",
+        AggFn::Avg => "avg",
+        AggFn::Min => "min",
+        AggFn::Max => "max",
+        AggFn::Median => "median",
+        AggFn::Stddev => "stddev",
+    };
+    let arg_s = match arg {
+        None => "*".to_string(),
+        Some(e) => render_expr_name(e),
+    };
+    if distinct {
+        format!("{}(distinct {})", fname, arg_s)
+    } else {
+        format!("{}({})", fname, arg_s)
+    }
+}
+
+/// Human-readable name for an expression, used for output column naming
+/// and canonical aggregate keys.
+pub fn render_expr_name(expr: &Expr) -> String {
+    match expr {
+        Expr::Column(c) => {
+            if let Some(t) = &c.table {
+                format!("{}.{}", t, c.column)
+            } else {
+                c.column.clone()
+            }
+        }
+        Expr::Literal(Literal::Integer(n)) => n.to_string(),
+        Expr::Literal(Literal::Float(f)) => f.to_string(),
+        Expr::Literal(Literal::String(s)) => format!("'{}'", s),
+        Expr::Literal(Literal::Boolean(b)) => b.to_string(),
+        Expr::Literal(Literal::Null) => "null".to_string(),
+        Expr::Function(f) => {
+            if let Some(func) = AggFn::from_name(f.name.name()) {
+                let arg = f.args.first();
+                let is_star =
+                    matches!(arg, Some(Expr::Column(c)) if c.column == "*");
+                render_agg_key(func, if is_star { None } else { arg }, f.distinct)
+            } else {
+                let args: Vec<String> = f.args.iter().map(render_expr_name).collect();
+                format!("{}({})", f.name.name().to_lowercase(), args.join(", "))
+            }
+        }
+        Expr::BinaryOp { left, op, right } => format!(
+            "{} {} {}",
+            render_expr_name(left),
+            binary_op_symbol(op),
+            render_expr_name(right)
+        ),
+        Expr::UnaryOp { op, expr } => match op {
+            UnaryOperator::Minus => format!("-{}", render_expr_name(expr)),
+            UnaryOperator::Plus => render_expr_name(expr),
+            UnaryOperator::Not => format!("not {}", render_expr_name(expr)),
+            UnaryOperator::BitNot => format!("~{}", render_expr_name(expr)),
+        },
+        _ => "expr".to_string(),
+    }
+}
+
+fn binary_op_symbol(op: &BinaryOperator) -> &'static str {
+    match op {
+        BinaryOperator::Plus => "+",
+        BinaryOperator::Minus => "-",
+        BinaryOperator::Multiply => "*",
+        BinaryOperator::Divide => "/",
+        BinaryOperator::Modulo => "%",
+        BinaryOperator::Eq => "=",
+        BinaryOperator::Ne => "<>",
+        BinaryOperator::Lt => "<",
+        BinaryOperator::Le => "<=",
+        BinaryOperator::Gt => ">",
+        BinaryOperator::Ge => ">=",
+        BinaryOperator::And => "and",
+        BinaryOperator::Or => "or",
+        _ => "?",
+    }
+}
+
+// ============================================================================
+// Scalar expression evaluation (over a materialized row)
+// ============================================================================
+
+/// Evaluate a scalar expression against a row map.
+///
+/// `agg_values`, when provided, resolves aggregate function calls by their
+/// canonical key — used for HAVING / ORDER BY / projection over finalized
+/// group rows.
+fn eval_scalar(
+    expr: &Expr,
+    row: &HashMap<String, SochValue>,
+    params: &[SochValue],
+) -> SochValue {
+    match expr {
+        Expr::Column(c) => {
+            if let Some(t) = &c.table {
+                let qualified = format!("{}.{}", t, c.column);
+                if let Some(v) = row.get(&qualified) {
+                    return v.clone();
+                }
+            }
+            row.get(&c.column).cloned().unwrap_or(SochValue::Null)
+        }
+        Expr::Literal(lit) => literal_to_value(lit),
+        Expr::Placeholder(idx) => params
+            .get((*idx as usize).saturating_sub(1))
+            .cloned()
+            .unwrap_or(SochValue::Null),
+        Expr::Function(f) => {
+            // Aggregate results are pre-bound into the row map under their
+            // canonical key by `finalize_groups`.
+            let key = render_expr_name(&Expr::Function(f.clone()));
+            row.get(&key).cloned().unwrap_or(SochValue::Null)
+        }
+        Expr::BinaryOp { left, op, right } => {
+            let l = eval_scalar(left, row, params);
+            let r = eval_scalar(right, row, params);
+            eval_binary(&l, op, &r)
+        }
+        Expr::UnaryOp { op, expr } => {
+            let v = eval_scalar(expr, row, params);
+            match op {
+                UnaryOperator::Minus => match v {
+                    SochValue::Int(i) => SochValue::Int(-i),
+                    SochValue::Float(f) => SochValue::Float(-f),
+                    _ => SochValue::Null,
+                },
+                UnaryOperator::Plus => v,
+                UnaryOperator::Not => match v {
+                    SochValue::Bool(b) => SochValue::Bool(!b),
+                    _ => SochValue::Null,
+                },
+                UnaryOperator::BitNot => match v {
+                    SochValue::Int(i) => SochValue::Int(!i),
+                    _ => SochValue::Null,
+                },
+            }
+        }
+        Expr::IsNull { expr, negated } => {
+            let v = eval_scalar(expr, row, params);
+            let is_null = v.is_null();
+            SochValue::Bool(if *negated { !is_null } else { is_null })
+        }
+        _ => SochValue::Null,
+    }
+}
+
+fn literal_to_value(lit: &Literal) -> SochValue {
+    match lit {
+        Literal::Integer(i) => SochValue::Int(*i),
+        Literal::Float(f) => SochValue::Float(*f),
+        Literal::String(s) => SochValue::Text(s.clone()),
+        Literal::Boolean(b) => SochValue::Bool(*b),
+        Literal::Null => SochValue::Null,
+        _ => SochValue::Null,
+    }
+}
+
+fn numeric(v: &SochValue) -> Option<f64> {
+    match v {
+        SochValue::Int(i) => Some(*i as f64),
+        SochValue::UInt(u) => Some(*u as f64),
+        SochValue::Float(f) => Some(*f),
+        SochValue::Bool(b) => Some(if *b { 1.0 } else { 0.0 }),
+        _ => None,
+    }
+}
+
+fn eval_binary(l: &SochValue, op: &BinaryOperator, r: &SochValue) -> SochValue {
+    use BinaryOperator::*;
+    match op {
+        Plus | Minus | Multiply | Divide | Modulo => {
+            // Integer arithmetic when both sides are ints (except division).
+            if let (SochValue::Int(a), SochValue::Int(b)) = (l, r) {
+                return match op {
+                    Plus => SochValue::Int(a.wrapping_add(*b)),
+                    Minus => SochValue::Int(a.wrapping_sub(*b)),
+                    Multiply => SochValue::Int(a.wrapping_mul(*b)),
+                    Divide => {
+                        if *b == 0 {
+                            SochValue::Null
+                        } else {
+                            SochValue::Float(*a as f64 / *b as f64)
+                        }
+                    }
+                    Modulo => {
+                        if *b == 0 {
+                            SochValue::Null
+                        } else {
+                            SochValue::Int(a % b)
+                        }
+                    }
+                    _ => unreachable!(),
+                };
+            }
+            let (a, b) = match (numeric(l), numeric(r)) {
+                (Some(a), Some(b)) => (a, b),
+                _ => return SochValue::Null,
+            };
+            match op {
+                Plus => SochValue::Float(a + b),
+                Minus => SochValue::Float(a - b),
+                Multiply => SochValue::Float(a * b),
+                Divide => {
+                    if b == 0.0 {
+                        SochValue::Null
+                    } else {
+                        SochValue::Float(a / b)
+                    }
+                }
+                Modulo => {
+                    if b == 0.0 {
+                        SochValue::Null
+                    } else {
+                        SochValue::Float(a % b)
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+        Eq | Ne | Lt | Le | Gt | Ge => {
+            if l.is_null() || r.is_null() {
+                return SochValue::Null;
+            }
+            let ord = compare_values(l, r);
+            let b = match op {
+                Eq => ord == std::cmp::Ordering::Equal,
+                Ne => ord != std::cmp::Ordering::Equal,
+                Lt => ord == std::cmp::Ordering::Less,
+                Le => ord != std::cmp::Ordering::Greater,
+                Gt => ord == std::cmp::Ordering::Greater,
+                Ge => ord != std::cmp::Ordering::Less,
+                _ => unreachable!(),
+            };
+            SochValue::Bool(b)
+        }
+        And => match (as_bool(l), as_bool(r)) {
+            (Some(a), Some(b)) => SochValue::Bool(a && b),
+            _ => SochValue::Null,
+        },
+        Or => match (as_bool(l), as_bool(r)) {
+            (Some(a), Some(b)) => SochValue::Bool(a || b),
+            _ => SochValue::Null,
+        },
+        _ => SochValue::Null,
+    }
+}
+
+fn as_bool(v: &SochValue) -> Option<bool> {
+    match v {
+        SochValue::Bool(b) => Some(*b),
+        SochValue::Int(i) => Some(*i != 0),
+        SochValue::Null => None,
+        _ => None,
+    }
+}
+
+/// Total ordering across SochValue for grouping/sorting.
+pub fn compare_values(a: &SochValue, b: &SochValue) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match (numeric(a), numeric(b)) {
+        (Some(x), Some(y)) => return x.partial_cmp(&y).unwrap_or(Ordering::Equal),
+        _ => {}
+    }
+    match (a, b) {
+        (SochValue::Text(x), SochValue::Text(y)) => x.cmp(y),
+        (SochValue::Null, SochValue::Null) => Ordering::Equal,
+        (SochValue::Null, _) => Ordering::Less,
+        (_, SochValue::Null) => Ordering::Greater,
+        _ => Ordering::Equal,
+    }
+}
+
+/// Canonical hash representation of a group-key value.
+/// Normalizes Int/UInt/Float-of-integral so `1`, `1u`, `1.0` group together.
+fn key_repr(v: &SochValue) -> String {
+    match v {
+        SochValue::Null => "\u{0}N".to_string(),
+        SochValue::Int(i) => format!("i{}", i),
+        SochValue::UInt(u) => format!("i{}", u),
+        SochValue::Float(f) => {
+            if f.fract() == 0.0 && f.abs() < 9.0e15 {
+                format!("i{}", *f as i64)
+            } else {
+                format!("f{}", f)
+            }
+        }
+        SochValue::Text(s) => format!("s{}", s),
+        SochValue::Bool(b) => format!("b{}", b),
+        other => format!("{:?}", other),
+    }
+}
+
+// ============================================================================
+// Accumulators
+// ============================================================================
+
+#[derive(Debug)]
+enum Acc {
+    CountStar(u64),
+    Count(u64),
+    CountDistinct(HashSet<String>),
+    /// Sum preserving integer-ness: (int_sum, float_sum, saw_float, saw_any)
+    Sum {
+        int: i64,
+        float: f64,
+        saw_float: bool,
+        saw_any: bool,
+        overflowed: bool,
+    },
+    Avg {
+        sum: f64,
+        n: u64,
+    },
+    Min(Option<SochValue>),
+    Max(Option<SochValue>),
+    Median(Vec<f64>),
+    /// Welford online variance: (n, mean, m2)
+    Stddev {
+        n: u64,
+        mean: f64,
+        m2: f64,
+    },
+}
+
+impl Acc {
+    fn new(spec: &AggSpec) -> Self {
+        match (spec.func, spec.arg.is_some(), spec.distinct) {
+            (AggFn::Count, false, _) => Acc::CountStar(0),
+            (AggFn::Count, true, true) => Acc::CountDistinct(HashSet::new()),
+            (AggFn::Count, true, false) => Acc::Count(0),
+            (AggFn::Sum, _, _) => Acc::Sum {
+                int: 0,
+                float: 0.0,
+                saw_float: false,
+                saw_any: false,
+                overflowed: false,
+            },
+            (AggFn::Avg, _, _) => Acc::Avg { sum: 0.0, n: 0 },
+            (AggFn::Min, _, _) => Acc::Min(None),
+            (AggFn::Max, _, _) => Acc::Max(None),
+            (AggFn::Median, _, _) => Acc::Median(Vec::new()),
+            (AggFn::Stddev, _, _) => Acc::Stddev {
+                n: 0,
+                mean: 0.0,
+                m2: 0.0,
+            },
+        }
+    }
+
+    /// Update with the evaluated argument value (`None` only for COUNT(*)).
+    fn update(&mut self, val: Option<&SochValue>) {
+        match self {
+            Acc::CountStar(n) => *n += 1,
+            Acc::Count(n) => {
+                if let Some(v) = val {
+                    if !v.is_null() {
+                        *n += 1;
+                    }
+                }
+            }
+            Acc::CountDistinct(set) => {
+                if let Some(v) = val {
+                    if !v.is_null() {
+                        set.insert(key_repr(v));
+                    }
+                }
+            }
+            Acc::Sum {
+                int,
+                float,
+                saw_float,
+                saw_any,
+                overflowed,
+            } => {
+                let Some(v) = val else { return };
+                match v {
+                    SochValue::Int(i) => {
+                        *saw_any = true;
+                        match int.checked_add(*i) {
+                            Some(s) => *int = s,
+                            None => *overflowed = true,
+                        }
+                        *float += *i as f64;
+                    }
+                    SochValue::UInt(u) => {
+                        *saw_any = true;
+                        match int.checked_add(*u as i64) {
+                            Some(s) => *int = s,
+                            None => *overflowed = true,
+                        }
+                        *float += *u as f64;
+                    }
+                    SochValue::Float(f) => {
+                        *saw_any = true;
+                        *saw_float = true;
+                        *float += *f;
+                    }
+                    _ => {}
+                }
+            }
+            Acc::Avg { sum, n } => {
+                if let Some(x) = val.and_then(numeric) {
+                    *sum += x;
+                    *n += 1;
+                }
+            }
+            Acc::Min(cur) => {
+                let Some(v) = val else { return };
+                if v.is_null() {
+                    return;
+                }
+                match cur {
+                    None => *cur = Some(v.clone()),
+                    Some(c) => {
+                        if compare_values(v, c) == std::cmp::Ordering::Less {
+                            *cur = Some(v.clone());
+                        }
+                    }
+                }
+            }
+            Acc::Max(cur) => {
+                let Some(v) = val else { return };
+                if v.is_null() {
+                    return;
+                }
+                match cur {
+                    None => *cur = Some(v.clone()),
+                    Some(c) => {
+                        if compare_values(v, c) == std::cmp::Ordering::Greater {
+                            *cur = Some(v.clone());
+                        }
+                    }
+                }
+            }
+            Acc::Median(vals) => {
+                if let Some(x) = val.and_then(numeric) {
+                    vals.push(x);
+                }
+            }
+            Acc::Stddev { n, mean, m2 } => {
+                if let Some(x) = val.and_then(numeric) {
+                    *n += 1;
+                    let delta = x - *mean;
+                    *mean += delta / *n as f64;
+                    let delta2 = x - *mean;
+                    *m2 += delta * delta2;
+                }
+            }
+        }
+    }
+
+    /// Merge a partial accumulator (from a parallel chunk) into self.
+    /// Both must originate from the same `AggSpec`.
+    fn merge(&mut self, other: Acc) {
+        match (self, other) {
+            (Acc::CountStar(a), Acc::CountStar(b)) => *a += b,
+            (Acc::Count(a), Acc::Count(b)) => *a += b,
+            (Acc::CountDistinct(a), Acc::CountDistinct(b)) => a.extend(b),
+            (
+                Acc::Sum {
+                    int,
+                    float,
+                    saw_float,
+                    saw_any,
+                    overflowed,
+                },
+                Acc::Sum {
+                    int: i2,
+                    float: f2,
+                    saw_float: sf2,
+                    saw_any: sa2,
+                    overflowed: of2,
+                },
+            ) => {
+                match int.checked_add(i2) {
+                    Some(s) => *int = s,
+                    None => *overflowed = true,
+                }
+                *float += f2;
+                *saw_float |= sf2;
+                *saw_any |= sa2;
+                *overflowed |= of2;
+            }
+            (Acc::Avg { sum, n }, Acc::Avg { sum: s2, n: n2 }) => {
+                *sum += s2;
+                *n += n2;
+            }
+            (Acc::Min(a), Acc::Min(Some(b))) => match a {
+                None => *a = Some(b),
+                Some(cur) => {
+                    if compare_values(&b, cur) == std::cmp::Ordering::Less {
+                        *a = Some(b);
+                    }
+                }
+            },
+            (Acc::Max(a), Acc::Max(Some(b))) => match a {
+                None => *a = Some(b),
+                Some(cur) => {
+                    if compare_values(&b, cur) == std::cmp::Ordering::Greater {
+                        *a = Some(b);
+                    }
+                }
+            },
+            (Acc::Min(_), Acc::Min(None)) | (Acc::Max(_), Acc::Max(None)) => {}
+            (Acc::Median(a), Acc::Median(b)) => a.extend(b),
+            (
+                Acc::Stddev { n, mean, m2 },
+                Acc::Stddev {
+                    n: nb,
+                    mean: mb,
+                    m2: m2b,
+                },
+            ) => {
+                // Chan et al. parallel variance merge.
+                if nb > 0 {
+                    if *n == 0 {
+                        *n = nb;
+                        *mean = mb;
+                        *m2 = m2b;
+                    } else {
+                        let na = *n as f64;
+                        let nbf = nb as f64;
+                        let delta = mb - *mean;
+                        let total = na + nbf;
+                        *mean += delta * nbf / total;
+                        *m2 += m2b + delta * delta * na * nbf / total;
+                        *n += nb;
+                    }
+                }
+            }
+            _ => unreachable!("mismatched accumulator merge"),
+        }
+    }
+
+    fn finalize(self) -> SochValue {
+        match self {
+            Acc::CountStar(n) | Acc::Count(n) => SochValue::Int(n as i64),
+            Acc::CountDistinct(set) => SochValue::Int(set.len() as i64),
+            Acc::Sum {
+                int,
+                float,
+                saw_float,
+                saw_any,
+                overflowed,
+            } => {
+                if !saw_any {
+                    SochValue::Null
+                } else if saw_float || overflowed {
+                    SochValue::Float(float)
+                } else {
+                    SochValue::Int(int)
+                }
+            }
+            Acc::Avg { sum, n } => {
+                if n == 0 {
+                    SochValue::Null
+                } else {
+                    SochValue::Float(sum / n as f64)
+                }
+            }
+            Acc::Min(v) | Acc::Max(v) => v.unwrap_or(SochValue::Null),
+            Acc::Median(mut vals) => {
+                if vals.is_empty() {
+                    return SochValue::Null;
+                }
+                let mid = vals.len() / 2;
+                if vals.len() % 2 == 1 {
+                    let (_, m, _) =
+                        vals.select_nth_unstable_by(mid, |a, b| {
+                            a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
+                        });
+                    SochValue::Float(*m)
+                } else {
+                    // Even count: average the two middle values.
+                    let (lo, hi_first, _) =
+                        vals.select_nth_unstable_by(mid, |a, b| {
+                            a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
+                        });
+                    let lo_max = lo
+                        .iter()
+                        .copied()
+                        .fold(f64::NEG_INFINITY, f64::max);
+                    SochValue::Float((lo_max + *hi_first) / 2.0)
+                }
+            }
+            Acc::Stddev { n, m2, .. } => {
+                if n < 2 {
+                    SochValue::Null
+                } else {
+                    SochValue::Float((m2 / (n - 1) as f64).sqrt())
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// The aggregation operator
+// ============================================================================
+
+struct GroupState {
+    key_values: Vec<SochValue>,
+    first_row: HashMap<String, SochValue>,
+    accs: Vec<Acc>,
+}
+
+// ----------------------------------------------------------------------------
+// Fast path: plain-column group keys and aggregate args
+// ----------------------------------------------------------------------------
+
+/// A group-key atom that borrows string data from the input rows —
+/// zero allocations during accumulation lookups.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum KeyAtom<'a> {
+    Null,
+    Int(i64),
+    /// Normalized f64 bits (integral floats normalize to `Int`).
+    FBits(u64),
+    Str(&'a str),
+    Bool(bool),
+}
+
+impl<'a> KeyAtom<'a> {
+    fn from_value(v: &'a SochValue) -> Self {
+        match v {
+            SochValue::Null => KeyAtom::Null,
+            SochValue::Int(i) => KeyAtom::Int(*i),
+            SochValue::UInt(u) => KeyAtom::Int(*u as i64),
+            SochValue::Float(f) => {
+                if f.fract() == 0.0 && f.abs() < 9.0e15 {
+                    KeyAtom::Int(*f as i64)
+                } else if f.is_nan() {
+                    KeyAtom::FBits(f64::NAN.to_bits())
+                } else {
+                    KeyAtom::FBits(f.to_bits())
+                }
+            }
+            SochValue::Text(s) => KeyAtom::Str(s.as_str()),
+            SochValue::Bool(b) => KeyAtom::Bool(*b),
+            _ => KeyAtom::Null,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum GroupKey<'a> {
+    Empty,
+    One(KeyAtom<'a>),
+    Many(Vec<KeyAtom<'a>>),
+}
+
+static NULL_VALUE: SochValue = SochValue::Null;
+
+/// Resolve a column reference against a row, trying qualified name first.
+#[inline]
+fn col_get<'r>(row: &'r HashMap<String, SochValue>, col: &PlainCol) -> &'r SochValue {
+    if let Some(q) = &col.qualified {
+        if let Some(v) = row.get(q) {
+            return v;
+        }
+    }
+    row.get(&col.name).unwrap_or(&NULL_VALUE)
+}
+
+/// Pre-resolved plain column: unqualified name + optional "table.col" form.
+struct PlainCol {
+    name: String,
+    qualified: Option<String>,
+}
+
+fn as_plain_col(expr: &Expr) -> Option<PlainCol> {
+    match expr {
+        Expr::Column(c) => Some(PlainCol {
+            name: c.column.clone(),
+            qualified: c.table.as_ref().map(|t| format!("{}.{}", t, c.column)),
+        }),
+        _ => None,
+    }
+}
+
+/// Build the borrowed group key for one row.
+fn make_group_key<'r>(
+    row: &'r HashMap<String, SochValue>,
+    group_cols: &[PlainCol],
+) -> GroupKey<'r> {
+    match group_cols.len() {
+        0 => GroupKey::Empty,
+        1 => GroupKey::One(KeyAtom::from_value(col_get(row, &group_cols[0]))),
+        _ => GroupKey::Many(
+            group_cols
+                .iter()
+                .map(|c| KeyAtom::from_value(col_get(row, c)))
+                .collect(),
+        ),
+    }
+}
+
+/// Try the optimized accumulation path. Applicable when every GROUP BY
+/// expression and every aggregate argument is a plain column reference
+/// (which covers typical analytics queries). Returns group states in
+/// first-seen order (per-chunk order under parallel execution).
+fn accumulate_fast<'a>(
+    select: &SelectStmt,
+    specs: &[AggSpec],
+    rows: &'a [HashMap<String, SochValue>],
+) -> Option<Vec<GroupState>> {
+    // Pre-resolve group-key columns.
+    let group_cols: Vec<PlainCol> = select
+        .group_by
+        .iter()
+        .map(as_plain_col)
+        .collect::<Option<Vec<_>>>()?;
+    // Pre-resolve aggregate argument columns (None = COUNT(*)).
+    let arg_cols: Vec<Option<PlainCol>> = specs
+        .iter()
+        .map(|s| match &s.arg {
+            None => Some(None),
+            Some(e) => as_plain_col(e).map(Some),
+        })
+        .collect::<Option<Vec<_>>>()?;
+
+    let accumulate_chunk = |chunk: &'a [HashMap<String, SochValue>]| -> Vec<(GroupKey<'a>, GroupState)> {
+        let mut order: Vec<(GroupKey<'a>, GroupState)> = Vec::new();
+        let mut index: HashMap<GroupKey<'a>, usize> = HashMap::new();
+        for row in chunk {
+            let key = make_group_key(row, &group_cols);
+            let idx = match index.get(&key) {
+                Some(&i) => i,
+                None => {
+                    let state = GroupState {
+                        key_values: group_cols
+                            .iter()
+                            .map(|c| col_get(row, c).clone())
+                            .collect(),
+                        first_row: row.clone(),
+                        accs: specs.iter().map(Acc::new).collect(),
+                    };
+                    order.push((key.clone(), state));
+                    index.insert(key, order.len() - 1);
+                    order.len() - 1
+                }
+            };
+            let accs = &mut order[idx].1.accs;
+            for (acc, arg) in accs.iter_mut().zip(arg_cols.iter()) {
+                match arg {
+                    None => acc.update(None),
+                    Some(col) => acc.update(Some(col_get(row, col))),
+                }
+            }
+        }
+        order
+    };
+
+    let merged: Vec<(GroupKey<'a>, GroupState)> = if rows.len() >= PARALLEL_THRESHOLD {
+        let n_threads = rayon::current_num_threads().max(1);
+        let chunk_size = (rows.len() / (n_threads * 4)).max(16_384);
+        let partials: Vec<Vec<(GroupKey<'a>, GroupState)>> = rows
+            .par_chunks(chunk_size)
+            .map(accumulate_chunk)
+            .collect();
+        // Merge chunk partials in chunk order.
+        let mut order: Vec<(GroupKey<'a>, GroupState)> = Vec::new();
+        let mut index: HashMap<GroupKey<'a>, usize> = HashMap::new();
+        for partial in partials {
+            for (key, state) in partial {
+                match index.get(&key) {
+                    Some(&i) => {
+                        let dst = &mut order[i].1;
+                        for (a, b) in dst.accs.iter_mut().zip(state.accs.into_iter()) {
+                            a.merge(b);
+                        }
+                    }
+                    None => {
+                        order.push((key.clone(), state));
+                        index.insert(key, order.len() - 1);
+                    }
+                }
+            }
+        }
+        order
+    } else {
+        accumulate_chunk(rows)
+    };
+
+    Some(merged.into_iter().map(|(_, s)| s).collect())
+}
+
+/// Execute aggregation over materialized input rows (already WHERE-filtered).
+///
+/// Handles GROUP BY, all aggregate accumulation, HAVING, ORDER BY,
+/// OFFSET/LIMIT, and final projection. Returns `ExecutionResult::Rows`.
+pub fn execute_aggregate(
+    select: &SelectStmt,
+    rows: &[HashMap<String, SochValue>],
+    params: &[SochValue],
+    limit: Option<usize>,
+    offset: Option<usize>,
+) -> SqlResult<ExecutionResult> {
+    let specs = collect_agg_specs(select);
+    let grouped = !select.group_by.is_empty();
+
+    // ---- accumulate ----
+    // Fast path: plain-column keys/args, borrowed-key hashing, parallel
+    // partitioned accumulation. Falls back to the general expression-based
+    // path for computed keys or computed aggregate arguments.
+    let mut order: Vec<GroupState> = match accumulate_fast(select, &specs, rows) {
+        Some(states) => states,
+        None => {
+            let mut order: Vec<GroupState> = Vec::new();
+            let mut index: HashMap<Vec<String>, usize> = HashMap::new();
+
+            for row in rows {
+                let key_values: Vec<SochValue> = select
+                    .group_by
+                    .iter()
+                    .map(|e| eval_scalar(e, row, params))
+                    .collect();
+                let hash_key: Vec<String> = key_values.iter().map(key_repr).collect();
+
+                let idx = match index.get(&hash_key) {
+                    Some(&i) => i,
+                    None => {
+                        let state = GroupState {
+                            key_values,
+                            first_row: row.clone(),
+                            accs: specs.iter().map(Acc::new).collect(),
+                        };
+                        order.push(state);
+                        index.insert(hash_key, order.len() - 1);
+                        order.len() - 1
+                    }
+                };
+
+                let state = &mut order[idx];
+                for (acc, spec) in state.accs.iter_mut().zip(specs.iter()) {
+                    match &spec.arg {
+                        None => acc.update(None),
+                        Some(arg) => {
+                            let v = eval_scalar(arg, row, params);
+                            acc.update(Some(&v));
+                        }
+                    }
+                }
+            }
+            order
+        }
+    };
+
+    // Ungrouped aggregate over zero rows still yields one (empty) group.
+    if !grouped && order.is_empty() {
+        order.push(GroupState {
+            key_values: Vec::new(),
+            first_row: HashMap::new(),
+            accs: specs.iter().map(Acc::new).collect(),
+        });
+    }
+
+    // ---- finalize: synthesize one row per group ----
+    let group_names: Vec<String> = select.group_by.iter().map(render_expr_name).collect();
+
+    let mut out_rows: Vec<HashMap<String, SochValue>> = Vec::with_capacity(order.len());
+    for state in order {
+        // Start from the first row of the group so non-aggregate columns
+        // (lenient mode) and qualified names still resolve.
+        let mut row = state.first_row;
+        for (name, val) in group_names.iter().zip(state.key_values.into_iter()) {
+            row.insert(name.clone(), val);
+        }
+        for (spec, acc) in specs.iter().zip(state.accs.into_iter()) {
+            row.insert(spec.key.clone(), acc.finalize());
+        }
+        out_rows.push(row);
+    }
+
+    // ---- HAVING ----
+    if let Some(having) = &select.having {
+        out_rows.retain(|row| {
+            matches!(eval_scalar(having, row, params), SochValue::Bool(true))
+        });
+    }
+
+    // ---- ORDER BY (may reference aggregates or aliases) ----
+    if !select.order_by.is_empty() {
+        // Bind aliases so ORDER BY alias works.
+        let alias_map: Vec<(String, Expr)> = select
+            .columns
+            .iter()
+            .filter_map(|item| match item {
+                SelectItem::Expr {
+                    expr,
+                    alias: Some(a),
+                } => Some((a.clone(), expr.clone())),
+                _ => None,
+            })
+            .collect();
+        for row in &mut out_rows {
+            for (alias, expr) in &alias_map {
+                if !row.contains_key(alias) {
+                    let v = eval_scalar(expr, row, params);
+                    row.insert(alias.clone(), v);
+                }
+            }
+        }
+        out_rows.sort_by(|a, b| {
+            for item in &select.order_by {
+                let va = eval_scalar(&item.expr, a, params);
+                let vb = eval_scalar(&item.expr, b, params);
+                let mut cmp = compare_values(&va, &vb);
+                if !item.asc {
+                    cmp = cmp.reverse();
+                }
+                if cmp != std::cmp::Ordering::Equal {
+                    return cmp;
+                }
+            }
+            std::cmp::Ordering::Equal
+        });
+    }
+
+    // ---- OFFSET / LIMIT ----
+    if let Some(off) = offset {
+        if off > 0 {
+            out_rows.drain(..off.min(out_rows.len()));
+        }
+    }
+    if let Some(lim) = limit {
+        out_rows.truncate(lim);
+    }
+
+    // ---- projection ----
+    let mut columns: Vec<String> = Vec::new();
+    let mut projections: Vec<(String, Expr)> = Vec::new();
+    for item in &select.columns {
+        match item {
+            SelectItem::Wildcard | SelectItem::QualifiedWildcard(_) => {
+                // SELECT * with GROUP BY: project group keys then aggregates.
+                for name in &group_names {
+                    columns.push(name.clone());
+                    projections.push((
+                        name.clone(),
+                        Expr::Column(ColumnRef::new(name.clone())),
+                    ));
+                }
+                for spec in &specs {
+                    columns.push(spec.key.clone());
+                    projections.push((
+                        spec.key.clone(),
+                        Expr::Column(ColumnRef::new(spec.key.clone())),
+                    ));
+                }
+            }
+            SelectItem::Expr { expr, alias } => {
+                let name = alias.clone().unwrap_or_else(|| render_expr_name(expr));
+                columns.push(name.clone());
+                projections.push((name, expr.clone()));
+            }
+        }
+    }
+
+    let projected: Vec<HashMap<String, SochValue>> = out_rows
+        .into_iter()
+        .map(|row| {
+            let mut out = HashMap::with_capacity(projections.len());
+            for (name, expr) in &projections {
+                let v = eval_scalar(expr, &row, params);
+                out.insert(name.clone(), v);
+            }
+            out
+        })
+        .collect();
+
+    Ok(ExecutionResult::Rows {
+        columns,
+        rows: projected,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::bridge::{SqlBridge, SqlConnection};
+    use super::*;
+
+    fn fcall(name: &str, arg: &str) -> Expr {
+        Expr::Function(FunctionCall {
+            name: ObjectName::new(name),
+            args: vec![Expr::Column(ColumnRef::new(arg))],
+            distinct: false,
+            filter: None,
+            over: None,
+        })
+    }
+
+    #[test]
+    fn agg_fn_recognition() {
+        assert_eq!(AggFn::from_name("median"), Some(AggFn::Median));
+        assert_eq!(AggFn::from_name("STDDEV"), Some(AggFn::Stddev));
+        assert_eq!(AggFn::from_name("stddev_samp"), Some(AggFn::Stddev));
+        assert_eq!(AggFn::from_name("upper"), None);
+    }
+
+    #[test]
+    fn canonical_keys() {
+        assert_eq!(render_expr_name(&fcall("SUM", "v1")), "sum(v1)");
+        assert_eq!(render_expr_name(&fcall("Median", "v3")), "median(v3)");
+    }
+
+    // ========================================================================
+    // End-to-end SQL tests through SqlBridge with an in-memory connection
+    // ========================================================================
+
+    /// In-memory table store implementing SqlConnection for tests.
+    struct DataConn {
+        tables: HashMap<String, Vec<HashMap<String, SochValue>>>,
+    }
+
+    impl DataConn {
+        fn new() -> Self {
+            Self {
+                tables: HashMap::new(),
+            }
+        }
+
+        fn with_table(
+            mut self,
+            name: &str,
+            cols: &[&str],
+            rows: Vec<Vec<SochValue>>,
+        ) -> Self {
+            let rows = rows
+                .into_iter()
+                .map(|vals| {
+                    cols.iter()
+                        .map(|c| c.to_string())
+                        .zip(vals.into_iter())
+                        .collect::<HashMap<_, _>>()
+                })
+                .collect();
+            self.tables.insert(name.to_string(), rows);
+            self
+        }
+    }
+
+    impl SqlConnection for DataConn {
+        fn select(
+            &self,
+            table: &str,
+            _: &[String],
+            _where_clause: Option<&Expr>,
+            _: &[OrderByItem],
+            _: Option<usize>,
+            _: Option<usize>,
+            _: &[SochValue],
+        ) -> SqlResult<ExecutionResult> {
+            // Tests using the aggregate path don't push WHERE here.
+            let rows = self.tables.get(table).cloned().unwrap_or_default();
+            Ok(ExecutionResult::Rows {
+                columns: vec![],
+                rows,
+            })
+        }
+        fn insert(
+            &mut self,
+            _: &str,
+            _: Option<&[String]>,
+            _: &[Vec<Expr>],
+            _: Option<&OnConflict>,
+            _: &[SochValue],
+        ) -> SqlResult<ExecutionResult> {
+            Ok(ExecutionResult::RowsAffected(0))
+        }
+        fn update(
+            &mut self,
+            _: &str,
+            _: &[Assignment],
+            _: Option<&Expr>,
+            _: &[SochValue],
+        ) -> SqlResult<ExecutionResult> {
+            Ok(ExecutionResult::RowsAffected(0))
+        }
+        fn delete(
+            &mut self,
+            _: &str,
+            _: Option<&Expr>,
+            _: &[SochValue],
+        ) -> SqlResult<ExecutionResult> {
+            Ok(ExecutionResult::RowsAffected(0))
+        }
+        fn create_table(&mut self, _: &CreateTableStmt) -> SqlResult<ExecutionResult> {
+            Ok(ExecutionResult::Ok)
+        }
+        fn drop_table(&mut self, _: &DropTableStmt) -> SqlResult<ExecutionResult> {
+            Ok(ExecutionResult::Ok)
+        }
+        fn create_index(&mut self, _: &CreateIndexStmt) -> SqlResult<ExecutionResult> {
+            Ok(ExecutionResult::Ok)
+        }
+        fn drop_index(&mut self, _: &DropIndexStmt) -> SqlResult<ExecutionResult> {
+            Ok(ExecutionResult::Ok)
+        }
+        fn alter_table(&mut self, _: &AlterTableStmt) -> SqlResult<ExecutionResult> {
+            Ok(ExecutionResult::Ok)
+        }
+        fn begin(&mut self, _: &BeginStmt) -> SqlResult<ExecutionResult> {
+            Ok(ExecutionResult::TransactionOk)
+        }
+        fn commit(&mut self) -> SqlResult<ExecutionResult> {
+            Ok(ExecutionResult::TransactionOk)
+        }
+        fn rollback(&mut self, _: Option<&str>) -> SqlResult<ExecutionResult> {
+            Ok(ExecutionResult::TransactionOk)
+        }
+        fn table_exists(&self, t: &str) -> SqlResult<bool> {
+            Ok(self.tables.contains_key(t))
+        }
+        fn index_exists(&self, _: &str) -> SqlResult<bool> {
+            Ok(false)
+        }
+        fn scan_all(
+            &self,
+            table: &str,
+            _: &[String],
+        ) -> SqlResult<Vec<HashMap<String, SochValue>>> {
+            Ok(self.tables.get(table).cloned().unwrap_or_default())
+        }
+        fn eval_join_predicate(
+            &self,
+            expr: &Expr,
+            row: &HashMap<String, SochValue>,
+            params: &[SochValue],
+        ) -> Option<bool> {
+            match eval_scalar(expr, row, params) {
+                SochValue::Bool(b) => Some(b),
+                SochValue::Null => Some(false),
+                _ => None,
+            }
+        }
+    }
+
+    fn i(v: i64) -> SochValue {
+        SochValue::Int(v)
+    }
+    fn f(v: f64) -> SochValue {
+        SochValue::Float(v)
+    }
+    fn t(v: &str) -> SochValue {
+        SochValue::Text(v.to_string())
+    }
+
+    /// db-benchmark-shaped fixture: x(id1 text, id3 text, v1 int, v2 int, v3 float)
+    fn bench_bridge() -> SqlBridge<DataConn> {
+        let conn = DataConn::new().with_table(
+            "x",
+            &["id1", "id3", "v1", "v2", "v3"],
+            vec![
+                vec![t("id001"), t("id0000001"), i(1), i(10), f(1.0)],
+                vec![t("id001"), t("id0000002"), i(2), i(20), f(2.0)],
+                vec![t("id002"), t("id0000001"), i(3), i(30), f(3.0)],
+                vec![t("id002"), t("id0000002"), i(4), i(40), f(4.0)],
+            ],
+        );
+        SqlBridge::new(conn)
+    }
+
+    fn rows_of(result: ExecutionResult) -> Vec<HashMap<String, SochValue>> {
+        match result {
+            ExecutionResult::Rows { rows, .. } => rows,
+            other => panic!("expected rows, got {:?}", other),
+        }
+    }
+
+    fn get<'a>(row: &'a HashMap<String, SochValue>, k: &str) -> &'a SochValue {
+        row.get(k)
+            .unwrap_or_else(|| panic!("column '{}' missing from {:?}", k, row))
+    }
+
+    #[test]
+    fn groupby_sum_q1_shape() {
+        // db-benchmark q1: SELECT id1, sum(v1) AS v1 FROM x GROUP BY id1
+        let mut b = bench_bridge();
+        let rows = rows_of(
+            b.execute("SELECT id1, sum(v1) AS v1 FROM x GROUP BY id1 ORDER BY id1")
+                .unwrap(),
+        );
+        assert_eq!(rows.len(), 2);
+        assert_eq!(get(&rows[0], "id1"), &t("id001"));
+        assert_eq!(get(&rows[0], "v1"), &i(3));
+        assert_eq!(get(&rows[1], "id1"), &t("id002"));
+        assert_eq!(get(&rows[1], "v1"), &i(7));
+    }
+
+    #[test]
+    fn groupby_multi_key_mean() {
+        // q4-like: SELECT id1, id3, avg(v1) AS m FROM x GROUP BY id1, id3
+        let mut b = bench_bridge();
+        let rows = rows_of(
+            b.execute(
+                "SELECT id1, id3, avg(v1) AS m FROM x GROUP BY id1, id3 ORDER BY id1, id3",
+            )
+            .unwrap(),
+        );
+        assert_eq!(rows.len(), 4);
+        assert_eq!(get(&rows[0], "m"), &f(1.0));
+        assert_eq!(get(&rows[3], "m"), &f(4.0));
+    }
+
+    #[test]
+    fn median_and_stddev() {
+        // q7-like: SELECT median(v3), stddev(v3) FROM x
+        // v3 = [1,2,3,4]: median = 2.5, sample sd = sqrt(5/3)
+        let mut b = bench_bridge();
+        let rows = rows_of(
+            b.execute("SELECT median(v3) AS med, stddev(v3) AS sd FROM x")
+                .unwrap(),
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(get(&rows[0], "med"), &f(2.5));
+        match get(&rows[0], "sd") {
+            SochValue::Float(sd) => {
+                assert!((sd - (5.0f64 / 3.0).sqrt()).abs() < 1e-12, "sd={}", sd)
+            }
+            other => panic!("expected float sd, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn median_odd_count() {
+        let conn = DataConn::new().with_table(
+            "t",
+            &["v"],
+            vec![vec![f(5.0)], vec![f(1.0)], vec![f(3.0)]],
+        );
+        let mut b = SqlBridge::new(conn);
+        let rows = rows_of(b.execute("SELECT median(v) AS m FROM t").unwrap());
+        assert_eq!(get(&rows[0], "m"), &f(3.0));
+    }
+
+    #[test]
+    fn range_expression_q9_shape() {
+        // q9: SELECT id3, max(v1) - min(v2) AS range_v1_v2 FROM x GROUP BY id3
+        let mut b = bench_bridge();
+        let rows = rows_of(
+            b.execute(
+                "SELECT id3, max(v1) - min(v2) AS range_v1_v2 FROM x GROUP BY id3 ORDER BY id3",
+            )
+            .unwrap(),
+        );
+        assert_eq!(rows.len(), 2);
+        // id0000001: max(v1)=3, min(v2)=10 -> -7
+        assert_eq!(get(&rows[0], "range_v1_v2"), &i(-7));
+        // id0000002: max(v1)=4, min(v2)=20 -> -16
+        assert_eq!(get(&rows[1], "range_v1_v2"), &i(-16));
+    }
+
+    #[test]
+    fn count_star_vs_count_col_with_nulls() {
+        let conn = DataConn::new().with_table(
+            "t",
+            &["g", "v"],
+            vec![
+                vec![t("a"), i(1)],
+                vec![t("a"), SochValue::Null],
+                vec![t("b"), i(2)],
+            ],
+        );
+        let mut b = SqlBridge::new(conn);
+        let rows = rows_of(
+            b.execute(
+                "SELECT g, count(*) AS n, count(v) AS nv FROM t GROUP BY g ORDER BY g",
+            )
+            .unwrap(),
+        );
+        assert_eq!(rows.len(), 2);
+        assert_eq!(get(&rows[0], "n"), &i(2));
+        assert_eq!(get(&rows[0], "nv"), &i(1));
+        assert_eq!(get(&rows[1], "n"), &i(1));
+        assert_eq!(get(&rows[1], "nv"), &i(1));
+    }
+
+    #[test]
+    fn count_distinct() {
+        // q6-like: SELECT id3, count(DISTINCT id1) AS u FROM x GROUP BY id3
+        let mut b = bench_bridge();
+        let rows = rows_of(
+            b.execute("SELECT id3, count(DISTINCT id1) AS u FROM x GROUP BY id3 ORDER BY id3")
+                .unwrap(),
+        );
+        assert_eq!(rows.len(), 2);
+        assert_eq!(get(&rows[0], "u"), &i(2));
+        assert_eq!(get(&rows[1], "u"), &i(2));
+    }
+
+    #[test]
+    fn having_filters_groups() {
+        let mut b = bench_bridge();
+        let rows = rows_of(
+            b.execute("SELECT id1, sum(v1) AS s FROM x GROUP BY id1 HAVING sum(v1) > 5")
+                .unwrap(),
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(get(&rows[0], "id1"), &t("id002"));
+        assert_eq!(get(&rows[0], "s"), &i(7));
+    }
+
+    #[test]
+    fn order_by_aggregate_desc_with_limit() {
+        let mut b = bench_bridge();
+        let rows = rows_of(
+            b.execute("SELECT id1, sum(v1) AS s FROM x GROUP BY id1 ORDER BY s DESC LIMIT 1")
+                .unwrap(),
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(get(&rows[0], "id1"), &t("id002"));
+    }
+
+    #[test]
+    fn ungrouped_aggregate_over_empty_table() {
+        let conn = DataConn::new().with_table("e", &["v"], vec![]);
+        let mut b = SqlBridge::new(conn);
+        let rows = rows_of(
+            b.execute("SELECT count(*) AS n, sum(v) AS s FROM e").unwrap(),
+        );
+        assert_eq!(rows.len(), 1, "ungrouped agg over empty input = one row");
+        assert_eq!(get(&rows[0], "n"), &i(0));
+        assert_eq!(get(&rows[0], "s"), &SochValue::Null);
+    }
+
+    #[test]
+    fn grouped_aggregate_over_empty_table_yields_no_rows() {
+        let conn = DataConn::new().with_table("e", &["g", "v"], vec![]);
+        let mut b = SqlBridge::new(conn);
+        let rows = rows_of(
+            b.execute("SELECT g, sum(v) AS s FROM e GROUP BY g").unwrap(),
+        );
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn sum_overflow_promotes_to_float() {
+        let conn = DataConn::new().with_table(
+            "t",
+            &["v"],
+            vec![vec![i(i64::MAX)], vec![i(i64::MAX)]],
+        );
+        let mut b = SqlBridge::new(conn);
+        let rows = rows_of(b.execute("SELECT sum(v) AS s FROM t").unwrap());
+        match get(&rows[0], "s") {
+            SochValue::Float(v) => assert!(*v > 1.8e19),
+            other => panic!("expected float after overflow, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn aggregate_after_join() {
+        // join + group: SELECT x.id1, sum(y.w) FROM x JOIN y ON x.id1 = y.id1 GROUP BY x.id1
+        let conn = DataConn::new()
+            .with_table(
+                "a",
+                &["id", "v"],
+                vec![
+                    vec![t("k1"), i(1)],
+                    vec![t("k1"), i(2)],
+                    vec![t("k2"), i(3)],
+                ],
+            )
+            .with_table(
+                "b",
+                &["id", "w"],
+                vec![vec![t("k1"), i(10)], vec![t("k2"), i(20)]],
+            );
+        let mut br = SqlBridge::new(conn);
+        let rows = rows_of(
+            br.execute(
+                "SELECT a.id, sum(a.v) AS sv, sum(b.w) AS sw \
+                 FROM a JOIN b ON a.id = b.id GROUP BY a.id ORDER BY a.id",
+            )
+            .unwrap(),
+        );
+        assert_eq!(rows.len(), 2);
+        assert_eq!(get(&rows[0], "sv"), &i(3));
+        assert_eq!(get(&rows[0], "sw"), &i(20)); // 10 joined to both k1 rows
+        assert_eq!(get(&rows[1], "sv"), &i(3));
+        assert_eq!(get(&rows[1], "sw"), &i(20));
+    }
+
+    #[test]
+    fn lowercase_function_names_parse() {
+        // db-benchmark SQL uses lowercase: sum(v1), median(v3)
+        let mut b = bench_bridge();
+        assert!(b.execute("SELECT id1, sum(v1) FROM x GROUP BY id1").is_ok());
+        assert!(b.execute("SELECT median(v3) FROM x").is_ok());
+        assert!(b.execute("SELECT stddev(v3) FROM x").is_ok());
+    }
+
+    #[test]
+    fn parallel_path_matches_reference_computation() {
+        // 150k rows (> PARALLEL_THRESHOLD) exercising the rayon merge:
+        // sum, avg, count, median, stddev per group, verified against
+        // values computed directly in the test.
+        let n: usize = 150_000;
+        let groups = 7usize;
+        let mut data: Vec<Vec<SochValue>> = Vec::with_capacity(n);
+        for idx in 0..n {
+            data.push(vec![
+                t(&format!("g{}", idx % groups)),
+                f((idx * 31 % 1000) as f64 / 4.0),
+            ]);
+        }
+        // Reference computation.
+        let mut per_group: Vec<Vec<f64>> = vec![Vec::new(); groups];
+        for idx in 0..n {
+            per_group[idx % groups].push((idx * 31 % 1000) as f64 / 4.0);
+        }
+
+        let conn = DataConn::new().with_table("big", &["g", "v"], data);
+        let mut b = SqlBridge::new(conn);
+        let rows = rows_of(
+            b.execute(
+                "SELECT g, count(*) AS n, sum(v) AS s, avg(v) AS m, \
+                 median(v) AS med, stddev(v) AS sd FROM big GROUP BY g ORDER BY g",
+            )
+            .unwrap(),
+        );
+        assert_eq!(rows.len(), groups);
+
+        for (gi, row) in rows.iter().enumerate() {
+            let vals = &per_group[gi];
+            let cnt = vals.len() as f64;
+            let sum: f64 = vals.iter().sum();
+            let mean = sum / cnt;
+            let var =
+                vals.iter().map(|x| (x - mean) * (x - mean)).sum::<f64>() / (cnt - 1.0);
+            let mut sorted = vals.clone();
+            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            let med = if sorted.len() % 2 == 1 {
+                sorted[sorted.len() / 2]
+            } else {
+                (sorted[sorted.len() / 2 - 1] + sorted[sorted.len() / 2]) / 2.0
+            };
+
+            assert_eq!(get(row, "g"), &t(&format!("g{}", gi)));
+            assert_eq!(get(row, "n"), &i(vals.len() as i64));
+            match get(row, "s") {
+                SochValue::Float(v) => assert!((v - sum).abs() < 1e-6, "sum"),
+                other => panic!("sum type {:?}", other),
+            }
+            match get(row, "m") {
+                SochValue::Float(v) => assert!((v - mean).abs() < 1e-9, "mean"),
+                other => panic!("mean type {:?}", other),
+            }
+            match get(row, "med") {
+                SochValue::Float(v) => assert!((v - med).abs() < 1e-9, "median"),
+                other => panic!("median type {:?}", other),
+            }
+            match get(row, "sd") {
+                SochValue::Float(v) => {
+                    assert!((v - var.sqrt()).abs() < 1e-9, "sd {} vs {}", v, var.sqrt())
+                }
+                other => panic!("sd type {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn unaliased_aggregate_column_name_is_canonical() {
+        let mut b = bench_bridge();
+        let result = b.execute("SELECT id1, sum(v1) FROM x GROUP BY id1").unwrap();
+        let cols = result.columns().unwrap().clone();
+        assert!(cols.contains(&"sum(v1)".to_string()), "cols={:?}", cols);
+    }
+}

--- a/sochdb-query/src/sql/bridge.rs
+++ b/sochdb-query/src/sql/bridge.rs
@@ -419,12 +419,32 @@ impl<C: SqlConnection> SqlBridge<C> {
         // Check table-level permission for SELECT
         self.check_table_permission(&table_name, PermissionOp::Select)?;
 
-        // Extract column names
-        let columns = self.extract_select_columns(&select.columns)?;
-
         // Extract LIMIT/OFFSET
         let limit = self.extract_limit(&select.limit)?;
         let offset = self.extract_limit(&select.offset)?;
+
+        // Aggregate / GROUP BY queries: fetch WHERE-filtered rows (all
+        // columns, no ordering/limit pushdown), then run the aggregation
+        // operator over them.
+        if super::aggregate::is_aggregate_query(select) {
+            let input = self.conn.select(
+                &table_name,
+                &[],
+                select.where_clause.as_ref(),
+                &[],
+                None,
+                None,
+                params,
+            )?;
+            let rows = match input {
+                ExecutionResult::Rows { rows, .. } => rows,
+                _ => Vec::new(),
+            };
+            return super::aggregate::execute_aggregate(select, &rows, params, limit, offset);
+        }
+
+        // Extract column names
+        let columns = self.extract_select_columns(&select.columns)?;
 
         self.conn.select(
             &table_name,
@@ -464,6 +484,13 @@ impl<C: SqlConnection> SqlBridge<C> {
                     .eval_join_predicate(expr, row, params)
                     .unwrap_or(false)
             });
+        }
+
+        // Aggregate / GROUP BY over the joined row set.
+        if super::aggregate::is_aggregate_query(select) {
+            let limit = self.extract_limit(&select.limit)?;
+            let offset = self.extract_limit(&select.offset)?;
+            return super::aggregate::execute_aggregate(select, &rows, params, limit, offset);
         }
 
         // Apply ORDER BY

--- a/sochdb-query/src/sql/mod.rs
+++ b/sochdb-query/src/sql/mod.rs
@@ -27,6 +27,7 @@
 //! let stmt = Parser::parse("SELECT * FROM users WHERE id = 1")?;
 //! ```
 
+pub mod aggregate;
 pub mod ast;
 pub mod bridge;
 pub mod compatibility;

--- a/sochdb-query/src/sql/mod.rs
+++ b/sochdb-query/src/sql/mod.rs
@@ -639,10 +639,10 @@ impl SqlExecutor {
 
                 match (&val, &pattern_val) {
                     (SochValue::Text(s), SochValue::Text(p)) => {
-                        let regex_pattern = p.replace('%', ".*").replace('_', ".");
-                        let matches = regex::Regex::new(&format!("^{}$", regex_pattern))
-                            .map(|re| re.is_match(s))
-                            .unwrap_or(false);
+                        // Route through the canonical LIKE matcher so SQL `LIKE`
+                        // behaves identically across every query path and treats
+                        // regex metacharacters (`.`, `*`, `[`, ...) as literals.
+                        let matches = crate::like::like_match(s, p);
                         Ok(SochValue::Bool(if *negated { !matches } else { matches }))
                     }
                     _ => Ok(SochValue::Bool(false)),

--- a/sochdb-query/src/sql/parser.rs
+++ b/sochdb-query/src/sql/parser.rs
@@ -63,16 +63,31 @@ impl std::fmt::Display for ParseError {
 
 impl std::error::Error for ParseError {}
 
+/// Maximum expression nesting depth. Recursive-descent expression parsing
+/// (`parse_expr` → … → `parse_primary_expr` → `parse_expr` on `(`, subscript,
+/// CASE, etc.) has no natural bound, so a pathological input like
+/// `((((((…))))))` or `NOT NOT NOT …` would recurse until the thread stack
+/// overflows and the process aborts (SIGABRT) — a DoS on attacker-controlled
+/// SQL. We cap depth and return a parse error instead. 256 is far deeper than
+/// any legitimate query yet leaves ample stack headroom.
+const MAX_EXPR_DEPTH: usize = 256;
+
 /// SQL Parser
 pub struct Parser<'a> {
     tokens: Vec<Token<'a>>,
     pos: usize,
+    /// Current expression-recursion depth (see [`MAX_EXPR_DEPTH`]).
+    depth: usize,
 }
 
 impl<'a> Parser<'a> {
     /// Create a new parser from tokens
     pub fn new(tokens: Vec<Token<'a>>) -> Self {
-        Self { tokens, pos: 0 }
+        Self {
+            tokens,
+            pos: 0,
+            depth: 0,
+        }
     }
 
     /// Parse a SQL string into a statement
@@ -1478,8 +1493,32 @@ impl<'a> Parser<'a> {
 
     // ========== Expression Parsing ==========
 
+    /// Enter one level of expression recursion, erroring if too deep.
+    /// Paired with `exit_recursion` so the depth counter stays balanced across
+    /// sibling expressions on the success path.
+    #[inline]
+    fn enter_recursion(&mut self) -> Result<(), ParseError> {
+        self.depth += 1;
+        if self.depth > MAX_EXPR_DEPTH {
+            self.depth -= 1;
+            return Err(ParseError::new(
+                "expression nesting too deep",
+                self.current_span(),
+            ));
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn exit_recursion(&mut self) {
+        self.depth = self.depth.saturating_sub(1);
+    }
+
     fn parse_expr(&mut self) -> Result<Expr, ParseError> {
-        self.parse_or_expr()
+        self.enter_recursion()?;
+        let r = self.parse_or_expr();
+        self.exit_recursion();
+        r
     }
 
     fn parse_or_expr(&mut self) -> Result<Expr, ParseError> {
@@ -1513,15 +1552,17 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_not_expr(&mut self) -> Result<Expr, ParseError> {
-        if self.match_token(&TokenKind::Not) {
-            let expr = self.parse_not_expr()?;
-            Ok(Expr::UnaryOp {
+        self.enter_recursion()?;
+        let r = if self.match_token(&TokenKind::Not) {
+            self.parse_not_expr().map(|expr| Expr::UnaryOp {
                 op: UnaryOperator::Not,
                 expr: Box::new(expr),
             })
         } else {
             self.parse_comparison_expr()
-        }
+        };
+        self.exit_recursion();
+        r
     }
 
     fn parse_comparison_expr(&mut self) -> Result<Expr, ParseError> {
@@ -1701,32 +1742,26 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_unary_expr(&mut self) -> Result<Expr, ParseError> {
-        match &self.peek().kind {
-            TokenKind::Minus => {
+        // Guard the `- - - …` / `+ +` / `~ ~` prefix chains, which self-recurse
+        // without passing through parse_expr.
+        let op = match &self.peek().kind {
+            TokenKind::Minus => Some(UnaryOperator::Minus),
+            TokenKind::Plus => Some(UnaryOperator::Plus),
+            TokenKind::BitNot => Some(UnaryOperator::BitNot),
+            _ => None,
+        };
+        match op {
+            Some(op) => {
                 self.advance();
-                let expr = self.parse_unary_expr()?;
-                Ok(Expr::UnaryOp {
-                    op: UnaryOperator::Minus,
+                self.enter_recursion()?;
+                let inner = self.parse_unary_expr();
+                self.exit_recursion();
+                inner.map(|expr| Expr::UnaryOp {
+                    op,
                     expr: Box::new(expr),
                 })
             }
-            TokenKind::Plus => {
-                self.advance();
-                let expr = self.parse_unary_expr()?;
-                Ok(Expr::UnaryOp {
-                    op: UnaryOperator::Plus,
-                    expr: Box::new(expr),
-                })
-            }
-            TokenKind::BitNot => {
-                self.advance();
-                let expr = self.parse_unary_expr()?;
-                Ok(Expr::UnaryOp {
-                    op: UnaryOperator::BitNot,
-                    expr: Box::new(expr),
-                })
-            }
-            _ => self.parse_primary_expr(),
+            None => self.parse_primary_expr(),
         }
     }
 
@@ -2198,6 +2233,32 @@ mod tests {
     fn test_simple_select() {
         let stmt = Parser::parse("SELECT * FROM users").unwrap();
         assert!(matches!(stmt, Statement::Select(_)));
+    }
+
+    #[test]
+    fn test_deeply_nested_expr_errors_not_panics() {
+        // Regression: unbounded recursive-descent recursion used to overflow
+        // the stack (SIGABRT) on attacker-controlled SQL. Now it must return a
+        // parse error well within stack limits. Three vectors: parentheses,
+        // NOT chains, unary-minus chains.
+        let depth = MAX_EXPR_DEPTH + 50;
+        for (open, close) in [("(", ")"), ("NOT ", ""), ("-", "")] {
+            let expr = format!(
+                "SELECT {}1{} FROM t",
+                open.repeat(depth),
+                close.repeat(depth)
+            );
+            let r = Parser::parse(&expr);
+            assert!(
+                r.is_err(),
+                "depth {} of {:?} should error, not parse/panic",
+                depth,
+                open
+            );
+        }
+        // A reasonably-nested expression still parses fine (no false positive).
+        let ok = format!("SELECT {}1{} FROM t", "(".repeat(20), ")".repeat(20));
+        assert!(Parser::parse(&ok).is_ok(), "20-deep nesting must still parse");
     }
 
     #[test]

--- a/sochdb-query/src/storage_bridge.rs
+++ b/sochdb-query/src/storage_bridge.rs
@@ -1204,18 +1204,24 @@ fn eval_binary_op(lhs: &CoreSochValue, op: &BinaryOperator, rhs: &CoreSochValue)
         BinaryOperator::Plus => numeric_op(lhs, rhs, |a, b| a + b, |a, b| a + b),
         BinaryOperator::Minus => numeric_op(lhs, rhs, |a, b| a - b, |a, b| a - b),
         BinaryOperator::Multiply => numeric_op(lhs, rhs, |a, b| a * b, |a, b| a * b),
-        BinaryOperator::Divide => numeric_op(
-            lhs,
-            rhs,
-            |a, b| if b != 0 { a / b } else { 0 },
-            |a, b| if b != 0.0 { a / b } else { 0.0 },
-        ),
-        BinaryOperator::Modulo => numeric_op(
-            lhs,
-            rhs,
-            |a, b| if b != 0 { a % b } else { 0 },
-            |a, b| if b != 0.0 { a % b } else { 0.0 },
-        ),
+        // Division/modulo by zero yields SQL NULL, not a silent 0. Returning 0
+        // here corrupted results: `WHERE x / 0 > 1` evaluated to `0 > 1`
+        // (false) and `UPDATE SET z = a / 0` stored 0. NULL also matches the
+        // aggregate-path evaluator (sql/aggregate.rs eval_binary).
+        BinaryOperator::Divide => {
+            if is_numeric_zero(rhs) {
+                CoreSochValue::Null
+            } else {
+                numeric_op(lhs, rhs, |a, b| a / b, |a, b| a / b)
+            }
+        }
+        BinaryOperator::Modulo => {
+            if is_numeric_zero(rhs) {
+                CoreSochValue::Null
+            } else {
+                numeric_op(lhs, rhs, |a, b| a % b, |a, b| a % b)
+            }
+        }
         BinaryOperator::Like => {
             if let (CoreSochValue::Text(s), CoreSochValue::Text(pattern)) = (lhs, rhs) {
                 CoreSochValue::Bool(sql_like_match(s, pattern))
@@ -1250,6 +1256,16 @@ fn eval_unary_op(op: &UnaryOperator, val: &CoreSochValue) -> CoreSochValue {
 }
 
 /// Numeric operation helper.
+/// True if the value is a numeric zero (used to guard divide/modulo, which
+/// must yield SQL NULL rather than a silent 0 on a zero divisor).
+fn is_numeric_zero(v: &CoreSochValue) -> bool {
+    match v {
+        CoreSochValue::Int(0) | CoreSochValue::UInt(0) => true,
+        CoreSochValue::Float(f) => *f == 0.0,
+        _ => false,
+    }
+}
+
 fn numeric_op(
     lhs: &CoreSochValue,
     rhs: &CoreSochValue,

--- a/sochdb-storage/src/txn_wal.rs
+++ b/sochdb-storage/src/txn_wal.rs
@@ -767,9 +767,16 @@ impl TxnWal {
         Ok(seq)
     }
 
-    /// Force sync to disk
+    /// Force sync to disk.
+    ///
+    /// Must flush the BufWriter BEFORE fsync: `get_ref()` reaches the raw File
+    /// and bypasses the 256 KB buffer, so without an explicit `flush()` the
+    /// just-appended commit/checkpoint record may still sit in userspace and
+    /// `sync_all()` would fsync stale bytes — silently breaking the durability
+    /// guarantee `append_sync`/`commit`/`checkpoint` advertise.
     pub fn sync(&self) -> Result<()> {
-        let writer = self.writer.lock();
+        let mut writer = self.writer.lock();
+        writer.flush()?;
         writer.get_ref().sync_all()?;
         self.bytes_since_sync.store(0, Ordering::Relaxed);
         Ok(())

--- a/sochdb-storage/src/wal_segment.rs
+++ b/sochdb-storage/src/wal_segment.rs
@@ -425,7 +425,12 @@ impl WalSegmentManager {
         segment.offset += record_len as u64;
 
         if self.config.sync_on_write {
+            // `flush()` only pushes the BufWriter into the kernel page cache;
+            // a true "sync on every write" durability guarantee additionally
+            // needs an fsync, matching rotate_segment()/shutdown(). Without it
+            // an acknowledged write is lost on power loss.
             segment.file.flush()?;
+            segment.file.get_ref().sync_all()?;
         }
 
         Ok(lsn)

--- a/sochdb-vector/src/portable_simd.rs
+++ b/sochdb-vector/src/portable_simd.rs
@@ -642,9 +642,12 @@ impl ScanOps {
         self.kernel
             .l2_squared_batch_f32(query, vectors, dim, &mut distances);
 
-        // Get top-k indices
+        // Get top-k indices. Use total_cmp, not partial_cmp().unwrap(): a NaN
+        // distance (e.g. from an Inf in the input vector — Inf-Inf=NaN) makes
+        // partial_cmp return None and the unwrap panics. total_cmp is a true
+        // total order that sinks NaN deterministically.
         let mut indices: Vec<usize> = (0..n).collect();
-        indices.sort_by(|&a, &b| distances[a].partial_cmp(&distances[b]).unwrap());
+        indices.sort_by(|&a, &b| distances[a].total_cmp(&distances[b]));
 
         indices
             .into_iter()
@@ -666,9 +669,10 @@ impl ScanOps {
 
         self.kernel.dot_batch_f32(query, vectors, dim, &mut scores);
 
-        // Get top-k indices (descending for dot product)
+        // Get top-k indices (descending for dot product). total_cmp avoids the
+        // NaN panic that partial_cmp().unwrap() would hit on Inf/NaN scores.
         let mut indices: Vec<usize> = (0..n).collect();
-        indices.sort_by(|&a, &b| scores[b].partial_cmp(&scores[a]).unwrap());
+        indices.sort_by(|&a, &b| scores[b].total_cmp(&scores[a]));
 
         indices
             .into_iter()


### PR DESCRIPTION
This pull request introduces several important improvements to the vector database, focusing on fixing deadlocks in concurrent HNSW index insertions, improving recall and performance, and correcting quota management in the collection and namespace services.

**Concurrency and Deadlock Fixes in HNSW Index:**

* Introduced a single-writer (`insert_lock`) discipline for all graph-mutation paths (`insert`, `insert_batch_bulk`, and `insert_from_flat`), ensuring that only one thread mutates the graph at a time while allowing fully concurrent reads. This resolves deadlocks previously seen under concurrent inserts. [[1]](diffhunk://#diff-e58cef846547c12b3e9194a2d94bc7b3a06a82111d7c88b60627af7ee64a61ffR2353-R2362) [[2]](diffhunk://#diff-e58cef846547c12b3e9194a2d94bc7b3a06a82111d7c88b60627af7ee64a61ffR3063-R3064) [[3]](diffhunk://#diff-e58cef846547c12b3e9194a2d94bc7b3a06a82111d7c88b60627af7ee64a61ffR3405-R3424) [[4]](diffhunk://#diff-e58cef846547c12b3e9194a2d94bc7b3a06a82111d7c88b60627af7ee64a61ffR3744-R3745)
* Replaced all recursive `RwLock` read accesses (`read()` → `read_recursive()`) where needed to prevent writer-starvation deadlocks during concurrent inserts. [[1]](diffhunk://#diff-e58cef846547c12b3e9194a2d94bc7b3a06a82111d7c88b60627af7ee64a61ffL2792-R2830) [[2]](diffhunk://#diff-e58cef846547c12b3e9194a2d94bc7b3a06a82111d7c88b60627af7ee64a61ffL2847-R2888) [[3]](diffhunk://#diff-e58cef846547c12b3e9194a2d94bc7b3a06a82111d7c88b60627af7ee64a61ffL2972-R3018) [[4]](diffhunk://#diff-e58cef846547c12b3e9194a2d94bc7b3a06a82111d7c88b60627af7ee64a61ffL3112-R3177)
* Refactored the batch insertion logic to avoid taking the global vector store write lock inside Rayon parallel workers, preventing lock contention and deadlocks. All vectors are quantized in parallel and inserted under a single lock on the calling thread. [[1]](diffhunk://#diff-e58cef846547c12b3e9194a2d94bc7b3a06a82111d7c88b60627af7ee64a61ffR3405-R3424) [[2]](diffhunk://#diff-e58cef846547c12b3e9194a2d94bc7b3a06a82111d7c88b60627af7ee64a61ffR3439-R3455) [[3]](diffhunk://#diff-e58cef846547c12b3e9194a2d94bc7b3a06a82111d7c88b60627af7ee64a61ffL3388-R3475)

**Recall and Performance Improvements:**

* Increased the default HNSW graph degree: `max_connections` from 16→32, `max_connections_layer0` from 32→64, and `ef_construction` from 200→256, significantly improving recall@10 on large datasets. The inline neighbor list size (`MAX_M`) was also raised to 64 to avoid per-node heap allocations. [[1]](diffhunk://#diff-e58cef846547c12b3e9194a2d94bc7b3a06a82111d7c88b60627af7ee64a61ffL88-R97) [[2]](diffhunk://#diff-e58cef846547c12b3e9194a2d94bc7b3a06a82111d7c88b60627af7ee64a61ffL2008-R2028)
* Enhanced search beam width scaling: the upper-layer and layer-1 seed beams now scale with `ef`, allowing higher recall for large `ef` values and more diverse entry points in hard/multi-cluster data.
* Added bounds checking to flat neighbor cache lookups, preventing panics if the cache is stale or undersized.

**Quota and Statistics Fixes:**

* Corrected vector and collection quota handling: deleting a collection or document now decrements the vector count in namespace stats, preventing quota exhaustion after repeated add/delete cycles. [[1]](diffhunk://#diff-5b512a9d17822e11949f32f6f09c3cd9c70bc9fc9ba756a8f888ef228215c800L216-R221) [[2]](diffhunk://#diff-5b512a9d17822e11949f32f6f09c3cd9c70bc9fc9ba756a8f888ef228215c800L402-R419) [[3]](diffhunk://#diff-52394cd6def837471d0dcdb23690e125cb029db87a2741265bf6e3a88cd40e32R124-R135)
* Fixed document addition logic to count only genuinely new documents (not overwrites), ensuring vector quotas are not over-counted on repeated upserts. [[1]](diffhunk://#diff-5b512a9d17822e11949f32f6f09c3cd9c70bc9fc9ba756a8f888ef228215c800L251-R257) [[2]](diffhunk://#diff-5b512a9d17822e11949f32f6f09c3cd9c70bc9fc9ba756a8f888ef228215c800L263-R271)

These changes collectively improve system correctness, stability under concurrent workloads, and recall performance, while preventing quota leaks and runtime panics.