### PR TITLE
chore(release): bump version to 2.0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "2.0.6"
+version = "2.0.7"
 edition = "2024"
 authors = ["Sushanth <sushanth@sochdb.dev>"]
 license = "AGPL-3.0-or-later"

--- a/deploy/helm/sochdb/Chart.yaml
+++ b/deploy/helm/sochdb/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sochdb
 description: SochDB - LLM-Optimized Embedded Database for Kubernetes
 type: application
-version: 2.0.5
-appVersion: "2.0.5"
+version: 2.0.7
+appVersion: "2.0.7"
 keywords:
   - database
   - llm

--- a/deploy/helm/sochdb/values-minikube.yaml
+++ b/deploy/helm/sochdb/values-minikube.yaml
@@ -3,7 +3,7 @@
 
 image:
   repository: sochdb/sochdb-grpc
-  tag: "2.0.5"
+  tag: "2.0.7"
   pullPolicy: Never  # Use locally built image in minikube
 
 replicaCount: 1

--- a/deploy/marketplace/aws/product.yaml
+++ b/deploy/marketplace/aws/product.yaml
@@ -13,8 +13,8 @@
 # === Image Publishing ===
 # Push to AWS Marketplace ECR:
 #   aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin <marketplace-ecr>
-#   docker tag sochdb/sochdb-grpc:latest <marketplace-ecr>/sochdb-grpc:2.0.5
-#   docker push <marketplace-ecr>/sochdb-grpc:2.0.5
+#   docker tag sochdb/sochdb-grpc:latest <marketplace-ecr>/sochdb-grpc:2.0.7
+#   docker push <marketplace-ecr>/sochdb-grpc:2.0.7
 
 # === Metering Integration ===
 # For paid plans, the SochDB server integrates with AWS Marketplace Metering API:
@@ -53,7 +53,7 @@ delivery:
   container_images:
     - name: sochdb-grpc
       repository: "<marketplace-ecr>/sochdb-grpc"
-      tag: "2.0.5"
+      tag: "2.0.7"
 
 pricing_models:
   - type: free

--- a/deploy/marketplace/azure/offer.yaml
+++ b/deploy/marketplace/azure/offer.yaml
@@ -14,8 +14,8 @@
 # === Image Publishing ===
 # Push to ACR (linked to Partner Center):
 #   az acr login --name sochdbregistry
-#   docker tag sochdb/sochdb-grpc:latest sochdbregistry.azurecr.io/sochdb-grpc:2.0.5
-#   docker push sochdbregistry.azurecr.io/sochdb-grpc:2.0.5
+#   docker tag sochdb/sochdb-grpc:latest sochdbregistry.azurecr.io/sochdb-grpc:2.0.7
+#   docker push sochdbregistry.azurecr.io/sochdb-grpc:2.0.7
 
 # === CNAB Bundle Structure ===
 # The Helm chart at deploy/helm/sochdb/ is packaged as a CNAB bundle:
@@ -46,7 +46,7 @@ description: |
   - Non-root container, read-only rootfs, mTLS support
 
   Deploy on any AKS cluster with:
-    helm install sochdb oci://sochdbregistry.azurecr.io/helm/sochdb --version 2.0.5
+    helm install sochdb oci://sochdbregistry.azurecr.io/helm/sochdb --version 2.0.7
 
 plans:
   - plan_id: free

--- a/deploy/marketplace/gcp/schema.yaml
+++ b/deploy/marketplace/gcp/schema.yaml
@@ -19,18 +19,18 @@
 # === Image Publishing ===
 # Push to Artifact Registry:
 #   gcloud auth configure-docker us-docker.pkg.dev
-#   docker tag sochdb/sochdb-grpc:latest us-docker.pkg.dev/sochdb-public/sochdb/sochdb-grpc:2.0.5
-#   docker push us-docker.pkg.dev/sochdb-public/sochdb/sochdb-grpc:2.0.5
+#   docker tag sochdb/sochdb-grpc:latest us-docker.pkg.dev/sochdb-public/sochdb/sochdb-grpc:2.0.7
+#   docker push us-docker.pkg.dev/sochdb-public/sochdb/sochdb-grpc:2.0.7
 
 # === Application Schema ===
 # GCP Marketplace apps use a schema.yaml to define parameters:
 x-google-marketplace:
   schemaVersion: v2
   applicationApiVersion: v1beta1
