### PR TITLE
Fix/hd7 simd runtime dispatch

### DIFF
--- a/sochdb-index/Cargo.toml
+++ b/sochdb-index/Cargo.toml
@@ -97,3 +97,7 @@ harness = false
 [[bench]]
 name = "perf_regression"
 harness = false
+
+[[bench]]
+name = "recall_latency"
+harness = false

--- a/sochdb-index/benches/recall_latency.rs
+++ b/sochdb-index/benches/recall_latency.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SochDB - LLM-Optimized Embedded Database
+// Copyright (C) 2026 Sushanth Reddy Vanagala (https://github.com/sushanthpy)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Recall@10 + search-latency gate for the HNSW hot path.
+//!
+//! This is the benchmark gate the HD-1 (contiguous vector arena) and HD-3
+//! (single-ownership insert) refactors must pass: a memory-layout change is only
+//! acceptable if it preserves recall@10 while improving (or not regressing) p95
+//! query latency at the embedding dimensions those tasks target (768/1536/3072).
+//!
+//! Unlike the criterion benches, this uses a custom harness so it can report
+//! recall@10 alongside p50/p95/p99 latency in one pass. Vectors are produced by
+//! a seeded xorshift PRNG, so the numbers are reproducible run-to-run.
+//!
+//! Run (in-repo smoke baseline):
+//!     cargo bench -p sochdb-index --bench recall_latency
+//!
+//! Run (the real gate — scale before drawing conclusions; the HD-1 scatter
+//! penalty only surfaces at large N):
+//!     RECALL_N=100000 RECALL_QUERIES=500 cargo bench -p sochdb-index --bench recall_latency
+//!
+//! Note: vectors are uniform-random (no cluster structure), which is a harder
+//! recall regime than real embeddings; treat the absolute recall as a relative
+//! baseline for before/after comparison, not as a production recall figure.
+
+use sochdb_index::hnsw::{DistanceMetric, HnswConfig, HnswIndex};
+use std::time::Instant;
+
+/// Deterministic xorshift64* PRNG — reproducible, no external dependency.
+struct Rng(u64);
+
+impl Rng {
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+
+    /// A float in [-0.5, 0.5).
+    fn unit(&mut self) -> f32 {
+        ((self.next_u64() >> 40) as f32 / (1u64 << 24) as f32) - 0.5
+    }
+}
+
+fn gen_vectors(n: usize, dim: usize, seed: u64) -> Vec<Vec<f32>> {
+    let mut rng = Rng(seed | 1);
+    (0..n)
+        .map(|_| (0..dim).map(|_| rng.unit()).collect())
+        .collect()
+}
+
+/// Cosine distance on raw vectors. Order-equivalent to the index's normalized
+/// cosine, so it is a valid ground truth for recall regardless of normalization.
+fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
+    let (mut dot, mut na, mut nb) = (0.0f32, 0.0f32, 0.0f32);
+    for i in 0..a.len() {
+        dot += a[i] * b[i];
+        na += a[i] * a[i];
+        nb += b[i] * b[i];
+    }
+    if na < 1e-12 || nb < 1e-12 {
+        1.0
+    } else {
+        1.0 - dot / (na.sqrt() * nb.sqrt())
+    }
+}
+
+/// Exhaustive top-k ids by cosine distance (recall ground truth).
+fn brute_force_topk(query: &[f32], data: &[Vec<f32>], k: usize) -> Vec<usize> {
+    let mut scored: Vec<(f32, usize)> = data
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (cosine_distance(query, v), i))
+        .collect();
+    scored.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    scored.into_iter().take(k).map(|(_, i)| i).collect()
+}
+
+fn percentile(sorted: &[f64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let idx = ((p / 100.0) * (sorted.len() as f64 - 1.0)).round() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}
+
+fn main() {
+    let n = env_usize("RECALL_N", 3000);
+    let q = env_usize("RECALL_QUERIES", 100);
+    let k = 10usize;
+    let dims = [768usize, 1536, 3072];
+
+    println!("HNSW recall@{k} + latency gate  (N={n}, queries={q}, metric=Cosine, seeded)\n");
+    println!(
+        "{:>6} {:>10} {:>10} {:>9} {:>9} {:>9} {:>9}",
+        "dim", "recall@10", "build_ms", "p50_us", "p95_us", "p99_us", "mean_us"
+    );
+
+    for &dim in &dims {
+        let data = gen_vectors(n, dim, 0x00C0_FFEE ^ dim as u64);
+        let queries = gen_vectors(q, dim, 0x0000_BEEF ^ dim as u64);
+
+        let config = HnswConfig {
+            metric: DistanceMetric::Cosine,
+            ..Default::default()
+        };
+        let index = HnswIndex::new(dim, config);
+
+        let batch: Vec<(u128, Vec<f32>)> = data
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (i as u128, v.clone()))
+            .collect();
+        let t_build = Instant::now();
+        index.insert_batch(&batch).expect("insert_batch failed");
+        let build_ms = t_build.elapsed().as_secs_f64() * 1000.0;
+
+        let mut latencies_us: Vec<f64> = Vec::with_capacity(q);
+        let (mut hits, mut total) = (0usize, 0usize);
+        for query in &queries {
+            let truth: std::collections::HashSet<usize> =
+                brute_force_topk(query, &data, k).into_iter().collect();
+
+            let t = Instant::now();
+            let res = index.search(query, k).expect("search failed");
+            latencies_us.push(t.elapsed().as_secs_f64() * 1e6);
+
+            hits += res
+                .iter()
+                .filter(|(id, _)| truth.contains(&(*id as usize)))
+                .count();
+            total += truth.len();
+        }
+
+        let recall = hits as f64 / total as f64;
+        latencies_us.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let mean = latencies_us.iter().sum::<f64>() / latencies_us.len().max(1) as f64;
+
+        println!(
+            "{:>6} {:>10.4} {:>10.1} {:>9.1} {:>9.1} {:>9.1} {:>9.1}",
+            dim,
+            recall,
+            build_ms,
+            percentile(&latencies_us, 50.0),
+            percentile(&latencies_us, 95.0),
+            percentile(&latencies_us, 99.0),
+            mean,
+        );
+    }
+}

