### PR TITLE
Fix/production hardening

### DIFF
--- a/sochdb-client/src/context_query.rs
+++ b/sochdb-client/src/context_query.rs
@@ -1531,8 +1531,11 @@ mod tests {
     #[test]
     fn test_estimate_tokens() {
         assert_eq!(estimate_tokens(""), 0);
-        assert_eq!(estimate_tokens("test"), 1);
-        assert_eq!(estimate_tokens("hello world!"), 3);
+        // estimate_tokens applies the deliberate ~1.15x safety margin (it is a
+        // budget estimate, intentionally conservative): ceil(4/4 * 1.15)=2 and
+        // ceil(3 * 1.15)=4. The old 1/3 expectations ignored the margin.
+        assert_eq!(estimate_tokens("test"), 2);
+        assert_eq!(estimate_tokens("hello world!"), 4);
     }
 
     #[test]

--- a/sochdb-grpc/src/blocking_pool.rs
+++ b/sochdb-grpc/src/blocking_pool.rs
@@ -485,17 +485,33 @@ mod tests {
         };
         let pool = BlockingPool::new(config);
 
-        // Submit tasks that will block
-        for _ in 0..2 {
-            pool.try_submit(move || {
-                thread::sleep(Duration::from_secs(1));
-            })
-            .unwrap();
-        }
+        // Occupy the single worker with a task that blocks until released, so
+        // it cannot dequeue anything else. This makes the queue state
+        // deterministic regardless of scheduler timing — the previous version
+        // raced the worker (it could dequeue task 1 before the 3rd submit) and
+        // was flaky under parallel test load.
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let (started_tx, started_rx) = std::sync::mpsc::channel::<()>();
+        pool.try_submit(move || {
+            started_tx.send(()).unwrap();
+            let _ = release_rx.recv(); // block until the test releases us
+        })
+        .unwrap();
+        started_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("worker did not start the blocking task");
 
-        // This should fail with QueueFull
+        // Worker is now busy; fill the queue to its depth (2).
+        pool.try_submit(|| {}).unwrap();
+        pool.try_submit(|| {}).unwrap();
+
+        // Queue is full and the worker is occupied → the next submit must be
+        // rejected with QueueFull.
         let result = pool.try_submit(|| {});
         assert!(matches!(result, Err(BlockingPoolError::QueueFull)));
+
+        // Release the worker so the pool can drain and shut down cleanly.
+        release_tx.send(()).unwrap();
     }
 
     #[test]

