### PR TITLE
Track a/ssi concurrency contract

### DIFF
--- a/sochdb-client/src/connection.rs
+++ b/sochdb-client/src/connection.rs
@@ -31,7 +31,7 @@
 //! ```rust,ignore
 //! use sochdb::DurableConnection;
 //!
-//! // Open a production-ready connection with WAL durability
+//! // Open a durable connection (WAL durability + MVCC + crash recovery)
 //! let conn = DurableConnection::open("./data")?;
 //!
 //! // Transactions are durable (survive crashes)
@@ -3066,18 +3066,23 @@ impl<'a> EmbeddedQueryBuilder<'a> {
 }
 
 // ============================================================================
-// DurableConnection - Production-grade connection with real WAL + MVCC
+// DurableConnection - durable connection with real WAL + MVCC
 // ============================================================================
 
 use sochdb_storage::durable_storage::DurableStorage;
 
 /// A durable connection that uses the real WAL + MVCC storage layer.
 ///
-/// This is the production-grade connection that actually persists data:
+/// This connection actually persists data, with the durability guarantees the
+/// live storage build provides:
 /// - WAL for durability (fsync before commit returns)
 /// - MVCC for snapshot isolation
 /// - Group commit for batched writes
 /// - Crash recovery via WAL replay
+///
+/// It does NOT provide at-rest encryption, point-in-time recovery, ARIES
+/// checkpointing, or WAL fencing (those modules are quarantined/unwired). See
+/// `sochdb_storage::durability_capabilities` for the authoritative matrix.
 ///
 /// ## Configuration Presets
 ///

--- a/sochdb-client/src/lib.rs
+++ b/sochdb-client/src/lib.rs
@@ -31,8 +31,9 @@
 //!
 //! The SDK provides two connection types:
 //!
-//! - **`Connection`** (alias for `DurableConnection`): Production-grade with WAL durability,
-//!   MVCC transactions, crash recovery. **Use this for production.**
+//! - **`Connection`** (alias for `DurableConnection`): durable WAL + MVCC transactions +
+//!   crash recovery. **Use this for persistent data.** (No at-rest encryption, PITR, or
+//!   WAL fencing — see `sochdb_storage::durability_capabilities`.)
 //!
 //! - **`InMemoryConnection`** (alias for `SochConnection`): Fast in-memory storage for testing.
 //!   Data is not persisted. **Use only for tests or ephemeral data.**

--- a/sochdb-storage/src/durable_storage.rs
+++ b/sochdb-storage/src/durable_storage.rs
@@ -3579,6 +3579,69 @@ mod tests {
         }
     }
 
