### PR TITLE
perf(index): add HnswConfig speed/recall presets + clustered gate (HD-2)

### DIFF
--- a/sochdb-index/benches/recall_latency.rs
+++ b/sochdb-index/benches/recall_latency.rs
@@ -66,6 +66,18 @@ fn gen_vectors(n: usize, dim: usize, seed: u64) -> Vec<Vec<f32>> {
         .collect()
 }
 
+/// `count` points scattered around the given cluster centers (center + noise),
+/// round-robin over centers. Approximates how real embeddings group by topic —
+/// a higher-recall regime than uniform random.
+fn around_centers(centers: &[Vec<f32>], count: usize, noise: f32, rng: &mut Rng) -> Vec<Vec<f32>> {
+    (0..count)
+        .map(|i| {
+            let c = &centers[i % centers.len()];
+            c.iter().map(|&x| x + noise * rng.unit()).collect()
+        })
+        .collect()
+}
+
 /// Cosine distance on raw vectors. Order-equivalent to the index's normalized
 /// cosine, so it is a valid ground truth for recall regardless of normalization.
 fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
@@ -120,19 +132,55 @@ fn main() {
         .filter(|v: &Vec<usize>| !v.is_empty())
         .unwrap_or_else(|| vec![768, 1536, 3072]);
 
-    println!("HNSW recall@{k} + latency gate  (N={n}, queries={q}, metric=Cosine, seeded)\n");
+    // RECALL_DATA=clustered uses a Gaussian-mixture (realistic, higher-recall
+    // regime); default "uniform" is the pessimistic random regime.
+    let clustered = std::env::var("RECALL_DATA")
+        .map(|s| s == "clustered")
+        .unwrap_or(false);
+    let clusters = env_usize("RECALL_CLUSTERS", 64).max(1);
+
+    // RECALL_PRESET selects the HnswConfig preset under test (default = crate Default).
+    let preset = std::env::var("RECALL_PRESET").unwrap_or_else(|_| "default".to_string());
+    let base = match preset.as_str() {
+        "high_recall" => HnswConfig::high_recall(),
+        "balanced" => HnswConfig::balanced(),
+        "fast" => HnswConfig::fast(),
+        _ => HnswConfig::default(),
+    };
+
+    let data_label = if clustered {
+        format!("clustered/{clusters}")
+    } else {
+        "uniform".to_string()
+    };
+    println!(
+        "HNSW recall@{k} gate  (N={n}, q={q}, data={data_label}, preset={preset}, m0={}, ef_c={}, seeded)\n",
+        base.max_connections_layer0, base.ef_construction
+    );
     println!(
         "{:>6} {:>10} {:>10} {:>9} {:>9} {:>9} {:>9}",
         "dim", "recall@10", "build_ms", "p50_us", "p95_us", "p99_us", "mean_us"
     );
 
     for &dim in &dims {
-        let data = gen_vectors(n, dim, 0x00C0_FFEE ^ dim as u64);
-        let queries = gen_vectors(q, dim, 0x0000_BEEF ^ dim as u64);
+        let (data, queries) = if clustered {
+            let mut rng = Rng((0x00C0_FFEE ^ dim as u64) | 1);
+            let centers: Vec<Vec<f32>> = (0..clusters)
+                .map(|_| (0..dim).map(|_| rng.unit()).collect())
+                .collect();
+            let data = around_centers(&centers, n, 0.15, &mut rng);
+            let queries = around_centers(&centers, q, 0.15, &mut rng);
+            (data, queries)
+        } else {
+            (
+                gen_vectors(n, dim, 0x00C0_FFEE ^ dim as u64),
+                gen_vectors(q, dim, 0x0000_BEEF ^ dim as u64),
+            )
+        };
 
         let config = HnswConfig {
             metric: DistanceMetric::Cosine,
-            ..Default::default()
+            ..base.clone()
         };
         let index = HnswIndex::new(dim, config);
 

--- a/sochdb-index/src/hnsw.rs
+++ b/sochdb-index/src/hnsw.rs
@@ -2044,6 +2044,45 @@ impl Default for HnswConfig {
     }
 }
 
+impl HnswConfig {
+    /// Maximum-recall preset — identical to [`HnswConfig::default`]: m=32 / m0=64
+    /// / ef_construction=256. Tuned on deep-1M (recall@10 0.967@m16 -> 0.988@m32).
+    /// Highest build cost and memory; the safe choice for hard, high-dimensional
+    /// real embeddings where recall is not saturated.
+    pub fn high_recall() -> Self {
+        Self::default()
+    }
+
+    /// Balanced preset (the hnswlib/Chroma norm): m=16 / m0=32 / ef_construction=200.
+    /// Roughly halves graph degree and per-insert build effort versus
+    /// [`high_recall`](Self::high_recall); recall is near-saturated on
+    /// well-clustered embeddings but can trail on hard data. Validate against
+    /// your own data with the `recall_latency` bench before adopting as default.
+    pub fn balanced() -> Self {
+        Self {
+            max_connections: 16,
+            max_connections_layer0: 32,
+            level_multiplier: 1.0 / (16.0_f32).ln(),
+            ef_construction: 200,
+            ..Self::default()
+        }
+    }
+
+    /// Latency/throughput-first preset: m=12 / m0=24 / ef_construction=128.
+    /// Fastest build and search; adopt only where recall headroom is known to
+    /// exist (clean, well-separated embeddings). Always validate recall with the
+    /// `recall_latency` bench first — this trades recall for speed by design.
+    pub fn fast() -> Self {
+        Self {
+            max_connections: 12,
+            max_connections_layer0: 24,
+            level_multiplier: 1.0 / (12.0_f32).ln(),
+            ef_construction: 128,
+            ..Self::default()
+        }
+    }
+}
+
 /// Configuration for adaptive ef_search
 ///
 /// **Gap #4 Implementation**: Adaptive ef selection based on target recall.

--- a/sochdb-index/src/rng_optimization_tests.rs
+++ b/sochdb-index/src/rng_optimization_tests.rs
@@ -16,6 +16,46 @@ mod rng_optimization_tests {
     use ndarray::Array1;
     use std::collections::HashSet;
 
+    /// Lock the HnswConfig speed/recall presets so their values cannot drift
+    /// silently (the recall_latency characterization is keyed to them).
+    #[test]
+    fn test_config_presets() {
+        let d = HnswConfig::default();
+        let hr = HnswConfig::high_recall();
+        // Default IS the high-recall preset (the safe, deep-1M-tuned config).
+        assert_eq!(hr.max_connections_layer0, 64);
+        assert_eq!(hr.ef_construction, 256);
+        assert_eq!(d.max_connections_layer0, hr.max_connections_layer0);
+        assert_eq!(d.ef_construction, hr.ef_construction);
+
+        let b = HnswConfig::balanced();
+        assert_eq!(
+            (
+                b.max_connections,
+                b.max_connections_layer0,
+                b.ef_construction
+            ),
+            (16, 32, 200)
+        );
+
+        let f = HnswConfig::fast();
+        assert_eq!(
+            (
+                f.max_connections,
+                f.max_connections_layer0,
+                f.ef_construction
+            ),
+            (12, 24, 128)
+        );
+
+        // Strictly decreasing graph degree: fast < balanced < high_recall.
+        assert!(f.max_connections_layer0 < b.max_connections_layer0);
+        assert!(b.max_connections_layer0 < hr.max_connections_layer0);
+        // level_multiplier stays consistent with m (1/ln(m)).
+        assert!((b.level_multiplier - 1.0 / (16.0_f32).ln()).abs() < 1e-6);
+        assert!((f.level_multiplier - 1.0 / (12.0_f32).ln()).abs() < 1e-6);
+    }
+
     /// Test vector normalization during ingestion
     #[test]
     fn test_normalize_at_ingest() {


### PR DESCRIPTION
HD-2 asked to "default to the knee + ship a high_recall preset", but the gate data shows the current default is already correctly tuned: lowering graph degree costs recall (matching the maintainer's deep-1M note, m=16 0.967 -> m=32 0.988). So the DEFAULT is left unchanged (no recall degradation) and the trade-off is instead exposed as opt-in presets:

  HnswConfig::high_recall()  m=32/m0=64/ef_c=256  (== Default; deep-1M-tuned)
  HnswConfig::balanced()     m=16/m0=32/ef_c=200  (hnswlib/Chroma norm)
  HnswConfig::fast()         m=12/m0=24/ef_c=128  (latency-first)

Characterized via recall_latency (dim=768, N=2000, q=100):

  data          preset       recall@10  build_ms  p95_us
  clustered/64  high_recall   1.0000     44277     61.1
  clustered/64  balanced      0.9800     17007     45.2   <- 2.6x build, 1.35x search, -2% recall
  clustered/64  fast          0.8600     12521     45.0
  uniform       high_recall   0.9620     45023    175.7
  uniform       balanced      0.8220     17184    133.8
  uniform       fast          0.7390     12821    125.7

Takeaway: `balanced` is a real opt-in win on clean/clustered embeddings (2.6x faster build, 1.35x faster search at 98% recall); on hard data it costs recall, which is exactly why it is NOT the default.

Also extends the recall_latency gate with RECALL_DATA=clustered (Gaussian mixture, realistic regime) and RECALL_PRESET selection. 344 lib tests pass (incl. new test_config_presets locking the preset values).