--- a/sochdb-grpc/src/observability.rs
+++ b/sochdb-grpc/src/observability.rs
@@ -809,11 +809,16 @@ mod tests {
     fn test_sli_histogram() {
         let hist = SliHistogram::latency_histogram();
 
-        // Add some observations
-        hist.observe(500); // 0.5ms
-        hist.observe(1500); // 1.5ms
-        hist.observe(5000); // 5ms
-        hist.observe(50000); // 50ms
+        // A meaningful distribution for the percentile assertions: 60 fast
+        // (1ms) + 40 slow (50ms). Four samples could not exercise p99 — its
+        // rank floor(N * 0.99) landed below the tail bucket. With 100 samples
+        // p50 sits in a low bucket and p99 in the tail regardless of rounding.
+        for _ in 0..60 {
+            hist.observe(1000); // 1ms
+        }
+        for _ in 0..40 {
+            hist.observe(50000); // 50ms
+        }
 
         // p50 should be around 5ms bucket (5000)
         assert!(hist.percentile(50.0) <= 5000);

--- a/sochdb-grpc/src/server.rs
+++ b/sochdb-grpc/src/server.rs
@@ -168,29 +168,37 @@ impl VectorIndexService for VectorIndexServer {
 
         // Build config
         let proto_config = req.config.unwrap_or_default();
+        // Fall back to HnswConfig::default() for any field the client leaves
+        // unset, so the gRPC path inherits the same 95+-recall defaults
+        // (m=32, m0=64, ef_construction=256, F32 precision) as every other
+        // entry point. Previously these fallbacks were hardcoded to the old
+        // cheap values (m=16/m0=32/efc=200), so a client that didn't specify
+        // an HNSW config silently got a low-recall graph (~0.90 vs ~0.97 on
+        // hard 768-d data) — the exact default-drift #27 removed elsewhere.
+        let def = HnswConfig::default();
         let config = HnswConfig {
             max_connections: if proto_config.max_connections > 0 {
                 proto_config.max_connections as usize
             } else {
-                16
+                def.max_connections
             },
             max_connections_layer0: if proto_config.max_connections_layer0 > 0 {
                 proto_config.max_connections_layer0 as usize
             } else {
-                32
+                def.max_connections_layer0
             },
             ef_construction: if proto_config.ef_construction > 0 {
                 proto_config.ef_construction as usize
             } else {
-                200
+                def.ef_construction
             },
             ef_search: if proto_config.ef_search > 0 {
                 proto_config.ef_search as usize
             } else {
-                300
+                def.ef_search
             },
             metric: Self::convert_metric(req.metric()),
-            ..Default::default()
+            ..def
         };
 
         let dimension = req.dimension as usize;

--- a/sochdb-index/src/ffi.rs
+++ b/sochdb-index/src/ffi.rs
@@ -107,18 +107,23 @@ pub unsafe extern "C" fn hnsw_new(
     ef_construction: usize,
 ) -> *mut HnswIndexPtr {
     ffi_guard!({
+        // Inherit HnswConfig::default() for any field the caller leaves as 0,
+        // so the embedded FFI path gets the same 95+-recall defaults (m=32,
+        // m0=64, ef_construction=256, F32) as every other entry point instead
+        // of the old cheap m=16/efc=100 graph.
+        let def = HnswConfig::default();
         let config = HnswConfig {
             max_connections: if max_connections == 0 {
-                16
+                def.max_connections
             } else {
                 max_connections
             },
             ef_construction: if ef_construction == 0 {
-                100
+                def.ef_construction
             } else {
                 ef_construction
-            }, // Reduced default from 200
-            ..Default::default()
+            },
+            ..def
         };
 
         let index = HnswIndex::new(dimension, config);

--- a/sochdb-kernel/src/boot_fsm.rs
+++ b/sochdb-kernel/src/boot_fsm.rs
@@ -332,7 +332,16 @@ impl BootStateMachine {
 
     /// Get time remaining in current phase budget
     pub fn remaining_budget(&self) -> Duration {
-        let phase = *self.phase.read();
+        self.remaining_budget_for(*self.phase.read())
+    }
+
+    /// Remaining budget for an explicitly-supplied phase, WITHOUT locking
+    /// `self.phase`. Callers that already hold the `self.phase` lock (e.g.
+    /// `transition_to`, which holds the write guard) MUST use this and pass the
+    /// phase value they hold — calling the public `remaining_budget()` there
+    /// re-locks `self.phase` and self-deadlocks (parking_lot RwLock is not
+    /// reentrant).
+    fn remaining_budget_for(&self, phase: BootPhase) -> Duration {
         let elapsed = self.phase_start.read().elapsed();
         let budget = match phase {
             BootPhase::Init => self.budgets.init_budget,
@@ -418,8 +427,10 @@ impl BootStateMachine {
             });
         }
 
-        // Check budget exceeded
-        if self.remaining_budget() == Duration::ZERO && current.is_booting() {
+        // Check budget exceeded. Use the lock-free variant with the phase we
+        // already hold the write lock on — calling remaining_budget() here would
+        // re-read-lock self.phase and self-deadlock.
+        if self.remaining_budget_for(current) == Duration::ZERO && current.is_booting() {
             *phase = BootPhase::Failed;
             *self.failure_reason.write() =
                 Some(format!("Budget exceeded in phase {}", current.name()));

--- a/sochdb-storage/src/stratified_skiplist.rs
+++ b/sochdb-storage/src/stratified_skiplist.rs
@@ -345,20 +345,25 @@ where
         let mut current = self.head;
 
         for level in (0..max_height).rev() {
-            loop {
-                let next_node = unsafe { (*current).tower.get(level) };
-                if next_node.is_null() {
-                    break;
-                }
-
-                let next_key = unsafe { &(*next_node).key };
+            // `succ` MUST be the successor the loop actually compared against
+            // (first node with key >= `key`, or null) — NOT a fresh re-read of
+            // current.next afterwards. A concurrent insert can splice a node
+            // with key < `key` between `current` and the old successor in the
+            // window between the loop deciding to stop and a re-read; capturing
+            // that as next[level] makes `insert` link the new node BEFORE the
+            // smaller-key node, mis-ordering the level-0 chain and orphaning it
+            // (counted in len, unreachable to ordered get). Keeping next[]
+            // consistent with the comparison means the level-0 CAS expecting
+            // `succ` fails and retries on exactly that race.
+            let mut succ = unsafe { (*current).tower.get(level) };
+            while !succ.is_null() {
+                let next_key = unsafe { &(*succ).key };
                 match next_key.cmp(key) {
                     Ordering::Less => {
-                        current = next_node;
+                        current = succ;
+                        succ = unsafe { (*current).tower.get(level) };
                     }
-                    Ordering::Equal | Ordering::Greater => {
-                        break;
-                    }
+                    Ordering::Equal | Ordering::Greater => break,
                 }
             }
 
@@ -367,7 +372,7 @@ where
             } else {
                 current
             };
-            next[level] = unsafe { (*current).tower.get(level) };
+            next[level] = succ;
         }
     }
 

--- a/sochdb-vector/src/compressed_routing.rs
+++ b/sochdb-vector/src/compressed_routing.rs
@@ -717,8 +717,11 @@ mod tests {
         let rec2 = CentroidCompression::recommend(20_000, dim, cache_32mb);
         assert!(matches!(rec2, CentroidCompression::Fp16));
 
-        // 50k centroids need Int8
-        let rec3 = CentroidCompression::recommend(50_000, dim, cache_32mb);
+        // 40k centroids: FP32 (123MB) and FP16 (61MB) exceed the 32MB cache,
+        // but Int8 (40k*768B = 30.7MB) fits — so Int8 is recommended. (The old
+        // 50k case asserted Int8 but 50k*768B = 36.6MB does NOT fit 32MB, so the
+        // code correctly fell through to PQ — the expectation, not the code, was wrong.)
+        let rec3 = CentroidCompression::recommend(40_000, dim, cache_32mb);
         assert!(matches!(rec3, CentroidCompression::Int8));
     }
 

--- a/sochdb-vector/src/cost_model.rs
+++ b/sochdb-vector/src/cost_model.rs
@@ -768,7 +768,11 @@ mod tests {
 
     #[test]
     fn test_admission_controller() {
-        let controller = AdmissionController::new(1024 * 1024);
+        // 64 MB global budget so memory is never the binding gate here — this
+        // test exercises the per-class concurrency limit (2). With the old 1 MB
+        // budget, a single low_latency query's 2 MB estimate already exceeded
+        // it, so try_admit rejected before the class limit could be reached.
+        let controller = AdmissionController::new(64 * 1024 * 1024);
         controller.set_class_limit("low_latency", 2);
 
         let budget = QueryBudget::low_latency();


### PR DESCRIPTION
This pull request focuses on improving correctness, consistency, and robustness across several modules, including configuration defaults, concurrency handling, test reliability, and data structure integrity. The most significant changes ensure that default configurations are consistently applied, concurrency and locking bugs are eliminated, and test cases more accurately reflect real-world behavior and expectations.

**Configuration Consistency and Defaults:**
* The default configuration for `HnswConfig` is now consistently inherited for unset fields in both the gRPC server (`sochdb-grpc/src/server.rs`) and FFI entry points (`sochdb-index/src/ffi.rs`). This ensures that all entry points use the same high-recall defaults (e.g., m=32, m0=64, ef_construction=256) rather than outdated, lower-quality values, fixing a silent default drift issue. [[1]](diffhunk://#diff-b8cd6166114582fbd6a50eab21955f99a8db1fadbbc851b8447626144b455fcbR171-R201) [[2]](diffhunk://#diff-9a86d433f28208c4aeb083692e14af400f9c7d2d5663605466c862e07f6e634bR110-R126)

**Concurrency and Locking Improvements:**
* The `BootStateMachine` in `sochdb-kernel/src/boot_fsm.rs` now provides a lock-free method `remaining_budget_for` for checking phase budgets when the phase lock is already held, preventing potential self-deadlocks due to non-reentrant locking. This is used internally in phase transitions for safe, deadlock-free operation. [[1]](diffhunk://#diff-0967cc7ab36ebc57180e22cb6249a6817046f73b99fbdd39a37170bef7a6cbe6L335-R344) [[2]](diffhunk://#diff-0967cc7ab36ebc57180e22cb6249a6817046f73b99fbdd39a37170bef7a6cbe6L421-R433)
* The skiplist implementation in `sochdb-storage/src/stratified_skiplist.rs` fixes a concurrency bug where the successor pointer in the insert path could become inconsistent in the presence of concurrent inserts, potentially corrupting the level-0 chain. The new approach ensures the successor is always the one compared during traversal, maintaining data structure integrity. [[1]](diffhunk://#diff-87c13e0bd4adb515eb6d6e80143cd16a3611185fdd19bb3b2c02701105b93785L348-R366) [[2]](diffhunk://#diff-87c13e0bd4adb515eb6d6e80143cd16a3611185fdd19bb3b2c02701105b93785L370-R375)

**Test Robustness and Accuracy:**
* Several tests have been updated to better reflect actual behavior and prevent flakiness:
  - The blocking pool test in `sochdb-grpc/src/blocking_pool.rs` is now deterministic and robust against scheduler timing, ensuring the queue state is predictable and the test is reliable under parallel load.
  - The `estimate_tokens` test in `sochdb-client/src/context_query.rs` now accounts for the intended safety margin in token estimation, correcting previous expectations.
  - The SLI histogram test in `sochdb-grpc/src/observability.rs` uses a larger, more meaningful sample size to accurately test percentile calculations.
  - The admission controller test in `sochdb-vector/src/cost_model.rs` uses a larger memory budget to ensure concurrency limits are tested, not memory limits.
  - The centroid compression recommendation test in `sochdb-vector/src/compressed_routing.rs` now uses a correct case where Int8 compression is expected to fit in cache, fixing a previously incorrect expectation.