+    /// Crash-atomicity invariant (Task 4 — completes the Task 1 single-writer
+    /// contract). `test_crash_recovery` proves committed data survives a crash;
+    /// this proves the other half: recovery must NOT resurrect aborted or
+    /// in-flight (never-committed) writes. Together they assert the live
+    /// single-writer engine's commit is atomic AND durable across a crash.
+    #[test]
+    fn test_crash_recovery_atomicity() {
+        let dir = tempdir().unwrap();
+
+        // Phase 1: one committed write, one aborted, one in-flight at crash.
+        {
+            let storage = DurableStorage::open_without_lock(dir.path()).unwrap();
+            storage.set_sync_mode(2); // FULL: fsync every commit before the "crash"
+
+            // Committed — must survive.
+            let t1 = storage.begin_transaction().unwrap();
+            storage
+                .write(t1, b"committed".to_vec(), b"durable".to_vec())
+                .unwrap();
+            storage.commit(t1).unwrap();
+
+            // Aborted — must NOT be resurrected.
+            let t2 = storage.begin_transaction().unwrap();
+            storage
+                .write(t2, b"aborted".to_vec(), b"rolledback".to_vec())
+                .unwrap();
+            storage.abort(t2).unwrap();
+
+            // In-flight (never committed) at crash time — must NOT be resurrected.
+            let t3 = storage.begin_transaction().unwrap();
+            storage
+                .write(t3, b"inflight".to_vec(), b"lost".to_vec())
+                .unwrap();
+
+            // Simulate a crash: skip Drop / clean shutdown.
+            std::mem::forget(storage);
+        }
+
+        // Phase 2: reopen + recover; assert atomicity.
+        {
+            let storage = DurableStorage::open_without_lock(dir.path()).unwrap();
+            storage.recover().unwrap();
+
+            let t = storage.begin_transaction().unwrap();
+            assert_eq!(
+                storage.read(t, b"committed").unwrap(),
+                Some(b"durable".to_vec()),
+                "committed write must survive the crash"
+            );
+            assert_eq!(
+                storage.read(t, b"aborted").unwrap(),
+                None,
+                "aborted write must not be resurrected by recovery"
+            );
+            assert_eq!(
+                storage.read(t, b"inflight").unwrap(),
+                None,
+                "uncommitted in-flight write must not be resurrected by recovery"
+            );
+            storage.abort(t).unwrap();
+        }
+    }
+
     #[test]
     fn test_scan_prefix() {
         let dir = tempdir().unwrap();

--- a/sochdb-storage/src/durable_storage.rs
+++ b/sochdb-storage/src/durable_storage.rs
@@ -17,13 +17,19 @@
 
 //! Durable Storage Layer
 //!
-//! This module wires together all storage components into a production-ready
-//! durable storage engine:
+//! Wires together the live storage components into a durable engine:
 //!
-//! - WAL (txn_wal.rs) for durability
+//! - WAL (txn_wal.rs) for crash-consistent durability + recovery
 //! - Group Commit for throughput
 //! - MVCC for isolation
 //! - LSCS for columnar efficiency
+//!
+//! Truth-in-capabilities: the live path provides crash-consistent WAL recovery,
+//! but NOT at-rest encryption, point-in-time recovery, ARIES checkpointing, or
+//! WAL fencing — those modules exist but are quarantined behind the empty,
+//! non-default `experimental` feature and are unwired. Query
+//! [`crate::durability_capabilities`] rather than relying on prose like
+//! "production-grade".
 //!
 //! ## Architecture
 //!

--- a/sochdb-storage/src/lib.rs
+++ b/sochdb-storage/src/lib.rs
@@ -280,6 +280,65 @@ pub use durable_storage::{
     ArenaMvccMemTable, DurableStorage, EphemeralHandle, MvccMemTable, TransactionMode,
 };
 
+// ============================================================================
+// Truth-in-capabilities: durability feature matrix (Task 3A)
+// ============================================================================
+
+/// Durability features actually wired into THIS build's live storage path.
+///
+/// Prose like "production-grade" must not be read as implying features that are
+/// quarantined behind the empty, non-default `experimental` feature and
+/// unreferenced by the live write/recovery path. Query this matrix instead of
+/// trusting documentation strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DurabilityCapabilities {
+    /// Crash-consistent WAL recovery (txn_wal / RecoveryStats / durability_contract). Live.
+    pub crash_recovery: bool,
+    /// At-rest encryption (AES-256-GCM-SIV). The `encryption` module exists but
+    /// is quarantined behind `experimental` and unwired — not on the live path.
+    pub at_rest_encryption: bool,
+    /// Point-in-time recovery via WAL archiving. `pitr` module, quarantined/unwired.
+    pub point_in_time_recovery: bool,
+    /// ARIES-style checkpointing. `aries_recovery` / `checkpoint` modules, quarantined/unwired.
+    pub aries_checkpoint: bool,
+    /// Epoch-based WAL fencing (split-brain detection). `wal_fencing` module, quarantined/unwired.
+    pub wal_fencing: bool,
+}
+
+/// The durability capabilities of the current build — a function of what is
+/// actually wired, not of documentation. The quarantined subsystems require the
+/// `experimental` feature AND live wiring that does not yet exist (Task 3B), so
+/// they report `false` here regardless of feature flags.
+pub const fn durability_capabilities() -> DurabilityCapabilities {
+    DurabilityCapabilities {
+        crash_recovery: true,
+        at_rest_encryption: false,
+        point_in_time_recovery: false,
+        aries_checkpoint: false,
+        wal_fencing: false,
+    }
+}
+
+#[cfg(test)]
+mod durability_capabilities_tests {
+    use super::durability_capabilities;
+
+    #[test]
+    fn live_build_durability_matrix_is_honest() {
+        let caps = durability_capabilities();
+        // The one durability guarantee the live path actually provides.
+        assert!(
+            caps.crash_recovery,
+            "live path must provide crash-consistent WAL recovery"
+        );
+        // Quarantined/unwired — must NOT be advertised as present on the live build.
+        assert!(!caps.at_rest_encryption);
+        assert!(!caps.point_in_time_recovery);
+        assert!(!caps.aries_checkpoint);
+        assert!(!caps.wal_fencing);
+    }
+}
+
 // Re-exports for concurrent MVCC (Task: Concurrent Embedded)
 pub use mvcc_concurrent::{
     ConcurrentMvcc, ConcurrentVersionChain, ConcurrentVersionEntry, HlcTimestamp, ReaderSlot,

--- a/sochdb-storage/src/ssi.rs
+++ b/sochdb-storage/src/ssi.rs
@@ -345,16 +345,27 @@ impl SsiManager {
         }
     }
 
