### PR TITLE
ci(task0): unsafe-site census + Miri bring-up + fix loom unexpected-cfg

### DIFF
--- a/.azurepipelines/azure-pipelines-ci.yml
+++ b/.azurepipelines/azure-pipelines-ci.yml
@@ -70,3 +70,23 @@ steps:
   # so they cannot rot silently while gated out of the default build.
   - script: cargo check -p sochdb-storage -p sochdb-query -p sochdb-index --features experimental
     displayName: 'Compile-check experimental modules'
+
+  # Reproducible census of the `unsafe` surface (Task 0). Informational: prints
+  # the per-crate + total `unsafe` keyword count so the figure is never quoted
+  # from memory and growth is visible in the log. Non-blocking.
+  - script: bash unsafe_census.sh
+    displayName: 'Unsafe-site census'
+    continueOnError: true
+
+  # Miri small gate over pure-Rust aliasing/UB in the epoch-partitioned arena
+  # (epoch_arena) — exactly the class that caught the MemoryBlock absolute-address
+  # alignment bug. NON-BLOCKING during bring-up (Miri may need per-test compat
+  # tweaks); promote to a hard gate once green, then widen to lockfree_epoch /
+  # generational_slab. Miri cannot interpret SIMD/FFI/mmap, so the scope stays
+  # narrow by test-name filter. (Next CI gate to add: ASAN/Valgrind over the
+  # SIMD/FFI/mmap surface on the nightly schedule — heavier, deferred.)
+  - script: |
+      rustup toolchain install nightly --component miri
+      cargo +nightly miri test -p sochdb-storage epoch_arena
+    displayName: 'Miri (epoch arena, non-blocking bring-up)'
+    continueOnError: true

--- a/sochdb-storage/Cargo.toml
+++ b/sochdb-storage/Cargo.toml
@@ -148,3 +148,9 @@ harness = false
 [[bench]]
 name = "bench_comparison"
 harness = false
+
+# `loom` is a custom cfg enabled via RUSTFLAGS="--cfg loom" for the Loom
+# concurrency model checker (tests/loom_concurrency.rs). Declare it so the
+# unexpected_cfgs lint does not flag it (otherwise every build warns).
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }

--- a/unsafe_census.sh
+++ b/unsafe_census.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Reproducible census of `unsafe` keyword usage across the workspace.
+#
+# Emits a per-crate and total count of the `unsafe` keyword in Rust sources
+# (src/*.rs, excluding target/ and generated output). This is the single source
+# of truth for the workspace's unsafe surface (Task 0): quote this script's
+# output, not a hard-coded number — the figure drifts as code changes.
+#
+# Note: this counts the `unsafe` *keyword* (including any occurrences in comments
+# or strings), i.e. an upper bound / order-of-magnitude signal, not a precise
+# count of `unsafe { }` blocks. It is intentionally simple and deterministic so
+# CI can run it and humans can reproduce it.
+#
+# Usage:  ./unsafe_census.sh
+set -euo pipefail
+cd "$(dirname "$0")"
+
+total=0
+lines=""
+for d in */; do
+  src="${d}src"
+  [ -d "$src" ] || continue
+  n=$({ grep -rhoE '\bunsafe\b' "$src" --include='*.rs' 2>/dev/null || true; } | wc -l | tr -d ' ')
+  [ "$n" -gt 0 ] || continue
+  lines+=$(printf '%8d  %s\n' "$n" "${d%/}")$'\n'
+  total=$((total + n))
+done
+
+echo "unsafe-keyword census (\\bunsafe\\b in */src/**.rs):"
+printf '%s' "$lines" | sort -rn
+printf '%8d  %s\n' "$total" "TOTAL"


### PR DESCRIPTION
Task 0 (memory-safety verification / lint hygiene), the items the diff review raised after hand-reasoned unsafe/concurrent code shipped:

- unsafe_census.sh (repo root, alongside the other committed tooling — note /scripts/ is gitignored): a reproducible per-crate + total census of the `unsafe` keyword surface, so the count is emitted by a script (current: 1177 — storage 577, index 353, vector 140, core 44, ...) rather than quoted from memory. Wired into CI as a non-blocking informational step.
- Miri small gate (CI, non-blocking bring-up) scoped to epoch_arena — the pure-Rust arena code whose absolute-address alignment bug is exactly the class Miri catches. Starts non-blocking (matching the clippy precedent); promote to a hard gate once green, then widen. ASAN/Valgrind over SIMD/FFI/ mmap noted as the next (heavier) gate.
- Declare the custom `loom` cfg via [lints.rust] check-cfg in sochdb-storage, silencing the unexpected_cfgs warning the Loom test (#![cfg(loom)]) emitted on every build — a small step toward the clippy ratchet's zero-baseline goal.

Locally validated: census script runs; loom unexpected-cfg warning gone; `cargo check -p sochdb-storage --tests` clean; Cargo.toml parses. The Miri CI step validates on the x86_64 CI runner (no nightly miri on this box).