### PR TITLE
fix(hnsw): search_exact SIGSEGV reading empty HnswNode.vector for bat…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.0.6] - 2026-06-14
+
+### Fixed
+
+- **`HnswIndex::search_exact` / `search_exact_f64` SIGSEGV on batch-inserted
+  indexes** (`sochdb-index`) — both exact-search paths read each node's vector via
+  `entry.value().vector` directly. Nodes added through the batch-contiguous bulk
+  path (`insert_batch_contiguous_bulk`) store a zero-length dummy in
+  `HnswNode.vector` (the real vector lives in `vector_store`), so the empty slice
+  was fed to the fixed-dimension SIMD distance kernels, causing an out-of-bounds
+  read (`SIGSEGV`, `KERN_INVALID_ADDRESS`). Reproduced 100% via the Python SDK's
+  `vector_search_exact` after a `> scaffold-size` `insert_batch`. Both paths now
+  fetch the vector via `vector_store.get(node.vector_index).unwrap_or(&node.vector)`
+  like every other search path. Adds a release-mode regression test that builds via
+  the batch path and asserts both exact paths match brute-force ground truth.
+
+---
+
 ## [2.0.4] - 2026-06-13
 
 Production-hardening release. (Crate version line; the `0.5.x` entries below are

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "2.0.5"
+version = "2.0.6"
 edition = "2024"
 authors = ["Sushanth <sushanth@sochdb.dev>"]
 license = "AGPL-3.0-or-later"

--- a/sochdb-client/Cargo.toml
+++ b/sochdb-client/Cargo.toml
@@ -15,10 +15,10 @@ readme = "README.md"
 
 [dependencies]
 # Internal crates
-sochdb-core = { version = "2.0.5", path = "../sochdb-core", features = ["analytics"] }
-sochdb-storage = { version = "2.0.5", path = "../sochdb-storage" }
-sochdb-index = { version = "2.0.5", path = "../sochdb-index" }
-sochdb-query = { version = "2.0.5", path = "../sochdb-query" }
+sochdb-core = { version = "2.0.6", path = "../sochdb-core", features = ["analytics"] }
+sochdb-storage = { version = "2.0.6", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.6", path = "../sochdb-index" }
+sochdb-query = { version = "2.0.6", path = "../sochdb-query" }
 
 # Synchronization
 parking_lot = "0.12"

--- a/sochdb-grpc/Cargo.toml
+++ b/sochdb-grpc/Cargo.toml
@@ -21,14 +21,14 @@ default = []
 async = []
 
 [dependencies]
-sochdb-index = { version = "2.0.5", path = "../sochdb-index" }
-sochdb-core = { version = "2.0.5", path = "../sochdb-core", features = ["analytics"] }
-sochdb-kernel = { version = "2.0.5", path = "../sochdb-kernel" }
-sochdb-storage = { version = "2.0.5", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.6", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.6", path = "../sochdb-core", features = ["analytics"] }
+sochdb-kernel = { version = "2.0.6", path = "../sochdb-kernel" }
+sochdb-storage = { version = "2.0.6", path = "../sochdb-storage" }
 # Real SQL engine for the PostgreSQL wire protocol (DatabasePgExecutor).
-sochdb-query = { version = "2.0.5", path = "../sochdb-query" }
-sochdb-memory = { version = "2.0.5", path = "../sochdb-memory" }
-sochdb-vector = { version = "2.0.5", path = "../sochdb-vector" }
+sochdb-query = { version = "2.0.6", path = "../sochdb-query" }
+sochdb-memory = { version = "2.0.6", path = "../sochdb-memory" }
+sochdb-vector = { version = "2.0.6", path = "../sochdb-vector" }
 
 # gRPC / Protocol Buffers
 tonic = { version = "0.13", features = ["tls-ring", "transport"] }

--- a/sochdb-index/Cargo.toml
+++ b/sochdb-index/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 rustc-hash = "2"  # fast non-crypto hasher for hot-path integer-keyed maps
-sochdb-core = { version = "2.0.5", path = "../sochdb-core" }
+sochdb-core = { version = "2.0.6", path = "../sochdb-core" }
 dashmap = { workspace = true }
 parking_lot = { workspace = true }
 moka = { workspace = true }  # LRU cache for path resolution

--- a/sochdb-index/src/hnsw.rs
+++ b/sochdb-index/src/hnsw.rs
@@ -6870,12 +6870,24 @@ impl HnswIndex {
             QuantizedVector::from_f32(ndarray::Array1::from_vec(query.to_vec()), precision)
         };
 
+        // Fetch each node's vector from vector_store. For batch-inserted nodes
+        // HnswNode.vector is a zero-length dummy (the real vector lives in
+        // vector_store; see insert_batch_contiguous_bulk), so reading
+        // entry.value().vector directly feeds an empty slice to the
+        // fixed-dimension SIMD distance kernels -> out-of-bounds read / SIGSEGV.
+        // Every other search path uses this same vector_store.get(...).unwrap_or
+        // accessor; search_exact must too.
+        let vector_store = self.vector_store.read();
         let mut distances: Vec<(u128, f32)> = self
             .nodes
             .iter()
             .map(|entry| {
                 let id = *entry.key();
-                let distance = self.calculate_distance(&query_quantized, &entry.value().vector);
+                let node = entry.value();
+                let node_vector = vector_store
+                    .get(node.vector_index as usize)
+                    .unwrap_or(&node.vector);
+                let distance = self.calculate_distance(&query_quantized, node_vector);
                 (id, distance)
             })
             .collect();
@@ -6934,6 +6946,12 @@ impl HnswIndex {
         // Collect node refs into a Vec so Rayon can partition them
         let node_entries: Vec<_> = self.nodes.iter().collect();
 
+        // Real vectors live in vector_store for batch-inserted nodes (HnswNode.vector
+        // is a zero-length dummy there). Borrow it as a slice the parallel closure can
+        // share; reading entry.value().vector directly would yield empty vectors.
+        let vector_store_guard = self.vector_store.read();
+        let vector_store: &[QuantizedVector] = &vector_store_guard;
+
         // Parallel fold: each thread builds a local top-k heap, then reduce merges them
         let top_k: Vec<(u128, f64)> = node_entries
             .par_iter()
@@ -6941,7 +6959,10 @@ impl HnswIndex {
                 || BinaryHeap::<(OrderedFloat<f64>, u128)>::with_capacity(k + 1),
                 |mut heap, entry| {
                     let id = *entry.key();
-                    let node_vec = &entry.value().vector;
+                    let node = entry.value();
+                    let node_vec = vector_store
+                        .get(node.vector_index as usize)
+                        .unwrap_or(&node.vector);
 
                     // Get f32 slice without allocation
                     let node_f32_owned;

--- a/sochdb-index/tests/search_exact_crash.rs
+++ b/sochdb-index/tests/search_exact_crash.rs
@@ -1,0 +1,83 @@
+// Regression test: vector_search_exact() segfaults via the SDK on 768-d cosine
+// indexes. Reproduces against the core to confirm whether current source crashes.
+// MUST be run in --release to match the shipped dylib (debug_assert!s in the inline
+// SIMD kernels mask the out-of-bounds read in debug builds).
+
+use sochdb_index::hnsw::{HnswConfig, HnswIndex};
+
+fn norm(mut v: Vec<f32>) -> Vec<f32> {
+    let n = v.iter().map(|x| x * x).sum::<f32>().sqrt().max(1e-9);
+    for x in &mut v {
+        *x /= n;
+    }
+    v
+}
+
+#[test]
+fn search_exact_does_not_crash_768_cosine_default() {
+    let dim = 768usize;
+    let index = HnswIndex::new(dim, HnswConfig::default()); // Cosine + F32 + normalize_at_ingest
+
+    // Deterministic pseudo-random normalized vectors.
+    let mut seed = 0x1234_5678u64;
+    let mut rnd = || {
+        seed ^= seed << 13;
+        seed ^= seed >> 7;
+        seed ^= seed << 17;
+        (seed as f32 / u64::MAX as f32) - 0.5
+    };
+
+    // Insert via the BATCH-CONTIGUOUS path the SDK actually uses (hnsw_insert_batch ->
+    // insert_batch_contiguous). This exceeds the scaffold threshold so most nodes go
+    // through the bulk path, where HnswNode.vector is left as a zero-length dummy and
+    // the real vectors live in vector_store. search_exact reading node.vector directly
+    // then feeds an empty slice to the fixed-768 SIMD kernel -> OOB read.
+    let n = 2000usize;
+    let mut ids = Vec::with_capacity(n);
+    let mut flat = Vec::with_capacity(n * dim);
+    for i in 0..n {
+        ids.push(i as u128);
+        flat.extend(norm((0..dim).map(|_| rnd()).collect::<Vec<f32>>()));
+    }
+    let inserted = index
+        .insert_batch_contiguous(&ids, &flat, dim)
+        .expect("batch insert failed");
+    assert_eq!(inserted, n);
+
+    let q = norm((0..dim).map(|_| rnd()).collect::<Vec<f32>>());
+
+    // Ground truth: brute-force cosine over the SAME vectors (normalized -> 1 - dot).
+    let mut truth: Vec<(u128, f32)> = (0..n)
+        .map(|i| {
+            let base = i * dim;
+            let dot: f32 = (0..dim).map(|d| q[d] * flat[base + d]).sum();
+            (i as u128, 1.0 - dot)
+        })
+        .collect();
+    truth.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+    let truth_top: std::collections::HashSet<u128> = truth[..10].iter().map(|(id, _)| *id).collect();
+
+    // This is the call that segfaults via the SDK (hnsw_search_exact -> search_exact).
+    let res = index.search_exact(&q, 10).expect("search_exact failed");
+    assert_eq!(res.len(), 10, "expected 10 exact neighbors");
+    // Correctness: search_exact must return the TRUE nearest neighbors (not the
+    // garbage it returned when it read the empty HnswNode.vector dummy).
+    let got: std::collections::HashSet<u128> = res.iter().map(|(id, _)| *id).collect();
+    let overlap = got.intersection(&truth_top).count();
+    assert!(
+        overlap >= 9,
+        "search_exact must match brute-force ground truth (overlap {overlap}/10): got {got:?}"
+    );
+
+    // The f64 variant must also read real vectors (it returned empty-vector garbage before).
+    let res_f64 = index.search_exact_f64(&q, 10).expect("search_exact_f64 failed");
+    let got_f64: std::collections::HashSet<u128> = res_f64.iter().map(|(id, _)| *id).collect();
+    assert!(
+        got_f64.intersection(&truth_top).count() >= 9,
+        "search_exact_f64 must match ground truth: got {got_f64:?}"
+    );
+
+    // Sanity: approximate search on the same index works (control).
+    let res2 = index.search(&q, 10).expect("search failed");
+    assert_eq!(res2.len(), 10);
+}

--- a/sochdb-kernel/Cargo.toml
+++ b/sochdb-kernel/Cargo.toml
@@ -14,7 +14,7 @@ wasm-plugins = ["wasmtime", "toml"]
 
 [dependencies]
 # Minimal dependencies - only what's needed for ACID core
-sochdb-core = { version = "2.0.5", path = "../sochdb-core" }
+sochdb-core = { version = "2.0.6", path = "../sochdb-core" }
 thiserror = { workspace = true }
 parking_lot = "0.12"
 crossbeam-channel = "0.5"

--- a/sochdb-mcp/Cargo.toml
+++ b/sochdb-mcp/Cargo.toml
@@ -35,9 +35,9 @@ toon-format = { version = "0.4", default-features = false }
 fastembed = { version = "4", optional = true }
 
 # SochDB crates
-sochdb = { version = "2.0.5", path = "../sochdb-client", features = ["embedded"] }
-sochdb-core = { version = "2.0.5", path = "../sochdb-core" }
-sochdb-query = { version = "2.0.5", path = "../sochdb-query" }
+sochdb = { version = "2.0.6", path = "../sochdb-client", features = ["embedded"] }
+sochdb-core = { version = "2.0.6", path = "../sochdb-core" }
+sochdb-query = { version = "2.0.6", path = "../sochdb-query" }
 
 # Minimal additional deps
 tracing = "0.1"

--- a/sochdb-memory/Cargo.toml
+++ b/sochdb-memory/Cargo.toml
@@ -8,10 +8,10 @@ repository.workspace = true
 description = "Bi-temporal agent memory layer with write-time lexical recall"
 
 [dependencies]
-sochdb-core = { version = "2.0.5", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.5", path = "../sochdb-storage", features = ["embedded-sync"] }
-sochdb-query = { version = "2.0.5", path = "../sochdb-query" }
-sochdb-vector = { version = "2.0.5", path = "../sochdb-vector" }
+sochdb-core = { version = "2.0.6", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.6", path = "../sochdb-storage", features = ["embedded-sync"] }
+sochdb-query = { version = "2.0.6", path = "../sochdb-query" }
+sochdb-vector = { version = "2.0.6", path = "../sochdb-vector" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/sochdb-plugin-logging/Cargo.toml
+++ b/sochdb-plugin-logging/Cargo.toml
@@ -6,7 +6,7 @@ description = "JSON structured logging plugin for SochDB"
 license.workspace = true
 
 [dependencies]
-sochdb-kernel = { version = "2.0.5", path = "../sochdb-kernel" }
+sochdb-kernel = { version = "2.0.6", path = "../sochdb-kernel" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"

--- a/sochdb-python/Cargo.toml
+++ b/sochdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sochdb-python"
-version = "2.0.5"
+version = "2.0.6"
 edition = "2024"
 authors = ["Sushanth <sushanth@sochdb.dev>"]
 license = "AGPL-3.0-or-later"

--- a/sochdb-query/Cargo.toml
+++ b/sochdb-query/Cargo.toml
@@ -22,9 +22,9 @@ default = []
 experimental = []
 
 [dependencies]
-sochdb-core = { version = "2.0.5", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.5", path = "../sochdb-storage" }
-sochdb-index = { version = "2.0.5", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.6", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.6", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.6", path = "../sochdb-index" }
 ndarray = "0.15"
 rayon = "1.10" # Parallel partitioned GROUP BY aggregation
 thiserror = { workspace = true }

--- a/sochdb-storage/Cargo.toml
+++ b/sochdb-storage/Cargo.toml
@@ -33,8 +33,8 @@ embedded-sync = []
 experimental = []
 
 [dependencies]
-sochdb-core = { version = "2.0.5", path = "../sochdb-core" }
-sochdb-index = { version = "2.0.5", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.6", path = "../sochdb-core" }
+sochdb-index = { version = "2.0.6", path = "../sochdb-index" }
 # Tokio is optional - only included when "async" feature is enabled
 tokio = { version = "1.35", features = ["sync", "time", "macros", "rt"], optional = true }
 serde = { workspace = true }

--- a/sochdb-tools/Cargo.toml
+++ b/sochdb-tools/Cargo.toml
@@ -19,10 +19,10 @@ name = "sochdb"
 path = "src/cli.rs"
 
 [dependencies]
-sochdb-index = { version = "2.0.5", path = "../sochdb-index" }
-sochdb-core = { version = "2.0.5", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.5", path = "../sochdb-storage" }
-sochdb-query = { version = "2.0.5", path = "../sochdb-query" }
+sochdb-index = { version = "2.0.6", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.6", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.6", path = "../sochdb-storage" }
+sochdb-query = { version = "2.0.6", path = "../sochdb-query" }
 
 # CLI
 clap = { version = "4.5", features = ["derive", "color", "env"] }

--- a/sochdb-vector/Cargo.toml
+++ b/sochdb-vector/Cargo.toml
@@ -12,9 +12,9 @@ path = "src/lib.rs"
 
 [dependencies]
 # SochDB dependencies
-sochdb-core = { version = "2.0.5", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.5", path = "../sochdb-storage" }
-sochdb-index = { version = "2.0.5", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.6", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.6", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.6", path = "../sochdb-index" }
 
 # Memory mapping for segment files
 memmap2 = "0.9"


### PR DESCRIPTION
…ch-inserted nodes

search_exact / search_exact_f64 read each node's vector via entry.value().vector directly. For nodes added through the batch-contiguous bulk path, HnswNode.vector is a zero-length dummy (the real vector lives in vector_store), so the empty slice was fed to the fixed-dimension SIMD distance kernels -> out-of-bounds read -> SIGSEGV (KERN_INVALID_ADDRESS at 0x4). Every other search path already fetches the vector via vector_store.get(node.vector_index).unwrap_or(&node.vector); both exact paths now do the same.

Reproduces 100% through the Python SDK (vector_search_exact after a >scaffold-size insert_batch); was entirely untested. Adds a release-mode regression test that builds via insert_batch_contiguous and asserts both exact paths match brute-force ground truth.