-    /// Begin a new transaction
+    /// Begin a new transaction (allocates an SSI-internal id).
     pub fn begin(&self) -> Result<(TxnId, Timestamp), SsiConflictError> {
         let txn_id = self.next_txn_id.fetch_add(1, Ordering::SeqCst);
+        let start_ts = self.begin_with_id(txn_id)?;
+        Ok((txn_id, start_ts))
+    }
+
+    /// Begin a transaction under a caller-supplied id.
+    ///
+    /// Lets an outer coordinator (e.g. `MvccTransactionManager`) keep ONE
+    /// consistent transaction identity across both managers, so later
+    /// `record_read`/`record_write`/`commit` calls keyed by that id resolve to
+    /// the transaction created here. Allocates only the SSI start timestamp.
+    pub fn begin_with_id(&self, txn_id: TxnId) -> Result<Timestamp, SsiConflictError> {
         let start_ts = self.timestamp.fetch_add(1, Ordering::SeqCst);
 
         let txn = SsiTransaction::new(txn_id, start_ts);
         self.transactions.write().insert(txn_id, txn);
         self.txn_states.set_status(txn_id, SsiTxnStatus::Active);
 
-        Ok((txn_id, start_ts))
+        Ok(start_ts)
     }
 
     /// Record a read and check for rw-antidependencies

--- a/sochdb-storage/src/transaction.rs
+++ b/sochdb-storage/src/transaction.rs
@@ -22,46 +22,46 @@
 //!
 //! ## Implementation Guide
 //!
-//! There are THREE transaction manager implementations in SochDB. Here's when to use each:
+//! **The live concurrency contract is multi-reader, single-writer.** Production
+//! isolation and durability run through `DurableStorage` (`database.rs` /
+//! `durable_storage.rs`): lock-free MVCC snapshot reads via `ConcurrentMvcc`,
+//! writes serialized by a single-writer lock (`acquire_writer`, "serialize WAL
+//! commits across processes"), and SSI conflict validation via `MvccManager`.
+//! WAL crash recovery is wired here (`txn_wal` / `RecoveryStats` /
+//! `durability_contract`). There is **no concurrent-writer (wired SSI) path on
+//! the live engine** — do not assume one exists.
 //!
-//! ### 1. `MvccTransactionManager` (wal_integration.rs) - **RECOMMENDED FOR PRODUCTION**
+//! SochDB contains three transaction-manager types; only the first is on the
+//! live path:
 //!
-//! Full-featured transaction manager with:
-//! - ✅ WAL-based durability (fsync on commit)
-//! - ✅ MVCC snapshot isolation
-//! - ✅ Serializable Snapshot Isolation (SSI)
-//! - ✅ Group commit for high throughput
-//! - ✅ Version chains with garbage collection
+//! ### 1. `DurableStorage` + `MvccManager` (durable_storage.rs) — LIVE / PRODUCTION
+//!
+//! The actual production path. Single-writer write coordination + MVCC snapshot
+//! reads, with `MvccManager` providing SSI rw-antidependency validation and the
+//! storage layer providing WAL durability and crash recovery.
+//!
+//! ### 2. `MvccTransactionManager` (wal_integration.rs) — STANDALONE, NOT WIRED
+//!
+//! A complete, self-contained manager (WAL durability, MVCC snapshot isolation,
+//! optional SSI, group commit, version-chain GC). Despite being feature-rich it
+//! has **no functional caller in the engine** — `DurableStorage` does not use
+//! it — so it is **not** the production path. Use it only if you explicitly
+//! construct and own one; it does not participate in the live database's
+//! single-writer concurrency contract. (Its SSI read/write tracking is correct
+//! as of the Task 1B id-divergence fix, but it remains unwired.)
 //!
 //! ```ignore
 //! use sochdb_storage::wal_integration::MvccTransactionManager;