--- a/sochdb-index/benches/recall_latency.rs
+++ b/sochdb-index/benches/recall_latency.rs
@@ -112,7 +112,13 @@ fn main() {
     let n = env_usize("RECALL_N", 3000);
     let q = env_usize("RECALL_QUERIES", 100);
     let k = 10usize;
-    let dims = [768usize, 1536, 3072];
+    // RECALL_DIMS=768,1536 restricts the dimensions probed (faster iteration);
+    // defaults to the three the HD-1/HD-3 refactors target.
+    let dims: Vec<usize> = std::env::var("RECALL_DIMS")
+        .ok()
+        .map(|s| s.split(',').filter_map(|d| d.trim().parse().ok()).collect())
+        .filter(|v: &Vec<usize>| !v.is_empty())
+        .unwrap_or_else(|| vec![768, 1536, 3072]);
 
     println!("HNSW recall@{k} + latency gate  (N={n}, queries={q}, metric=Cosine, seeded)\n");
     println!(

--- a/sochdb-index/src/hnsw.rs
+++ b/sochdb-index/src/hnsw.rs
@@ -96,6 +96,16 @@ use crate::vector_storage::VectorStorage;
 /// neighbor-list inline size cannot drift from the in-memory one.
 pub(crate) const MAX_M: usize = 64;
 
+// Test-only override that forces `calculate_distance` down the runtime-guarded
+// generic distance path, so the AVX2-absent fallback (see
+// `HnswIndex::dim_specialized_kernels_available`) can be exercised on any host
+// — including AVX2-capable CI runners and aarch64. Thread-local, so it is
+// parallel-test safe; compiled out entirely in non-test builds.
+#[cfg(test)]
+thread_local! {
+    pub(crate) static FORCE_GENERIC_DISTANCE: std::cell::Cell<bool> = std::cell::Cell::new(false);
+}
+
 // ==================== Task #11: Performance Cost Model Types ====================
 
 /// Adaptive performance monitor for automatic parameter optimization
@@ -8130,6 +8140,12 @@ impl HnswIndex {
     /// so the check is a cheap relaxed load after the first call.
     #[inline]
     fn dim_specialized_kernels_available() -> bool {
+        #[cfg(test)]
+        {
+            if FORCE_GENERIC_DISTANCE.with(|f| f.get()) {
+                return false;
+            }
+        }
         #[cfg(target_arch = "x86_64")]
         {
             std::is_x86_feature_detected!("avx2") && std::is_x86_feature_detected!("fma")

--- a/sochdb-index/src/hnsw.rs
+++ b/sochdb-index/src/hnsw.rs
@@ -3369,7 +3369,12 @@ impl HnswIndex {
         // =========================================================================
 
         let existing_nodes = self.nodes.len();
-        let scaffold_threshold = 10 * self.config.max_connections_layer0;
+        // Converged with insert_batch_contiguous (the production ingest path):
+        // a 2*M0 backbone seeds the parallel bulk phase just as well as the old
+        // 10*M0, while moving ~8x fewer inserts through the serialized scaffold
+        // (640 -> 128 at the default M0=64), so most inserts go through the
+        // parallel bulk path. Recall is gate-verified unchanged (recall_latency).
+        let scaffold_threshold = 2 * self.config.max_connections_layer0;
 
         // Only use scaffold if graph is cold (few existing nodes)
         if existing_nodes < scaffold_threshold {

--- a/sochdb-index/src/hnsw.rs
+++ b/sochdb-index/src/hnsw.rs
@@ -8117,6 +8117,29 @@ impl HnswIndex {
         }
     }
 
+    /// Whether the dimension-specialized inline SIMD kernels may be dispatched
+    /// on this host.
+    ///
+    /// The `*_distance_inline_*` kernels call AVX2+FMA intrinsics directly with
+    /// no per-call feature check, so on x86_64 they are sound only when the CPU
+    /// actually advertises `avx2`+`fma`. When it does not, callers must take the
+    /// runtime-guarded generic path instead (`*_quantized` in `vector_quantized`,
+    /// which dispatches through `simd_distance`). On aarch64 the kernels use NEON
+    /// (an architectural baseline) and on other targets a scalar fallback, so
+    /// both are always safe. `std::is_x86_feature_detected!` caches its result,
+    /// so the check is a cheap relaxed load after the first call.
+    #[inline]
+    fn dim_specialized_kernels_available() -> bool {
+        #[cfg(target_arch = "x86_64")]
+        {
+            std::is_x86_feature_detected!("avx2") && std::is_x86_feature_detected!("fma")
+        }
+        #[cfg(not(target_arch = "x86_64"))]
+        {
+            true
+        }
+    }
+
     /// Calculate distance between vectors with inline optimization for common dimensions
     ///
     /// **Task 5 Implementation**: Specialized inline kernels for dimensions [128, 256, 512, 768, 1536]
@@ -8140,83 +8163,90 @@ impl HnswIndex {
 
                 // Inline kernels for most common embedding dimensions
                 // Covers: 128, 256, 384 (MiniLM), 512, 768 (BERT), 1024 (Cohere), 1536 (OpenAI), 3072 (OpenAI large)
-                match (self.config.metric, dim) {
-                    (DistanceMetric::Cosine, 128) => {
-                        return self.cosine_distance_inline_128(a_slice, b_slice);
-                    }
-                    (DistanceMetric::Cosine, 256) => {
-                        return self.cosine_distance_inline_256(a_slice, b_slice);
-                    }
-                    (DistanceMetric::Cosine, 384) => {
-                        return self.cosine_distance_inline_384(a_slice, b_slice);
-                    }
-                    (DistanceMetric::Cosine, 512) => {
-                        return self.cosine_distance_inline_512(a_slice, b_slice);
-                    }
-                    (DistanceMetric::Cosine, 768) => {
-                        return self.cosine_distance_inline_768(a_slice, b_slice);
-                    }
-                    (DistanceMetric::Cosine, 1024) => {
-                        return self.cosine_distance_inline_1024(a_slice, b_slice);
-                    }
-                    (DistanceMetric::Cosine, 1536) => {
-                        return self.cosine_distance_inline_1536(a_slice, b_slice);
-                    }
-                    (DistanceMetric::Cosine, 3072) => {
-                        return self.cosine_distance_inline_3072(a_slice, b_slice);
-                    }
+                //
+                // The inline kernels invoke AVX2+FMA intrinsics unconditionally,
+                // so dispatch to them only when the host supports those features;
+                // otherwise fall through to the runtime-guarded generic path below
+                // (prevents UB / SIGILL on x86_64 CPUs without AVX2+FMA).
+                if Self::dim_specialized_kernels_available() {
+                    match (self.config.metric, dim) {
+                        (DistanceMetric::Cosine, 128) => {
+                            return self.cosine_distance_inline_128(a_slice, b_slice);
+                        }
+                        (DistanceMetric::Cosine, 256) => {
+                            return self.cosine_distance_inline_256(a_slice, b_slice);
+                        }
+                        (DistanceMetric::Cosine, 384) => {
+                            return self.cosine_distance_inline_384(a_slice, b_slice);
+                        }
+                        (DistanceMetric::Cosine, 512) => {
+                            return self.cosine_distance_inline_512(a_slice, b_slice);
+                        }
+                        (DistanceMetric::Cosine, 768) => {
+                            return self.cosine_distance_inline_768(a_slice, b_slice);
+                        }
+                        (DistanceMetric::Cosine, 1024) => {
+                            return self.cosine_distance_inline_1024(a_slice, b_slice);
+                        }
+                        (DistanceMetric::Cosine, 1536) => {
+                            return self.cosine_distance_inline_1536(a_slice, b_slice);
+                        }
+                        (DistanceMetric::Cosine, 3072) => {
+                            return self.cosine_distance_inline_3072(a_slice, b_slice);
+                        }
 
-                    (DistanceMetric::Euclidean, 128) => {
-                        return self.l2_distance_inline_128(a_slice, b_slice);
-                    }
-                    (DistanceMetric::Euclidean, 256) => {
-                        return self.l2_distance_inline_256(a_slice, b_slice);
-                    }
-                    (DistanceMetric::Euclidean, 384) => {
-                        return self.l2_distance_inline_384(a_slice, b_slice);
-                    }
-                    (DistanceMetric::Euclidean, 512) => {
-                        return self.l2_distance_inline_512(a_slice, b_slice);
-                    }
-                    (DistanceMetric::Euclidean, 768) => {
-                        return self.l2_distance_inline_768(a_slice, b_slice);
-                    }
-                    (DistanceMetric::Euclidean, 1024) => {
-                        return self.l2_distance_inline_1024(a_slice, b_slice);
-                    }
-                    (DistanceMetric::Euclidean, 1536) => {
-                        return self.l2_distance_inline_1536(a_slice, b_slice);
-                    }
-                    (DistanceMetric::Euclidean, 3072) => {
-                        return self.l2_distance_inline_3072(a_slice, b_slice);
-                    }
+                        (DistanceMetric::Euclidean, 128) => {
+                            return self.l2_distance_inline_128(a_slice, b_slice);
+                        }
+                        (DistanceMetric::Euclidean, 256) => {
+                            return self.l2_distance_inline_256(a_slice, b_slice);
+                        }
+                        (DistanceMetric::Euclidean, 384) => {
+                            return self.l2_distance_inline_384(a_slice, b_slice);
+                        }
+                        (DistanceMetric::Euclidean, 512) => {
+                            return self.l2_distance_inline_512(a_slice, b_slice);
+                        }
+                        (DistanceMetric::Euclidean, 768) => {
+                            return self.l2_distance_inline_768(a_slice, b_slice);
+                        }
+                        (DistanceMetric::Euclidean, 1024) => {
+                            return self.l2_distance_inline_1024(a_slice, b_slice);
+                        }
+                        (DistanceMetric::Euclidean, 1536) => {
+                            return self.l2_distance_inline_1536(a_slice, b_slice);
+                        }
+                        (DistanceMetric::Euclidean, 3072) => {
+                            return self.l2_distance_inline_3072(a_slice, b_slice);
+                        }
 
-                    (DistanceMetric::DotProduct, 128) => {
-                        return -self.dot_product_inline_128(a_slice, b_slice);
-                    }
-                    (DistanceMetric::DotProduct, 256) => {
-                        return -self.dot_product_inline_256(a_slice, b_slice);
-                    }
-                    (DistanceMetric::DotProduct, 384) => {
-                        return -self.dot_product_inline_384(a_slice, b_slice);
-                    }
-                    (DistanceMetric::DotProduct, 512) => {
-                        return -self.dot_product_inline_512(a_slice, b_slice);
-                    }
-                    (DistanceMetric::DotProduct, 768) => {
-                        return -self.dot_product_inline_768(a_slice, b_slice);
-                    }
-                    (DistanceMetric::DotProduct, 1024) => {
-                        return -self.dot_product_inline_1024(a_slice, b_slice);
-                    }
-                    (DistanceMetric::DotProduct, 1536) => {
-                        return -self.dot_product_inline_1536(a_slice, b_slice);
-                    }
-                    (DistanceMetric::DotProduct, 3072) => {
-                        return -self.dot_product_inline_3072(a_slice, b_slice);
-                    }
+                        (DistanceMetric::DotProduct, 128) => {
+                            return -self.dot_product_inline_128(a_slice, b_slice);
+                        }
+                        (DistanceMetric::DotProduct, 256) => {
+                            return -self.dot_product_inline_256(a_slice, b_slice);
+                        }
+                        (DistanceMetric::DotProduct, 384) => {
+                            return -self.dot_product_inline_384(a_slice, b_slice);
+                        }
+                        (DistanceMetric::DotProduct, 512) => {
+                            return -self.dot_product_inline_512(a_slice, b_slice);
+                        }
+                        (DistanceMetric::DotProduct, 768) => {
+                            return -self.dot_product_inline_768(a_slice, b_slice);
+                        }
+                        (DistanceMetric::DotProduct, 1024) => {
+                            return -self.dot_product_inline_1024(a_slice, b_slice);
+                        }
+                        (DistanceMetric::DotProduct, 1536) => {
+                            return -self.dot_product_inline_1536(a_slice, b_slice);
+                        }
+                        (DistanceMetric::DotProduct, 3072) => {
+                            return -self.dot_product_inline_3072(a_slice, b_slice);
+                        }
 
-                    _ => {} // Fall through to generic SIMD implementation
+                        _ => {} // Fall through to generic SIMD implementation
+                    }
                 }
             }
         }

--- a/sochdb-index/src/rng_optimization_tests.rs
+++ b/sochdb-index/src/rng_optimization_tests.rs
@@ -94,6 +94,94 @@ mod rng_optimization_tests {
         );
     }
 
+    /// Regression test for the AVX2/FMA runtime-dispatch guard (HD-7).
+    ///
+    /// The dimension-specialized inline kernels execute AVX2+FMA intrinsics with
+    /// no per-call feature check; `calculate_distance` only enters them when
+    /// `dim_specialized_kernels_available()` is true. This forces that guard
+    /// false — the path an x86_64 CPU without AVX2/FMA takes — for every
+    /// specialized dimension and metric, asserting the generic fallback (a) does
+    /// not panic / SIGILL and (b) matches the native specialized path to within
+    /// floating-point reordering error. Runs on every host, so the fallback is
+    /// covered even on AVX2-capable CI runners.
+    #[test]
+    fn test_distance_fallback_matches_specialized_kernels() {
+        use crate::hnsw::FORCE_GENERIC_DISTANCE;
+
+        // Deterministic pseudo-random vector with components in [-0.5, 0.5).
+        let make = |dim: usize, seed: u64| -> QuantizedVector {
+            let mut s = seed;
+            let v: Vec<f32> = (0..dim)
+                .map(|_| {
+                    s = s
+                        .wrapping_mul(6364136223846793005)
+                        .wrapping_add(1442695040888963407);
+                    ((s >> 40) as f32 / (1u64 << 24) as f32) - 0.5
+                })
+                .collect();
+            QuantizedVector::F32(Array1::from_vec(v))
+        };
+
+        // RAII guard so the thread-local resets even if an assertion panics.
+        struct ForceGeneric;
+        impl ForceGeneric {
+            fn on() -> Self {
+                FORCE_GENERIC_DISTANCE.with(|f| f.set(true));
+                ForceGeneric
+            }
+        }
+        impl Drop for ForceGeneric {
+            fn drop(&mut self) {
+                FORCE_GENERIC_DISTANCE.with(|f| f.set(false));
+            }
+        }
+
+        let dims = [128usize, 256, 384, 512, 768, 1024, 1536, 3072];
+        let metrics = [
+            DistanceMetric::Cosine,
+            DistanceMetric::Euclidean,
+            DistanceMetric::DotProduct,
+        ];
+
+        for &dim in &dims {
+            let a = make(dim, 0x1234_5678);
+            let b = make(dim, 0x9abc_def0);
+            for &metric in &metrics {
+                let config = HnswConfig {
+                    metric,
+                    // Disable the normalized fast path so calculate_distance
+                    // reaches the dimension-specialized kernel dispatch.
+                    rng_optimization: RngOptimizationConfig {
+                        normalize_at_ingest: false,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                };
+                let index = HnswIndex::new(dim, config);
+
+                // Native path: inline AVX2 on x86+AVX2, NEON on aarch64.
+                let native = index.calculate_distance(&a, &b);
+
+                // Forced generic fallback: the AVX2-absent x86_64 path.
+                let fallback = {
+                    let _g = ForceGeneric::on();
+                    index.calculate_distance(&a, &b)
+                };
+
+                assert!(
+                    native.is_finite() && fallback.is_finite(),
+                    "non-finite distance: dim={dim} metric={metric:?} native={native} fallback={fallback}"
+                );
+                let tol = 1e-3 * (1.0 + native.abs().max(fallback.abs()));
+                assert!(
+                    (native - fallback).abs() <= tol,
+                    "fallback diverges from specialized kernel: dim={dim} metric={metric:?} \
+                     native={native} fallback={fallback} tol={tol}"
+                );
+            }
+        }
+    }
+
     /// Test that triangle inequality gating produces same results as original RNG
     #[test]
     fn test_triangle_inequality_equivalence() {


### PR DESCRIPTION
This pull request introduces a new recall and latency benchmark for the HNSW index, improves the safety and testability of SIMD kernel dispatch, and includes a regression test to ensure correct fallback behavior on CPUs without AVX2/FMA support. It also adjusts the bulk-insert scaffold threshold for better parallelism, with recall verified unchanged. The most important changes are grouped below:

### Benchmarks and Testing

* Added a new benchmark `recall_latency` (`sochdb-index/benches/recall_latency.rs`) to measure recall@10 and search latency (p50/p95/p99) for the HNSW hot path, ensuring memory layout changes do not regress performance or recall. [[1]](diffhunk://#diff-ba53dc372f4d3706d7e89d850c689b5b4dee6f28f980f05fbd2a6b3fd3d9033cR1-R180) [[2]](diffhunk://#diff-533499856c2a7a544f03eec04052c627bd8ecae6fefaa2d3dcbf147d0969d5d3R100-R103)
* Introduced a regression test `test_distance_fallback_matches_specialized_kernels` to verify that the generic distance computation path is correct and safe on all hosts, even those without AVX2/FMA, and matches the specialized kernels within floating-point tolerance.

### SIMD Kernel Dispatch and Safety

* Added a thread-local test-only override `FORCE_GENERIC_DISTANCE` to force the use of the generic distance computation path, ensuring the fallback path is exercised even on AVX2-capable CI runners.
* Refactored the SIMD dispatch logic so that dimension-specialized inline kernels (which use AVX2+FMA intrinsics) are only called if the host supports those features, preventing undefined behavior or illegal instructions on unsupported CPUs. [[1]](diffhunk://#diff-e58cef846547c12b3e9194a2d94bc7b3a06a82111d7c88b60627af7ee64a61ffR8135-R8163) [[2]](diffhunk://#diff-e58cef846547c12b3e9194a2d94bc7b3a06a82111d7c88b60627af7ee64a61ffR8187-R8192) [[3]](diffhunk://#diff-e58cef846547c12b3e9194a2d94bc7b3a06a82111d7c88b60627af7ee64a61ffR8273)

### Performance Improvements

* Reduced the scaffold threshold for HNSW bulk-insert from `10*M0` to `2*M0`, moving more inserts through the parallel path and improving ingest performance without affecting recall, as verified by the new benchmark.