-  publishedVersion: "2.0.5"
+  publishedVersion: "2.0.7"
   publishedVersionMetadata:
     releaseNote: >
-      SochDB 2.0.5 — MultiShardHnswIndex production readiness,
+      SochDB 2.0.7 — MultiShardHnswIndex production readiness,
       Context Queries, token budgeting, gRPC + REST API.
   images:
     sochdb-grpc:

--- a/sochdb-client/Cargo.toml
+++ b/sochdb-client/Cargo.toml
@@ -15,10 +15,10 @@ readme = "README.md"
 
 [dependencies]
 # Internal crates
-sochdb-core = { version = "2.0.6", path = "../sochdb-core", features = ["analytics"] }
-sochdb-storage = { version = "2.0.6", path = "../sochdb-storage" }
-sochdb-index = { version = "2.0.6", path = "../sochdb-index" }
-sochdb-query = { version = "2.0.6", path = "../sochdb-query" }
+sochdb-core = { version = "2.0.7", path = "../sochdb-core", features = ["analytics"] }
+sochdb-storage = { version = "2.0.7", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.7", path = "../sochdb-index" }
+sochdb-query = { version = "2.0.7", path = "../sochdb-query" }
 
 # Synchronization
 parking_lot = "0.12"

--- a/sochdb-grpc/Cargo.toml
+++ b/sochdb-grpc/Cargo.toml
@@ -21,14 +21,14 @@ default = []
 async = []
 
 [dependencies]
-sochdb-index = { version = "2.0.6", path = "../sochdb-index" }
-sochdb-core = { version = "2.0.6", path = "../sochdb-core", features = ["analytics"] }
-sochdb-kernel = { version = "2.0.6", path = "../sochdb-kernel" }
-sochdb-storage = { version = "2.0.6", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.7", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.7", path = "../sochdb-core", features = ["analytics"] }
+sochdb-kernel = { version = "2.0.7", path = "../sochdb-kernel" }
+sochdb-storage = { version = "2.0.7", path = "../sochdb-storage" }
 # Real SQL engine for the PostgreSQL wire protocol (DatabasePgExecutor).
-sochdb-query = { version = "2.0.6", path = "../sochdb-query" }
-sochdb-memory = { version = "2.0.6", path = "../sochdb-memory" }
-sochdb-vector = { version = "2.0.6", path = "../sochdb-vector" }
+sochdb-query = { version = "2.0.7", path = "../sochdb-query" }
+sochdb-memory = { version = "2.0.7", path = "../sochdb-memory" }
+sochdb-vector = { version = "2.0.7", path = "../sochdb-vector" }
 
 # gRPC / Protocol Buffers
 tonic = { version = "0.13", features = ["tls-ring", "transport"] }

--- a/sochdb-index/Cargo.toml
+++ b/sochdb-index/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 rustc-hash = "2"  # fast non-crypto hasher for hot-path integer-keyed maps
-sochdb-core = { version = "2.0.6", path = "../sochdb-core" }
+sochdb-core = { version = "2.0.7", path = "../sochdb-core" }
 dashmap = { workspace = true }
 parking_lot = { workspace = true }
 moka = { workspace = true }  # LRU cache for path resolution

--- a/sochdb-index/src/hnsw.rs
+++ b/sochdb-index/src/hnsw.rs
@@ -5113,7 +5113,7 @@ impl HnswIndex {
         let candidates = self.search_layer_zero_lock(
             query,
             &curr_nearest,
-            self.effective_ef_search().max(k),
+            self.beam_for(k),
             0,
             &vector_store,
             &internal_nodes,
@@ -5221,7 +5221,7 @@ impl HnswIndex {
         let candidates = self.search_layer_zero_flat(
             query,
             &curr_nearest,
-            self.effective_ef_search().max(k),
+            self.beam_for(k),
             &vector_store,
             &internal_nodes,
             &flat_neighbors,
@@ -5557,7 +5557,10 @@ impl HnswIndex {
     ) -> Vec<SearchCandidate> {
         // Rec 9: local id→dense cache eliminates DashMap from hot loop
         let mut id_to_dense: rustc_hash::FxHashMap<u128, u32> =
-            rustc_hash::FxHashMap::with_capacity_and_hasher(num_to_return * 2, rustc_hash::FxBuildHasher::default());
+            rustc_hash::FxHashMap::with_capacity_and_hasher(
+                num_to_return * 2,
+                rustc_hash::FxBuildHasher::default(),
+            );
 
         with_scratch_buffers(|scratch| {
             // Initialize with entry points — resolve dense via internal_nodes or DashMap fallback
@@ -5893,7 +5896,7 @@ impl HnswIndex {
         let candidates = self.search_layer_ref(
             &query_quantized,
             &curr_nearest,
-            self.effective_ef_search().max(k),
+            self.beam_for(k),
             0,
             &vector_store,
             &internal_nodes,
@@ -6056,12 +6059,8 @@ impl HnswIndex {
                 curr_nearest = self.search_layer_concurrent(query_quantized, &curr_nearest, 1, lc);
             }
 
-            let candidates = self.search_layer_concurrent(
-                query_quantized,
-                &curr_nearest,
-                self.effective_ef_search().max(k),
-                0,
-            );
+            let candidates =
+                self.search_layer_concurrent(query_quantized, &curr_nearest, self.beam_for(k), 0);
 
             per_query_candidates.push(candidates);
         }
@@ -6664,7 +6663,10 @@ impl HnswIndex {
         let mut results: BinaryHeap<Reverse<SearchCandidate>> = BinaryHeap::new();
         let mut visited: HashSet<u32> = HashSet::with_capacity(ef.saturating_mul(8).max(64));
         let mut id_to_dense: rustc_hash::FxHashMap<u128, u32> =
-            rustc_hash::FxHashMap::with_capacity_and_hasher(ef.saturating_mul(8).max(64), rustc_hash::FxBuildHasher::default());
+            rustc_hash::FxHashMap::with_capacity_and_hasher(
+                ef.saturating_mul(8).max(64),
+                rustc_hash::FxBuildHasher::default(),
+            );
 
         let use_normalized = self.use_normalized_fast_path();
 
@@ -7123,6 +7125,19 @@ impl HnswIndex {
         self.adaptive_ef.load(AtomicOrdering::Relaxed)
     }
 
+    /// Per-query layer-0 search beam width, capped to `max(2k, EF_FLOOR)`.
+    ///
+    /// Recall@k plateaus once the beam exceeds ~2k, so a flat ef_search (e.g.
+    /// 500) wastes ~1.7-2.7x search latency for typical small k at no recall
+    /// gain. The `.max(k)` keeps large-k callers (e.g. filtered over-fetch that
+    /// requests many candidates) at a wide-enough beam, so this never starves
+    /// them. `effective_ef_search()` is still honored as the upper bound.
+    #[inline]
+    pub(crate) fn beam_for(&self, k: usize) -> usize {
+        const EF_FLOOR: usize = 64;
+        self.effective_ef_search().min((2 * k).max(EF_FLOOR)).max(k)
+    }
+
     /// Get the current effective ef_search value (honors runtime overrides).
     pub fn get_ef_search(&self) -> usize {
         self.effective_ef_search()
@@ -7160,7 +7175,10 @@ impl HnswIndex {
     ) -> Vec<SearchCandidate> {
         // Rec 9: local id→dense cache eliminates DashMap from hot loop
         let mut id_to_dense: rustc_hash::FxHashMap<u128, u32> =
-            rustc_hash::FxHashMap::with_capacity_and_hasher(num_to_return * 2, rustc_hash::FxBuildHasher::default());
+            rustc_hash::FxHashMap::with_capacity_and_hasher(
+                num_to_return * 2,
+                rustc_hash::FxBuildHasher::default(),
+            );
 
         with_scratch_buffers(|scratch| {
             for ep in entry_points {
@@ -7355,7 +7373,10 @@ impl HnswIndex {
         let internal_nodes = self.internal_nodes.read_recursive();
         // Rec 9: local id→dense cache eliminates DashMap from hot loop
         let mut id_to_dense: rustc_hash::FxHashMap<u128, u32> =
-            rustc_hash::FxHashMap::with_capacity_and_hasher(num_to_return * 2, rustc_hash::FxBuildHasher::default());
+            rustc_hash::FxHashMap::with_capacity_and_hasher(
+                num_to_return * 2,
+                rustc_hash::FxBuildHasher::default(),
+            );
 
         with_scratch_buffers(|scratch| {
             for ep in entry_points {

--- a/sochdb-index/tests/search_exact_crash.rs
+++ b/sochdb-index/tests/search_exact_crash.rs
@@ -55,7 +55,8 @@ fn search_exact_does_not_crash_768_cosine_default() {
         })
         .collect();
     truth.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
-    let truth_top: std::collections::HashSet<u128> = truth[..10].iter().map(|(id, _)| *id).collect();
+    let truth_top: std::collections::HashSet<u128> =
+        truth[..10].iter().map(|(id, _)| *id).collect();
 
     // This is the call that segfaults via the SDK (hnsw_search_exact -> search_exact).
     let res = index.search_exact(&q, 10).expect("search_exact failed");
@@ -70,7 +71,9 @@ fn search_exact_does_not_crash_768_cosine_default() {
     );
 
     // The f64 variant must also read real vectors (it returned empty-vector garbage before).
-    let res_f64 = index.search_exact_f64(&q, 10).expect("search_exact_f64 failed");
+    let res_f64 = index
+        .search_exact_f64(&q, 10)
+        .expect("search_exact_f64 failed");
     let got_f64: std::collections::HashSet<u128> = res_f64.iter().map(|(id, _)| *id).collect();
     assert!(
         got_f64.intersection(&truth_top).count() >= 9,

--- a/sochdb-kernel/Cargo.toml
+++ b/sochdb-kernel/Cargo.toml
@@ -14,7 +14,7 @@ wasm-plugins = ["wasmtime", "toml"]
 
 [dependencies]
 # Minimal dependencies - only what's needed for ACID core
-sochdb-core = { version = "2.0.6", path = "../sochdb-core" }
+sochdb-core = { version = "2.0.7", path = "../sochdb-core" }
 thiserror = { workspace = true }
 parking_lot = "0.12"
 crossbeam-channel = "0.5"

--- a/sochdb-mcp/Cargo.toml
+++ b/sochdb-mcp/Cargo.toml
@@ -35,9 +35,9 @@ toon-format = { version = "0.4", default-features = false }
 fastembed = { version = "4", optional = true }
 
 # SochDB crates
-sochdb = { version = "2.0.6", path = "../sochdb-client", features = ["embedded"] }
-sochdb-core = { version = "2.0.6", path = "../sochdb-core" }
-sochdb-query = { version = "2.0.6", path = "../sochdb-query" }
+sochdb = { version = "2.0.7", path = "../sochdb-client", features = ["embedded"] }
+sochdb-core = { version = "2.0.7", path = "../sochdb-core" }
+sochdb-query = { version = "2.0.7", path = "../sochdb-query" }
 
 # Minimal additional deps
 tracing = "0.1"

--- a/sochdb-memory/Cargo.toml
+++ b/sochdb-memory/Cargo.toml
@@ -8,10 +8,10 @@ repository.workspace = true
 description = "Bi-temporal agent memory layer with write-time lexical recall"
 
 [dependencies]
-sochdb-core = { version = "2.0.6", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.6", path = "../sochdb-storage", features = ["embedded-sync"] }
-sochdb-query = { version = "2.0.6", path = "../sochdb-query" }
-sochdb-vector = { version = "2.0.6", path = "../sochdb-vector" }
+sochdb-core = { version = "2.0.7", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.7", path = "../sochdb-storage", features = ["embedded-sync"] }
+sochdb-query = { version = "2.0.7", path = "../sochdb-query" }
+sochdb-vector = { version = "2.0.7", path = "../sochdb-vector" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/sochdb-plugin-logging/Cargo.toml
+++ b/sochdb-plugin-logging/Cargo.toml
@@ -6,7 +6,7 @@ description = "JSON structured logging plugin for SochDB"
 license.workspace = true
 
 [dependencies]
-sochdb-kernel = { version = "2.0.6", path = "../sochdb-kernel" }
+sochdb-kernel = { version = "2.0.7", path = "../sochdb-kernel" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"

--- a/sochdb-python/Cargo.toml
+++ b/sochdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sochdb-python"
-version = "2.0.6"
+version = "2.0.7"
 edition = "2024"
 authors = ["Sushanth <sushanth@sochdb.dev>"]
 license = "AGPL-3.0-or-later"

--- a/sochdb-python/pyproject.toml
+++ b/sochdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "sochdb"
-version = "2.0.5"
+version = "2.0.7"
 description = "SochDB - AI-native database with zero-copy vector search via PyO3"
 readme = "README.md"
 license = {text = "AGPL-3.0-or-later"}

--- a/sochdb-python/python/sochdb/__init__.py
+++ b/sochdb-python/python/sochdb/__init__.py
@@ -70,7 +70,7 @@ __all__ = [
     "bulk_build_index",
 ]
 
-__version__ = "2.0.5"
+__version__ = "2.0.7"
 
 
 def _check_native():

--- a/sochdb-query/Cargo.toml
+++ b/sochdb-query/Cargo.toml
@@ -22,9 +22,9 @@ default = []
 experimental = []
 
 [dependencies]
-sochdb-core = { version = "2.0.6", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.6", path = "../sochdb-storage" }
-sochdb-index = { version = "2.0.6", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.7", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.7", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.7", path = "../sochdb-index" }
 ndarray = "0.15"
 rayon = "1.10" # Parallel partitioned GROUP BY aggregation
 thiserror = { workspace = true }

--- a/sochdb-sdk/node/package.json
+++ b/sochdb-sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sochdb/sdk",
-  "version": "2.0.5",
+  "version": "2.0.7",
   "description": "SochDB Node.js SDK — Thin gRPC client for the LLM-optimized database",
   "main": "dist/client.js",
   "types": "dist/client.d.ts",

--- a/sochdb-sdk/python/pyproject.toml
+++ b/sochdb-sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sochdb-sdk"
-version = "2.0.5"
+version = "2.0.7"
 description = "SochDB Python SDK — Thin gRPC client for the LLM-optimized database"
 requires-python = ">=3.9"
 license = {text = "AGPL-3.0-or-later"}

--- a/sochdb-sdk/python/sochdb_sdk/__init__.py
+++ b/sochdb-sdk/python/sochdb_sdk/__init__.py
@@ -11,7 +11,7 @@ from .client import (
     NamespaceClient,
 )
 
-__version__ = "2.0.5"
+__version__ = "2.0.7"
 __all__ = [
     "SochDB",
     "VectorClient",

--- a/sochdb-sdk/python/sochdb_sdk/client.py
+++ b/sochdb-sdk/python/sochdb_sdk/client.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import grpc
 from typing import Any, Dict, List, Optional, Sequence
 
-__version__ = "2.0.5"
+__version__ = "2.0.7"
 __all__ = ["SochDB", "VectorClient", "KvClient", "GraphClient", "SqlClient"]
 
 

--- a/sochdb-storage/Cargo.toml
+++ b/sochdb-storage/Cargo.toml
@@ -33,8 +33,8 @@ embedded-sync = []
 experimental = []
 
 [dependencies]
-sochdb-core = { version = "2.0.6", path = "../sochdb-core" }
-sochdb-index = { version = "2.0.6", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.7", path = "../sochdb-core" }
+sochdb-index = { version = "2.0.7", path = "../sochdb-index" }
 # Tokio is optional - only included when "async" feature is enabled
 tokio = { version = "1.35", features = ["sync", "time", "macros", "rt"], optional = true }
 serde = { workspace = true }

--- a/sochdb-tools/Cargo.toml
+++ b/sochdb-tools/Cargo.toml
@@ -19,10 +19,10 @@ name = "sochdb"
 path = "src/cli.rs"
 
 [dependencies]
-sochdb-index = { version = "2.0.6", path = "../sochdb-index" }
-sochdb-core = { version = "2.0.6", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.6", path = "../sochdb-storage" }
-sochdb-query = { version = "2.0.6", path = "../sochdb-query" }
+sochdb-index = { version = "2.0.7", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.7", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.7", path = "../sochdb-storage" }
+sochdb-query = { version = "2.0.7", path = "../sochdb-query" }
 
 # CLI
 clap = { version = "4.5", features = ["derive", "color", "env"] }

--- a/sochdb-vector/Cargo.toml
+++ b/sochdb-vector/Cargo.toml
@@ -12,9 +12,9 @@ path = "src/lib.rs"
 
 [dependencies]
 # SochDB dependencies
-sochdb-core = { version = "2.0.6", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.6", path = "../sochdb-storage" }
-sochdb-index = { version = "2.0.6", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.7", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.7", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.7", path = "../sochdb-index" }
 
 # Memory mapping for segment files
 memmap2 = "0.9"


### PR DESCRIPTION
- Bump workspace version 2.0.6 -> 2.0.7 (Cargo.toml, deploy manifests, SDK manifests, path-dep pins)
- Include hnsw.rs change
- Apply cargo fmt to search_exact_crash.rs for CI fmt check