-//!
-//! let txm = MvccTransactionManager::new("wal.log", |key, value| {
-//!     // Apply callback
-//!     Ok(())
-//! })?;
-//!
+//! let txm = MvccTransactionManager::new("wal.log", |_key, _value| Ok(()))?;
 //! let txn_id = txm.begin(IsolationLevel::Serializable)?;
 //! txm.write(txn_id, b"key", b"value")?;
-//! txm.commit(txn_id)?; // fsync guarantee
+//! txm.commit(txn_id)?;
 //! ```
 //!
-//! ### 2. `MvccManager` (durable_storage.rs) - SSI VALIDATION ONLY
+//! ### 3. `TransactionManager` (mvcc_snapshot.rs) — `#[deprecated]`
 //!
-//! Provides SSI conflict detection but delegates durability to storage layer.
-//! Used internally by `DurableStorage` for transaction tracking.
-//!
-//! - ✅ SSI rw-antidependency detection
-//! - ✅ Bloom filter optimization for read/write sets
-//! - ❌ No WAL (relies on caller for durability)
-//!
-//! ### 3. `TransactionManager` (mvcc_snapshot.rs) - **DEPRECATED FOR NEW CODE**
-//!
-//! Minimal snapshot isolation without durability. Only suitable for:
-//! - Unit testing
-//! - Ephemeral in-memory operations
-//!
-//! **Do not use for production workloads requiring crash recovery.**
+//! Minimal snapshot isolation without durability. Unit tests / ephemeral
+//! in-memory only. **Not for production workloads requiring crash recovery.**
 //!
 //! ## Transaction Coordinator Trait
 //!

--- a/sochdb-storage/src/wal_integration.rs
+++ b/sochdb-storage/src/wal_integration.rs
@@ -633,9 +633,14 @@ impl MvccTransactionManager {
         // Update min snapshot for GC
         self.update_min_snapshot();
 
-        // For SSI, register with SSI manager
+        // For SSI, register with the SSI manager under the SAME txn id this
+        // manager uses, so later record_read/record_write/commit (keyed by
+        // txn_id) resolve to this transaction. Previously begin() allocated a
+        // divergent SSI-internal id, so a Serializable txn created after any
+        // non-Serializable begin was recorded under the wrong/non-existent id
+        // (Task 1B).
         if isolation_level == IsolationLevel::Serializable {
-            self.ssi_manager.begin().ok();
+            self.ssi_manager.begin_with_id(txn_id).ok();
         }
 
         Ok(txn_id)
@@ -1273,6 +1278,37 @@ mod tests {
         let _value = manager.read(txn2, b"key1").unwrap();
 
         manager.commit(txn2).unwrap();
+    }
+
+    /// Regression test for the SSI transaction-id divergence (Task 1B).
+    ///
+    /// `begin` allocates txn ids from the outer counter on EVERY begin, but only
+    /// advances `SsiManager`'s independent counter on Serializable begins. So
+    /// after any non-Serializable begin, a later Serializable transaction's
+    /// outer id no longer matches the id SsiManager stored it under, and
+    /// `read`'s `ssi_manager.record_read(outer_id, ...)` looks up a non-existent
+    /// SSI transaction — spuriously failing the read. The fix threads one
+    /// identity (begin_with_id) so both sides agree.
+    #[test]
+    fn test_ssi_txn_id_divergence_serializable_read() {
+        let dir = tempdir().unwrap();
+        let wal_path = dir.path().join("ssi_divergence.wal");
+        let manager = MvccTransactionManager::new(wal_path, |_, _| Ok(())).unwrap();
+
+        // A non-Serializable begin advances the outer counter but NOT the SSI one.
+        let _si = manager.begin(IsolationLevel::SnapshotIsolation).unwrap();
+
+        // Serializable begin: the outer id is now ahead of the SSI-assigned id.
+        let ser = manager.begin(IsolationLevel::Serializable).unwrap();
+
+        // A Serializable read records into SSI under the OUTER id. With the
+        // divergence bug this errors ("SSI conflict: Transaction not found").
+        let res = manager.read(ser, b"key");
+        assert!(
+            res.is_ok(),
+            "Serializable read failed due to SSI txn-id divergence: {:?}",
+            res.err()
+        );
     }
 
     #[test]

--- a/sochdb-storage/src/wal_integration.rs
+++ b/sochdb-storage/src/wal_integration.rs
@@ -536,7 +536,13 @@ impl MvccVersionChain {
     }
 }
 
-/// Full MVCC Transaction Manager with WAL and Group Commit
+/// Full MVCC Transaction Manager with WAL and Group Commit.
+///
+/// NOTE (concurrency contract): this is a complete but **standalone, unwired**
+/// manager. The live engine's contract is multi-reader/single-writer via
+/// `DurableStorage` (see `transaction.rs`), which does NOT use this type. It is
+/// retained as a self-contained reference implementation; construct it only if
+/// you own its lifecycle. It is not the production transaction path.
 ///
 /// Provides ACID transactions with:
 /// - Multi-Version Concurrency Control


### PR DESCRIPTION
This pull request focuses on improving the accuracy and transparency of SochDB's durability and concurrency documentation, clarifying the live engine's capabilities, and fixing a subtle SSI transaction-id bug. It also introduces a programmatic durability feature matrix, adds new tests for crash recovery and SSI correctness, and makes several code and docstring improvements.

**Durability and Feature Transparency**

* Added a `DurabilityCapabilities` struct and `durability_capabilities()` function to `sochdb-storage/src/lib.rs`, providing a programmatic matrix of which durability features are actually wired into the live engine (e.g., crash recovery is live, but at-rest encryption, PITR, ARIES checkpointing, and WAL fencing are not). Includes a test to ensure the matrix is honest.
* Updated documentation throughout (`sochdb-client/src/lib.rs`, `sochdb-client/src/connection.rs`, `sochdb-storage/src/durable_storage.rs`) to replace "production-grade" with precise descriptions of live durability features and to direct users to the new durability matrix. [[1]](diffhunk://#diff-1391a1a8ff763e4853e47535bcab98055aeffe6d7ee25df65f3393a6b83d49cbL34-R36) [[2]](diffhunk://#diff-3bfba99e525a414a13e60d1d91fe225c093e66ff0a73d3ec232b51de1c9f4e76L34-R34) [[3]](diffhunk://#diff-3bfba99e525a414a13e60d1d91fe225c093e66ff0a73d3ec232b51de1c9f4e76L3069-R3086) [[4]](diffhunk://#diff-8a013dc9ff00ae5b19f676937d8cc929c2fe59411901c38cc1dd90ef260bb1e7L20-R33)

**Crash Recovery and Atomicity**

* Added a new test (`test_crash_recovery_atomicity`) to `sochdb-storage/src/durable_storage.rs` that verifies the engine's crash-atomicity: only committed transactions survive a crash, while aborted and in-flight writes are not resurrected.

**Concurrency Contract and Transaction Management**

* Clarified in the documentation for `transaction.rs` and `wal_integration.rs` that the live engine uses a multi-reader/single-writer concurrency contract, and that the standalone `MvccTransactionManager` is not wired into the production path. Updated the isolation and durability explanations accordingly. [[1]](diffhunk://#diff-0ea2e874e5adac210008c6031fb9ea74cf98a37d4d86e4063d0368951e22b1c6L25-R64) [[2]](diffhunk://#diff-1002faeaadd3199aab7c35de8de5cad166ce2416518d8f263aedbb9f54ed0b1dL539-R545)

**SSI Transaction-ID Bugfix**

* Fixed a bug where SSI (Serializable Snapshot Isolation) transactions could be tracked under divergent IDs, causing spurious errors. Now, `MvccTransactionManager` registers SSI transactions using the outer transaction ID, ensuring both managers agree. Added a regression test for this bug. [[1]](diffhunk://#diff-1002faeaadd3199aab7c35de8de5cad166ce2416518d8f263aedbb9f54ed0b1dL636-R649) [[2]](diffhunk://#diff-4cc48ce29ef08420db521827ba33348f4fb2855620f78c91a0703b710b291c09L348-R368) [[3]](diffhunk://#diff-1002faeaadd3199aab7c35de8de5cad166ce2416518d8f263aedbb9f54ed0b1dR1289-R1319)

These changes improve the reliability, transparency, and correctness of SochDB's durability and concurrency guarantees.