### PR TITLE
feat(storage): wire at-rest encryption into WAL + DurableStorage (Tas…

### DIFF
--- a/sochdb-core/src/error.rs
+++ b/sochdb-core/src/error.rs
@@ -100,6 +100,16 @@ pub enum SochDBError {
 
     #[error("Split-brain detected in WAL: {0}")]
     SplitBrain(String),
+
+    /// Data-at-rest encryption / key-management failure.
+    ///
+    /// This is a HARD error: it is deliberately distinct from `Io` so that WAL
+    /// replay loops can tell a genuine torn-tail (`Io(UnexpectedEof)` at a frame
+    /// boundary, which is tolerated) apart from an AEAD authentication failure /
+    /// wrong-or-missing key / format mismatch (which must abort recovery rather
+    /// than be silently treated as end-of-WAL). See `txn_wal` replay.
+    #[error("Encryption error: {0}")]
+    Encryption(String),
 }
 
 pub type Result<T> = std::result::Result<T, SochDBError>;

--- a/sochdb-storage/Cargo.toml
+++ b/sochdb-storage/Cargo.toml
@@ -31,6 +31,13 @@ embedded-sync = []
 # quarantined behind this feature so the default build surface (and attack
 # surface) stays minimal. Enable explicitly to compile them: `--features experimental`.
 experimental = []
+# Data-at-rest encryption (AES-256-GCM-SIV envelope) and Point-in-Time Recovery.
+# The crypto/keyring/PITR *code* now compiles in the default build (so its tests
+# run in CI and it can be wired into DurableStorage); these features exist to
+# gate higher-level wiring/CLI surfaces and to document intent. Encryption is
+# inert at runtime unless a key is configured (fail-closed; see keyring).
+encryption = []
+pitr = ["encryption"]
 
 [dependencies]
 sochdb-core = { version = "2.0.8", path = "../sochdb-core" }
@@ -67,6 +74,12 @@ arc-swap = "1.6"
 aes-gcm-siv = "0.11"
 rand = "0.8"
 zeroize = { version = "1.8", features = ["derive"] }
+# HKDF-SHA256 for deriving per-DB DEK/wrapping subkeys from the supplied KEK,
+# so the operator secret is never used verbatim as cipher key material.
+hkdf = "0.12"
+# HMAC-SHA256 to authenticate the keyring descriptor (so `encrypted=false`
+# cannot be silently forged to downgrade an encrypted DB to plaintext reads).
+hmac = "0.12"
 lz4_flex = "0.11"
 similar = "2.5"
 uuid = { version = "1.8", features = ["v4"] }

--- a/sochdb-storage/src/durable_storage.rs
+++ b/sochdb-storage/src/durable_storage.rs
@@ -108,8 +108,11 @@ use smallvec::SmallVec;
 
 use crossbeam_skiplist::SkipMap;
 
+use crate::DurabilityCapabilities;
 use crate::deferred_index::{DeferredIndexConfig, DeferredSortedIndex};
+use crate::encryption::EncryptionKey;
 use crate::group_commit::EventDrivenGroupCommit;
+use crate::keyring;
 use crate::txn_wal::{TxnWal, TxnWalBuffer, TxnWalEntry};
 use sochdb_core::version_chain::{
     BinarySearchChain, ChainEntry, MvccVersionChain, MvccVersionChainMut, Timestamp, TxnId,
@@ -2463,6 +2466,48 @@ pub struct DurableStorage {
     /// Database lock for exclusive access (None = no locking)
     #[allow(dead_code)]
     db_lock: Option<crate::lock::DatabaseLock>,
+    /// Whether at-rest encryption is active for this instance (drives the live
+    /// per-instance durability matrix). Set from the resolved keyring at open.
+    at_rest_encrypted: bool,
+}
+
+/// Encryption configuration for opening a [`DurableStorage`].
+///
+/// `disabled()` (the default for the legacy open variants) keeps the database
+/// plaintext and byte-compatible with pre-encryption binaries. `with_kek()`
+/// supplies the Key-Encryption-Key — the operator secret that *wraps* a
+/// per-database data key; it is never used verbatim as the cipher key (see
+/// [`crate::keyring`]). A wrong/missing KEK for an encrypted database fails
+/// closed at open (the DB will refuse to open, never silently read as plaintext).
+pub struct StorageEncryption {
+    /// The KEK. `None` ⇒ plaintext database.
+    pub kek: Option<EncryptionKey>,
+    /// Human-readable identifier for the key source (e.g. "env:SOCHDB_ENCRYPTION_KEY",
+    /// "embedded", "kms:..."). Bound into the keyring for provenance.
+    pub source_id: String,
+}
+
+impl StorageEncryption {
+    /// Plaintext (no encryption) — the default.
+    pub fn disabled() -> Self {
+        Self {
+            kek: None,
+            source_id: "none".to_string(),
+        }
+    }
+
+    /// Encrypt at rest under the given KEK.
+    pub fn with_kek(kek: EncryptionKey, source_id: impl Into<String>) -> Self {
+        Self {
+            kek: Some(kek),
+            source_id: source_id.into(),
+        }
+    }
+
+    /// Whether a key is configured (i.e. encryption is requested).
+    pub fn is_enabled(&self) -> bool {
+        self.kek.is_some()
+    }
 }
 
 impl DurableStorage {
@@ -2507,7 +2552,58 @@ impl DurableStorage {
         enable_ordered_index: bool,
         memtable_type: MemTableType,
     ) -> Result<Self> {
-        Self::open_with_full_config_internal(path, enable_ordered_index, memtable_type, true)
+        Self::open_with_full_config_internal(
+            path,
+            enable_ordered_index,
+            memtable_type,
+            true,
+            StorageEncryption::disabled(),
+        )
+    }
+
+    /// Open with at-rest encryption configured via [`StorageEncryption`].
+    ///
+    /// With `StorageEncryption::disabled()` this is identical to
+    /// [`Self::open_with_full_config`]. With a KEK, the database is opened (or
+    /// created) encrypted: a per-DB data key is generated and wrapped into the
+    /// keyring on first open, and a wrong/missing key on a subsequent open fails
+    /// closed. Reads are unaffected (the live read path is in-memory); only the
+    /// WAL write/recovery path pays the AEAD cost.
+    pub fn open_with_encryption<P: AsRef<Path>>(
+        path: P,
+        enable_ordered_index: bool,
+        memtable_type: MemTableType,
+        encryption: StorageEncryption,
+    ) -> Result<Self> {
+        Self::open_with_full_config_internal(
+            path,
+            enable_ordered_index,
+            memtable_type,
+            true,
+            encryption,
+        )
+    }
+
+    /// The live, per-instance durability capabilities of THIS database.
+    ///
+    /// Unlike the build-level [`crate::durability_capabilities`] (which reports
+    /// defaults), this reflects the actual resolved state — notably whether
+    /// at-rest encryption is active for this opened instance.
+    pub fn durability_capabilities(&self) -> DurabilityCapabilities {
+        DurabilityCapabilities {
+            crash_recovery: true,
+            at_rest_encryption: self.at_rest_encrypted,
+            // PITR / ARIES / fencing remain unwired on the live path (landing
+            // incrementally in Task 3B).
+            point_in_time_recovery: false,
+            aries_checkpoint: false,
+            wal_fencing: false,
+        }
+    }
+
+    /// Whether at-rest encryption is active for this instance.
+    pub fn is_encrypted(&self) -> bool {
+        self.at_rest_encrypted
     }
 
     /// Open without locking (for testing crash recovery scenarios)
@@ -2517,7 +2613,13 @@ impl DurableStorage {
     /// the storage instance. In production, always use `open_with_full_config`.
     #[cfg(test)]
     pub fn open_without_lock<P: AsRef<Path>>(path: P) -> Result<Self> {
-        Self::open_with_full_config_internal(path, true, MemTableType::Standard, false)
+        Self::open_with_full_config_internal(
+            path,
+            true,
+            MemTableType::Standard,
+            false,
+            StorageEncryption::disabled(),
+        )
     }
 
     /// Open an ephemeral (in-memory-like) DurableStorage backed by a temp directory.
@@ -2546,6 +2648,7 @@ impl DurableStorage {
             true,
             MemTableType::Standard,
             false, // No lock needed for ephemeral
+            StorageEncryption::disabled(),
         )?;
         Ok(EphemeralHandle {
             storage,
@@ -2558,8 +2661,13 @@ impl DurableStorage {
     /// Same as `open_ephemeral()` but with group commit for higher throughput.
     pub fn open_ephemeral_with_group_commit() -> Result<EphemeralHandle> {
         let tmp = tempfile::tempdir().map_err(|e| SochDBError::Io(e))?;
-        let mut storage =
-            Self::open_with_full_config_internal(tmp.path(), true, MemTableType::Standard, false)?;
+        let mut storage = Self::open_with_full_config_internal(
+            tmp.path(),
+            true,
+            MemTableType::Standard,
+            false,
+            StorageEncryption::disabled(),
+        )?;
 
         let wal = storage.wal.clone();
         let gc = EventDrivenGroupCommit::new(move |txn_ids: &[u64]| {
@@ -2587,6 +2695,7 @@ impl DurableStorage {
         enable_ordered_index: bool,
         memtable_type: MemTableType,
         acquire_lock: bool,
+        encryption: StorageEncryption,
     ) -> Result<Self> {
         let path = path.as_ref().to_path_buf();
         std::fs::create_dir_all(&path)?;
@@ -2602,7 +2711,25 @@ impl DurableStorage {
         };
 
         let wal_path = path.join("wal.log");
-        let wal = Arc::new(TxnWal::new(&wal_path)?);
+
+        // Resolve at-rest encryption from the keyring BEFORE touching the WAL.
+        // - A fresh DB (no wal.log yet) with a KEK ⇒ create an encrypted keyring.
+        // - An existing plaintext DB with a KEK ⇒ refused (must migrate explicitly).
+        // - An encrypted DB with a wrong/missing KEK ⇒ refused fail-closed.
+        let is_new_db = !wal_path.exists();
+        let enc_state = keyring::load_or_init(
+            &path,
+            encryption.kek.as_ref(),
+            &encryption.source_id,
+            is_new_db,
+        )?;
+        let at_rest_encrypted = enc_state.is_encrypted();
+        let wal = Arc::new(TxnWal::new_with_encryption(
+            &wal_path,
+            enc_state.engine(),
+            enc_state.db_uuid(),
+            enc_state.key_epoch(),
+        )?);
 
         let storage = Self {
             path,
@@ -2620,6 +2747,7 @@ impl DurableStorage {
             last_commit_us: AtomicU64::new(0),
             fsync_latency_us: AtomicU64::new(5000), // 5ms default
             db_lock,
+            at_rest_encrypted,
         };
 
         // Check if recovery needed
@@ -2746,7 +2874,13 @@ impl DurableStorage {
         };
 
         // Open WITHOUT exclusive file lock (concurrent MVCC handles coordination)
-        Self::open_with_full_config_internal(path, enable_ordered_index, memtable_type, false)
+        Self::open_with_full_config_internal(
+            path,
+            enable_ordered_index,
+            memtable_type,
+            false,
+            StorageEncryption::disabled(),
+        )
     }
 
     /// Get the memtable type being used
@@ -3577,6 +3711,101 @@ mod tests {
             assert_eq!(v, Some(b"data".to_vec()));
             storage.abort(txn).unwrap();
         }
+    }
+
+    /// At-rest encryption end-to-end through the live DurableStorage engine
+    /// (Task 3B): an encrypted DB round-trips committed data, never leaks
+    /// plaintext to the WAL file, flips the per-instance durability matrix, and
+    /// fails CLOSED on a wrong or missing key (never a silent plaintext/empty
+    /// open).
+    #[test]
+    fn test_at_rest_encryption_end_to_end() {
+        let dir = tempdir().unwrap();
+        let kek = || EncryptionKey::new([0xABu8; 32]);
+
+        // Phase 1: create an encrypted DB, write committed data, clean close.
+        {
+            let storage = DurableStorage::open_with_encryption(
+                dir.path(),
+                true,
+                MemTableType::Standard,
+                StorageEncryption::with_kek(kek(), "test"),
+            )
+            .unwrap();
+            assert!(storage.is_encrypted());
+            assert!(storage.durability_capabilities().at_rest_encryption);
+            storage.set_sync_mode(2);
+            let t = storage.begin_transaction().unwrap();
+            storage
+                .write(t, b"secret-key".to_vec(), b"secret-value".to_vec())
+                .unwrap();
+            storage.commit(t).unwrap();
+        } // clean drop releases the file lock
+
+        // The keyring exists and the WAL bytes do not leak the plaintext record.
+        assert!(dir.path().join("keyring.json").exists());
+        let raw = std::fs::read(dir.path().join("wal.log")).unwrap();
+        assert!(!contains(&raw, b"secret-value"), "value leaked to WAL");
+        assert!(!contains(&raw, b"secret-key"), "key leaked to WAL");
+
+        // Phase 2: reopen with the CORRECT key, recover, read back.
+        {
+            let storage = DurableStorage::open_with_encryption(
+                dir.path(),
+                true,
+                MemTableType::Standard,
+                StorageEncryption::with_kek(kek(), "test"),
+            )
+            .unwrap();
+            storage.recover().unwrap();
+            let t = storage.begin_transaction().unwrap();
+            assert_eq!(
+                storage.read(t, b"secret-key").unwrap(),
+                Some(b"secret-value".to_vec()),
+                "committed encrypted data must round-trip"
+            );
+            storage.abort(t).unwrap();
+        }
+
+        // Phase 3: WRONG key must fail closed (keyring canary), not open empty.
+        {
+            let wrong = DurableStorage::open_with_encryption(
+                dir.path(),
+                true,
+                MemTableType::Standard,
+                StorageEncryption::with_kek(EncryptionKey::new([0x00u8; 32]), "test"),
+            );
+            assert!(wrong.is_err(), "wrong KEK must fail closed");
+        }
+
+        // Phase 4: opening an encrypted DB with NO key must fail closed.
+        {
+            let no_key = DurableStorage::open_with_encryption(
+                dir.path(),
+                true,
+                MemTableType::Standard,
+                StorageEncryption::disabled(),
+            );
+            assert!(
+                no_key.is_err(),
+                "encrypted DB opened without key must fail closed"
+            );
+        }
+    }
+
+    /// A plaintext DB reports at_rest_encryption=false on the live matrix.
+    #[test]
+    fn test_plaintext_db_reports_unencrypted() {
+        let dir = tempdir().unwrap();
+        let storage = DurableStorage::open_without_lock(dir.path()).unwrap();
+        assert!(!storage.is_encrypted());
+        assert!(!storage.durability_capabilities().at_rest_encryption);
+        assert!(storage.durability_capabilities().crash_recovery);
+        assert!(!dir.path().join("keyring.json").exists());
+    }
+
+    fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+        haystack.windows(needle.len()).any(|w| w == needle)
     }
 
     /// Crash-atomicity invariant (Task 4 — completes the Task 1 single-writer

--- a/sochdb-storage/src/encryption.rs
+++ b/sochdb-storage/src/encryption.rs
@@ -33,9 +33,12 @@
 
 use aes_gcm_siv::{
     Aes256GcmSiv, Nonce,
-    aead::{Aead, KeyInit, OsRng},
+    aead::{Aead, KeyInit, OsRng, Payload},
 };
+use hkdf::Hkdf;
 use rand::RngCore;
+use sha2::Sha256;
+use sochdb_core::SochDBError;
 use zeroize::Zeroize;
 
 /// Current encryption format version.
@@ -69,6 +72,14 @@ impl EncryptionEngine {
         }
     }
 
+    /// Create an encryption engine from a zeroize-on-drop [`EncryptionKey`].
+    ///
+    /// Preferred over [`Self::new`] on the live path: the caller holds the key
+    /// material in a wiping container rather than a bare `[u8; 32]`.
+    pub fn from_key(key: &EncryptionKey) -> Self {
+        Self::new(key.as_bytes())
+    }
+
     /// Create a disabled (passthrough) encryption engine.
     ///
     /// `encrypt()` and `decrypt()` are identity operations when disabled.
@@ -97,7 +108,30 @@ impl EncryptionEngine {
     /// ~4 GB/s on x86_64 with AES-NI. The overhead is the 13-byte header
     /// plus 16-byte auth tag per block.
     pub fn encrypt(&self, plaintext: &[u8]) -> Result<Vec<u8>, EncryptionError> {
+        self.encrypt_with_aad(plaintext, &[])
+    }
+
+    /// Encrypt a plaintext block, binding `aad` as additional authenticated data.
+    ///
+    /// Returns `[version(1) | nonce(12) | ciphertext+tag(N+16)]`. The `aad` is
+    /// NOT stored in the output — it is authenticated only, and the reader MUST
+    /// reconstruct the identical `aad` (e.g. `{format_version, db_uuid,
+    /// dek_epoch, record_LSN}`) from its own trusted state. Binding framing/
+    /// position as AAD is what prevents an attacker (or a corrupt/misdirected
+    /// write) from reordering, duplicating, splicing, or downgrading WAL records
+    /// — GCM-SIV alone authenticates only the isolated record body.
+    ///
+    /// AAD scope is part of the on-disk format and cannot be widened later
+    /// without a format break, so callers must commit to the full AAD tuple from
+    /// the first encrypted byte written.
+    pub fn encrypt_with_aad(
+        &self,
+        plaintext: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>, EncryptionError> {
         if !self.enabled {
+            // Passthrough MUST stay byte-identical to the legacy plaintext frame
+            // so an un-keyed DB is wire-compatible with pre-encryption binaries.
             return Ok(plaintext.to_vec());
         }
 
@@ -108,7 +142,13 @@ impl EncryptionEngine {
 
         let ciphertext = self
             .cipher
-            .encrypt(nonce, plaintext)
+            .encrypt(
+                nonce,
+                Payload {
+                    msg: plaintext,
+                    aad,
+                },
+            )
             .map_err(|_| EncryptionError::EncryptFailed)?;
 
         // Build output: version + nonce + ciphertext
@@ -124,6 +164,20 @@ impl EncryptionEngine {
     ///
     /// Validates the version byte and authentication tag.
     pub fn decrypt(&self, encrypted: &[u8]) -> Result<Vec<u8>, EncryptionError> {
+        self.decrypt_with_aad(encrypted, &[])
+    }
+
+    /// Decrypt an encrypted block, verifying it against the same `aad` the writer
+    /// bound via [`Self::encrypt_with_aad`]. A mismatched `aad` (e.g. a record
+    /// that was moved to a different LSN/position) fails authentication exactly
+    /// like a wrong key or tampered ciphertext — surfaced as
+    /// [`EncryptionError::DecryptFailed`], which callers MUST treat as a hard
+    /// error, never as a clean end-of-stream.
+    pub fn decrypt_with_aad(
+        &self,
+        encrypted: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>, EncryptionError> {
         if !self.enabled {
             return Ok(encrypted.to_vec());
         }
@@ -143,7 +197,13 @@ impl EncryptionEngine {
         let ciphertext = &encrypted[HEADER_SIZE..];
 
         self.cipher
-            .decrypt(nonce, ciphertext)
+            .decrypt(
+                nonce,
+                Payload {
+                    msg: ciphertext,
+                    aad,
+                },
+            )
             .map_err(|_| EncryptionError::DecryptFailed)
     }
 
@@ -160,6 +220,22 @@ impl EncryptionEngine {
         *buffer = encrypted;
         Ok(())
     }
+}
+
+/// HKDF-SHA256 expand: derive a 32-byte subkey from input key material.
+///
+/// Used so the operator-supplied secret (the KEK) is never used verbatim as a
+/// cipher key: the per-DB DEK and the keyring wrapping-key are both derived via
+/// this with a per-DB random salt and a distinct `info` label. The same env
+/// secret across two databases therefore yields independent keys.
+pub fn derive_subkey(ikm: &[u8], salt: &[u8], info: &[u8]) -> EncryptionKey {
+    let hk = Hkdf::<Sha256>::new(Some(salt), ikm);
+    let mut okm = [0u8; 32];
+    hk.expand(info, &mut okm)
+        .expect("HKDF expand of 32 bytes never fails");
+    let key = EncryptionKey::new(okm);
+    okm.zeroize();
+    key
 }
 
 /// Encryption error types.
@@ -190,7 +266,32 @@ impl std::fmt::Display for EncryptionError {
     }
 }
 
+impl EncryptionError {
+    /// Whether this error means the bytes failed integrity/authentication and
+    /// therefore CANNOT be a clean torn-tail. A torn write truncates the file —
+    /// it never produces a full-length frame that fails the AEAD tag, an
+    /// unsupported version, or a malformed envelope. WAL replay must treat these
+    /// as hard, recovery-aborting errors (wrong/missing key, key-epoch mismatch,
+    /// bit-rot, or tampering), never as end-of-WAL.
+    pub fn is_integrity_failure(&self) -> bool {
+        matches!(
+            self,
+            EncryptionError::DecryptFailed
+                | EncryptionError::InvalidFormat(_)
+                | EncryptionError::UnsupportedVersion(_)
+        )
+    }
+}
+
 impl std::error::Error for EncryptionError {}
+
+impl From<EncryptionError> for SochDBError {
+    fn from(e: EncryptionError) -> Self {
+        // Map to the dedicated `Encryption` variant (NOT `Io`) so replay loops
+        // never mistake an authentication failure for a torn-tail EOF.
+        SochDBError::Encryption(e.to_string())
+    }
+}
 
 /// Generate a new random 256-bit encryption key.
 ///
@@ -322,17 +423,90 @@ mod tests {
         // Too short
         assert!(engine.decrypt(&[1, 2, 3]).is_err());
         // Wrong version
-        let mut fake = vec![99u8; 50];
+        let fake = vec![99u8; 50];
         assert!(engine.decrypt(&fake).is_err());
     }
 
     #[test]
     fn test_key_zeroize() {
-        let mut key = EncryptionKey::new(generate_key());
+        let key = EncryptionKey::new(generate_key());
         assert_ne!(key.as_bytes(), &[0u8; 32]);
         drop(key);
         // After drop, memory should be zeroed (we can't read it, but the Zeroize
         // derive guarantees it)
+    }
+
+    #[test]
+    fn test_aad_roundtrip() {
+        let key = generate_key();
+        let engine = EncryptionEngine::new(&key);
+        let aad = b"v1|db-uuid|epoch=0|lsn=42";
+
+        let ct = engine.encrypt_with_aad(b"payload", aad).unwrap();
+        let pt = engine.decrypt_with_aad(&ct, aad).unwrap();
+        assert_eq!(pt, b"payload");
+    }
+
+    #[test]
+    fn test_aad_mismatch_fails_like_wrong_key() {
+        let key = generate_key();
+        let engine = EncryptionEngine::new(&key);
+
+        // A record encrypted at lsn=42 must NOT authenticate when the reader
+        // reconstructs aad for a different position (splice/reorder defense).
+        let ct = engine
+            .encrypt_with_aad(b"committed record", b"...|lsn=42")
+            .unwrap();
+        let err = engine.decrypt_with_aad(&ct, b"...|lsn=43").unwrap_err();
+        assert!(matches!(err, EncryptionError::DecryptFailed));
+        assert!(err.is_integrity_failure());
+    }
+
+    #[test]
+    fn test_no_aad_is_not_same_as_some_aad() {
+        let key = generate_key();
+        let engine = EncryptionEngine::new(&key);
+        let ct = engine.encrypt_with_aad(b"x", b"bound").unwrap();
+        // Decrypting the same ciphertext with empty aad must fail.
+        assert!(engine.decrypt(&ct).is_err());
+        // And the plain encrypt()/decrypt() pair (empty aad) round-trips.
+        let ct2 = engine.encrypt(b"x").unwrap();
+        assert_eq!(engine.decrypt(&ct2).unwrap(), b"x");
+    }
+
+    #[test]
+    fn test_integrity_failure_classification() {
+        assert!(EncryptionError::DecryptFailed.is_integrity_failure());
+        assert!(EncryptionError::UnsupportedVersion(9).is_integrity_failure());
+        assert!(EncryptionError::InvalidFormat("x".into()).is_integrity_failure());
+        // EncryptFailed is a write-side fault, not a replay terminator concern.
+        assert!(!EncryptionError::EncryptFailed.is_integrity_failure());
+    }
+
+    #[test]
+    fn test_hkdf_deterministic_and_salt_separated() {
+        let kek = b"operator-supplied-kek-material";
+        let salt_a = [1u8; 16];
+        let salt_b = [2u8; 16];
+
+        // Same inputs -> same key (deterministic unwrap on reopen).
+        let k1 = derive_subkey(kek, &salt_a, b"sochdb/dek/v1");
+        let k2 = derive_subkey(kek, &salt_a, b"sochdb/dek/v1");
+        assert_eq!(k1.as_bytes(), k2.as_bytes());
+
+        // Different salt (per-DB) -> different key, so the same env secret across
+        // two databases yields independent DEKs.
+        let k3 = derive_subkey(kek, &salt_b, b"sochdb/dek/v1");
+        assert_ne!(k1.as_bytes(), k3.as_bytes());
+
+        // Different info label -> different key (DEK vs wrapping-key separation).
+        let k4 = derive_subkey(kek, &salt_a, b"sochdb/wrap/v1");
+        assert_ne!(k1.as_bytes(), k4.as_bytes());
+
+        // Derived key is usable.
+        let engine = EncryptionEngine::from_key(&k1);
+        let ct = engine.encrypt(b"hi").unwrap();
+        assert_eq!(engine.decrypt(&ct).unwrap(), b"hi");
     }
 
     #[test]

--- a/sochdb-storage/src/keyring.rs
+++ b/sochdb-storage/src/keyring.rs
@@ -1,0 +1,541 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SochDB - LLM-Optimized Embedded Database
+// Copyright (C) 2026 Sushanth Reddy Vanagala (https://github.com/sushanthpy)
+
+//! # Keyring — KEK/DEK envelope for data-at-rest encryption (Task 3B)
+//!
+//! The keyring is the per-database key-management substrate that sits in front
+//! of [`crate::encryption::EncryptionEngine`]. It exists so that:
+//!
+//! - The operator-supplied secret (the **KEK**, e.g. `SOCHDB_ENCRYPTION_KEY` or
+//!   an embedded `ConnectionConfig.encryption` key) is **never** used verbatim
+//!   as the cipher key. Instead a random per-DB **DEK** is generated, and the
+//!   KEK only wraps it. Rotating the KEK is then a cheap re-wrap — it does NOT
+//!   require re-encrypting any data.
+//! - A wrong or missing key is caught **fail-closed at open**, before a single
+//!   WAL byte is read, via an authenticated descriptor MAC and a DEK canary —
+//!   never silently degrading to a plaintext read or an "empty" database.
+//! - A `key_epoch` is reserved from the first encrypted byte, so future DEK
+//!   rotation is expressible on disk without a format break.
+//!
+//! ## On-disk descriptor (`<db_dir>/keyring.json`)
+//!
+//! The **presence** of this file with `encrypted=true` is the source of truth
+//! that a database is encrypted. A plaintext DB has no keyring file at all
+//! (preserving byte-compatibility with pre-3B binaries). All byte fields are
+//! hex-encoded. The whole descriptor is authenticated by `mac` =
+//! HMAC-SHA256(HKDF(KEK, salt, "keyring-mac"), canonical-fields), so an attacker
+//! or a bad rollback cannot flip `encrypted` to `false` to force a downgrade.
+//!
+//! ```text
+//! { format_version, encrypted, db_uuid, kek_source_id, key_epoch,
+//!   salt, wrapped_dek, canary, mac }
+//! ```
+//!
+//! - `wrapped_dek` = AEAD(HKDF(KEK,salt,"wrap")).encrypt(DEK, aad=wrap_aad)
+//! - `canary`      = AEAD(DEK).encrypt(CANARY_TOKEN, aad=canary_aad)
+//!
+//! On open we (1) verify the MAC with the KEK, (2) unwrap the DEK, (3) decrypt
+//! the canary with the DEK. Any failure ⇒ hard error (wrong/missing KEK or
+//! tampering). Only after all three pass is the WAL touched.
+
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+use crate::encryption::{EncryptionEngine, EncryptionKey, derive_subkey, generate_key};
+use sochdb_core::{Result, SochDBError};
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Current keyring descriptor format version.
+const KEYRING_FORMAT_VERSION: u32 = 1;
+/// Keyring file name within the database directory.
+pub const KEYRING_FILE_NAME: &str = "keyring.json";
+/// Fixed plaintext token sealed under the DEK to detect a wrong key at open.
+const CANARY_TOKEN: &[u8] = b"sochdb-keyring-canary-v1";
+/// HKDF info labels — keep these stable; they are part of the on-disk contract.
+const INFO_WRAP: &[u8] = b"sochdb/keyring/wrap/v1";
+const INFO_MAC: &[u8] = b"sochdb/keyring/mac/v1";
+
+/// The resolved encryption state for an opened database.
+///
+/// `Plaintext` carries a disabled engine (identity passthrough, byte-identical
+/// legacy frames). `Encrypted` carries the live DEK-backed engine plus the
+/// `db_uuid` and `key_epoch` that the WAL binds into every record's AAD.
+pub enum EncryptionState {
+    Plaintext,
+    Encrypted(ActiveEncryption),
+}
+
+impl std::fmt::Debug for EncryptionState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Deliberately does NOT print key material.
+        match self {
+            EncryptionState::Plaintext => write!(f, "EncryptionState::Plaintext"),
+            EncryptionState::Encrypted(a) => write!(
+                f,
+                "EncryptionState::Encrypted {{ db_uuid: {}, key_epoch: {} }}",
+                hex::encode(a.db_uuid),
+                a.key_epoch
+            ),
+        }
+    }
+}
+
+impl EncryptionState {
+    /// Whether at-rest encryption is active for this database.
+    pub fn is_encrypted(&self) -> bool {
+        matches!(self, EncryptionState::Encrypted(_))
+    }
+
+    /// The engine to hand to the WAL (disabled passthrough if plaintext).
+    pub fn engine(&self) -> Arc<EncryptionEngine> {
+        match self {
+            EncryptionState::Plaintext => Arc::new(EncryptionEngine::disabled()),
+            EncryptionState::Encrypted(a) => a.engine.clone(),
+        }
+    }
+
+    /// 16-byte DB identity bound into WAL AAD (all-zero for plaintext, unused).
+    pub fn db_uuid(&self) -> [u8; 16] {
+        match self {
+            EncryptionState::Plaintext => [0u8; 16],
+            EncryptionState::Encrypted(a) => a.db_uuid,
+        }
+    }
+
+    /// Active DEK epoch (0 for plaintext, unused).
+    pub fn key_epoch(&self) -> u32 {
+        match self {
+            EncryptionState::Plaintext => 0,
+            EncryptionState::Encrypted(a) => a.key_epoch,
+        }
+    }
+}
+
+/// Live encryption context for an encrypted database.
+pub struct ActiveEncryption {
+    pub engine: Arc<EncryptionEngine>,
+    pub db_uuid: [u8; 16],
+    pub key_epoch: u32,
+}
+
+/// On-disk keyring descriptor (hex-encoded byte fields).
+#[derive(serde::Serialize, serde::Deserialize)]
+struct KeyringFile {
+    format_version: u32,
+    encrypted: bool,
+    db_uuid: String,
+    kek_source_id: String,
+    key_epoch: u32,
+    salt: String,
+    wrapped_dek: String,
+    canary: String,
+    mac: String,
+}
+
+/// Resolve the encryption state for a database directory.
+///
+/// Contract (the file's presence + `encrypted` flag is the source of truth):
+/// - **keyring present, `encrypted=true`**: `kek` is REQUIRED. We verify the
+///   descriptor MAC, unwrap the DEK, and check the canary. Any failure (wrong
+///   key, missing key, tamper) is a hard, fail-closed error — we never fall
+///   back to a disabled engine. Returns `Encrypted`.
+/// - **keyring present, `encrypted=false`**: plaintext DB. Returns `Plaintext`.
+/// - **keyring absent + `kek = Some`**: a *new* encrypted DB. Generates a DEK,
+///   wraps it, writes the keyring atomically. `allow_create` MUST be true (the
+///   caller asserts this is not an existing plaintext DB). Returns `Encrypted`.
+/// - **keyring absent + `kek = None`**: legacy/plaintext DB. Returns `Plaintext`.
+pub fn load_or_init(
+    db_dir: &Path,
+    kek: Option<&EncryptionKey>,
+    source_id: &str,
+    allow_create: bool,
+) -> Result<EncryptionState> {
+    let path = keyring_path(db_dir);
+
+    if path.exists() {
+        let file: KeyringFile = read_keyring(&path)?;
+        if file.format_version != KEYRING_FORMAT_VERSION {
+            return Err(SochDBError::Encryption(format!(
+                "unsupported keyring format version {} (expected {})",
+                file.format_version, KEYRING_FORMAT_VERSION
+            )));
+        }
+        // A keyring file is ONLY ever written for an encrypted database, so its
+        // mere presence means a KEK is required. Resolve it fail-closed BEFORE
+        // honoring the `encrypted` flag — otherwise an attacker could flip
+        // `encrypted` to false (or drop the env key) to force a plaintext
+        // downgrade. The descriptor MAC (verified inside `open_encrypted`, and
+        // re-checked below for the plaintext-marker case) cannot be recomputed
+        // without the KEK, so a forged `encrypted=false` is rejected.
+        let kek = kek.ok_or_else(|| {
+            SochDBError::Encryption(
+                "database has a keyring (encryption configured) but no \
+                 encryption key was provided (set the KEK, e.g. \
+                 SOCHDB_ENCRYPTION_KEY); refusing to open"
+                    .to_string(),
+            )
+        })?;
+        // Authenticate the descriptor with the KEK first. This rejects a forged
+        // `encrypted=false` downgrade, since the MAC covers the `encrypted`
+        // field and cannot be reforged without the KEK.
+        verify_mac(&file, kek)?;
+        if !file.encrypted {
+            // MAC-authenticated plaintext marker (not written by current code,
+            // but honored if it ever authenticates — defensive forward-compat).
+            return Ok(EncryptionState::Plaintext);
+        }
+        open_encrypted(file, kek)
+    } else if let Some(kek) = kek {
+        if !allow_create {
+            return Err(SochDBError::Encryption(
+                "an encryption key was provided for a database that has no \
+                 keyring (existing plaintext data must be migrated explicitly, \
+                 not encrypted in place); refusing to open"
+                    .to_string(),
+            ));
+        }
+        create_encrypted(db_dir, &path, kek, source_id)
+    } else {
+        Ok(EncryptionState::Plaintext)
+    }
+}
+
+fn keyring_path(db_dir: &Path) -> PathBuf {
+    db_dir.join(KEYRING_FILE_NAME)
+}
+
+fn read_keyring(path: &Path) -> Result<KeyringFile> {
+    let bytes = fs::read(path)?;
+    serde_json::from_slice(&bytes)
+        .map_err(|e| SochDBError::Encryption(format!("malformed keyring: {e}")))
+}
+
+/// Build the canonical, deterministic byte string the MAC authenticates.
+/// Length-prefixed fields so no two distinct descriptors collide.
+fn mac_input(file: &KeyringFile) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut push = |b: &[u8]| {
+        out.extend_from_slice(&(b.len() as u32).to_le_bytes());
+        out.extend_from_slice(b);
+    };
+    push(&file.format_version.to_le_bytes());
+    push(&[file.encrypted as u8]);
+    push(file.db_uuid.as_bytes());
+    push(file.kek_source_id.as_bytes());
+    push(&file.key_epoch.to_le_bytes());
+    push(file.salt.as_bytes());
+    push(file.wrapped_dek.as_bytes());
+    push(file.canary.as_bytes());
+    out
+}
+
+fn compute_mac(mac_key: &EncryptionKey, file: &KeyringFile) -> Vec<u8> {
+    let mut mac = <HmacSha256 as Mac>::new_from_slice(mac_key.as_bytes())
+        .expect("HMAC accepts any key length");
+    mac.update(&mac_input(file));
+    mac.finalize().into_bytes().to_vec()
+}
+
+/// AAD binding the wrapped DEK to this DB identity + epoch + KEK source, so a
+/// wrapped DEK cannot be spliced into a different DB/epoch under a shared KEK.
+fn wrap_aad(db_uuid: &[u8; 16], epoch: u32, source_id: &str) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(16 + 4 + source_id.len());
+    aad.extend_from_slice(db_uuid);
+    aad.extend_from_slice(&epoch.to_le_bytes());
+    aad.extend_from_slice(source_id.as_bytes());
+    aad
+}
+
+fn canary_aad(db_uuid: &[u8; 16], epoch: u32) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(16 + 4);
+    aad.extend_from_slice(db_uuid);
+    aad.extend_from_slice(&epoch.to_le_bytes());
+    aad
+}
+
+fn create_encrypted(
+    db_dir: &Path,
+    path: &Path,
+    kek: &EncryptionKey,
+    source_id: &str,
+) -> Result<EncryptionState> {
+    let mut db_uuid = [0u8; 16];
+    {
+        use rand::RngCore;
+        rand::rngs::OsRng.fill_bytes(&mut db_uuid);
+    }
+    let mut salt = [0u8; 16];
+    {
+        use rand::RngCore;
+        rand::rngs::OsRng.fill_bytes(&mut salt);
+    }
+    let epoch: u32 = 0;
+
+    // Random per-DB DEK; this is what actually encrypts data.
+    let dek = EncryptionKey::new(generate_key());
+
+    // Wrap the DEK under a wrapping key derived from the KEK.
+    let wrap_key = derive_subkey(kek.as_bytes(), &salt, INFO_WRAP);
+    let wrap_engine = EncryptionEngine::from_key(&wrap_key);
+    let wrapped_dek =
+        wrap_engine.encrypt_with_aad(dek.as_bytes(), &wrap_aad(&db_uuid, epoch, source_id))?;
+
+    // Seal a canary under the DEK so a wrong key is detected at open.
+    let dek_engine = EncryptionEngine::from_key(&dek);
+    let canary = dek_engine.encrypt_with_aad(CANARY_TOKEN, &canary_aad(&db_uuid, epoch))?;
+
+    let mut file = KeyringFile {
+        format_version: KEYRING_FORMAT_VERSION,
+        encrypted: true,
+        db_uuid: hex::encode(db_uuid),
+        kek_source_id: source_id.to_string(),
+        key_epoch: epoch,
+        salt: hex::encode(salt),
+        wrapped_dek: hex::encode(&wrapped_dek),
+        canary: hex::encode(&canary),
+        mac: String::new(),
+    };
+    let mac_key = derive_subkey(kek.as_bytes(), &salt, INFO_MAC);
+    file.mac = hex::encode(compute_mac(&mac_key, &file));
+
+    write_keyring_atomic(db_dir, path, &file)?;
+
+    Ok(EncryptionState::Encrypted(ActiveEncryption {
+        engine: Arc::new(dek_engine),
+        db_uuid,
+        key_epoch: epoch,
+    }))
+}
+
+/// Verify the descriptor MAC with the KEK. A wrong KEK or any tampering of an
+/// authenticated field (e.g. `encrypted` flipped to false, epoch altered) fails
+/// here — the MAC cannot be recomputed without the KEK.
+fn verify_mac(file: &KeyringFile, kek: &EncryptionKey) -> Result<()> {
+    let salt = decode_fixed::<16>(&file.salt, "salt")?;
+    let mac_key = derive_subkey(kek.as_bytes(), &salt, INFO_MAC);
+    let expected = compute_mac(&mac_key, file);
+    let actual = hex::decode(&file.mac)
+        .map_err(|_| SochDBError::Encryption("malformed keyring mac".into()))?;
+    if !constant_time_eq(&expected, &actual) {
+        return Err(SochDBError::Encryption(
+            "keyring authentication failed: wrong encryption key or tampered \
+             keyring; refusing to open"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn open_encrypted(file: KeyringFile, kek: &EncryptionKey) -> Result<EncryptionState> {
+    // MAC is already verified by the caller (load_or_init).
+    let salt = decode_fixed::<16>(&file.salt, "salt")?;
+    let db_uuid = decode_fixed::<16>(&file.db_uuid, "db_uuid")?;
+    let epoch = file.key_epoch;
+
+    // Unwrap the DEK.
+    let wrap_key = derive_subkey(kek.as_bytes(), &salt, INFO_WRAP);
+    let wrap_engine = EncryptionEngine::from_key(&wrap_key);
+    let wrapped_dek = hex::decode(&file.wrapped_dek)
+        .map_err(|_| SochDBError::Encryption("malformed wrapped_dek".into()))?;
+    let dek_bytes = wrap_engine
+        .decrypt_with_aad(
+            &wrapped_dek,
+            &wrap_aad(&db_uuid, epoch, &file.kek_source_id),
+        )
+        .map_err(|_| {
+            SochDBError::Encryption(
+                "failed to unwrap data key: wrong encryption key; refusing to open".into(),
+            )
+        })?;
+    if dek_bytes.len() != 32 {
+        return Err(SochDBError::Encryption(
+            "unwrapped DEK is not 32 bytes".into(),
+        ));
+    }
+    let mut dek_arr = [0u8; 32];
+    dek_arr.copy_from_slice(&dek_bytes);
+    let dek = EncryptionKey::new(dek_arr);
+
+    // Canary check: prove the DEK actually decrypts data before touching WAL.
+    let dek_engine = EncryptionEngine::from_key(&dek);
+    let canary = hex::decode(&file.canary)
+        .map_err(|_| SochDBError::Encryption("malformed canary".into()))?;
+    let token = dek_engine
+        .decrypt_with_aad(&canary, &canary_aad(&db_uuid, epoch))
+        .map_err(|_| {
+            SochDBError::Encryption(
+                "canary decryption failed: wrong encryption key; refusing to open".into(),
+            )
+        })?;
+    if token != CANARY_TOKEN {
+        return Err(SochDBError::Encryption(
+            "canary token mismatch; refusing to open".into(),
+        ));
+    }
+
+    Ok(EncryptionState::Encrypted(ActiveEncryption {
+        engine: Arc::new(dek_engine),
+        db_uuid,
+        key_epoch: epoch,
+    }))
+}
+
+fn decode_fixed<const N: usize>(hexstr: &str, what: &str) -> Result<[u8; N]> {
+    let v = hex::decode(hexstr)
+        .map_err(|_| SochDBError::Encryption(format!("malformed keyring {what}")))?;
+    if v.len() != N {
+        return Err(SochDBError::Encryption(format!(
+            "keyring {what} wrong length: {} != {N}",
+            v.len()
+        )));
+    }
+    let mut a = [0u8; N];
+    a.copy_from_slice(&v);
+    Ok(a)
+}
+
+/// Constant-time equality for MAC comparison.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Atomically persist the keyring: write temp, fsync file, rename, fsync dir.
+fn write_keyring_atomic(db_dir: &Path, path: &Path, file: &KeyringFile) -> Result<()> {
+    fs::create_dir_all(db_dir)?;
+    let json = serde_json::to_vec_pretty(file)
+        .map_err(|e| SochDBError::Encryption(format!("serialize keyring: {e}")))?;
+    let tmp = path.with_extension("json.tmp");
+    {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(&json)?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp, path)?;
+    // fsync the directory so the rename is durable.
+    if let Ok(dir) = fs::File::open(db_dir) {
+        let _ = dir.sync_all();
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn kek(seed: u8) -> EncryptionKey {
+        EncryptionKey::new([seed; 32])
+    }
+
+    #[test]
+    fn plaintext_when_no_key_and_no_file() {
+        let dir = tempdir().unwrap();
+        let st = load_or_init(dir.path(), None, "test", true).unwrap();
+        assert!(!st.is_encrypted());
+        assert!(!dir.path().join(KEYRING_FILE_NAME).exists());
+    }
+
+    #[test]
+    fn create_then_reopen_roundtrips_dek() {
+        let dir = tempdir().unwrap();
+        let st = load_or_init(dir.path(), Some(&kek(7)), "env", true).unwrap();
+        assert!(st.is_encrypted());
+        let uuid1 = st.db_uuid();
+        // Engine actually encrypts.
+        let ct = st.engine().encrypt(b"secret").unwrap();
+        assert_ne!(ct, b"secret");
+
+        // Reopen with the SAME kek -> same DEK -> can decrypt the ciphertext.
+        let st2 = load_or_init(dir.path(), Some(&kek(7)), "env", false).unwrap();
+        assert!(st2.is_encrypted());
+        assert_eq!(st2.db_uuid(), uuid1);
+        assert_eq!(st2.engine().decrypt(&ct).unwrap(), b"secret");
+    }
+
+    #[test]
+    fn reopen_with_wrong_key_fails_closed() {
+        let dir = tempdir().unwrap();
+        load_or_init(dir.path(), Some(&kek(1)), "env", true).unwrap();
+        let err = load_or_init(dir.path(), Some(&kek(2)), "env", false).unwrap_err();
+        // Must be a hard encryption error, NOT a silent plaintext/empty open.
+        assert!(matches!(err, SochDBError::Encryption(_)));
+    }
+
+    #[test]
+    fn reopen_encrypted_without_key_fails_closed() {
+        let dir = tempdir().unwrap();
+        load_or_init(dir.path(), Some(&kek(1)), "env", true).unwrap();
+        let err = load_or_init(dir.path(), None, "env", true).unwrap_err();
+        assert!(matches!(err, SochDBError::Encryption(_)));
+    }
+
+    #[test]
+    fn forging_encrypted_false_is_rejected_by_mac() {
+        let dir = tempdir().unwrap();
+        load_or_init(dir.path(), Some(&kek(9)), "env", true).unwrap();
+        let path = dir.path().join(KEYRING_FILE_NAME);
+
+        // Attacker flips encrypted -> false to force a plaintext downgrade.
+        let mut file: KeyringFile = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        file.encrypted = false;
+        fs::write(&path, serde_json::to_vec_pretty(&file).unwrap()).unwrap();
+
+        // MAC is verified BEFORE the encrypted flag is honored, and the MAC
+        // covers `encrypted`, so the forgery is rejected fail-closed — never a
+        // silent plaintext/empty open.
+        let err = load_or_init(dir.path(), Some(&kek(9)), "env", false).unwrap_err();
+        assert!(matches!(err, SochDBError::Encryption(_)));
+    }
+
+    #[test]
+    fn keyring_present_but_no_key_fails_even_if_flag_says_plaintext() {
+        let dir = tempdir().unwrap();
+        load_or_init(dir.path(), Some(&kek(4)), "env", true).unwrap();
+        let path = dir.path().join(KEYRING_FILE_NAME);
+        let mut file: KeyringFile = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        file.encrypted = false; // forged
+        fs::write(&path, serde_json::to_vec_pretty(&file).unwrap()).unwrap();
+
+        // No key supplied + keyring present ⇒ refuse (presence implies encryption).
+        let err = load_or_init(dir.path(), None, "env", false).unwrap_err();
+        assert!(matches!(err, SochDBError::Encryption(_)));
+    }
+
+    #[test]
+    fn tampering_authenticated_field_is_rejected() {
+        let dir = tempdir().unwrap();
+        load_or_init(dir.path(), Some(&kek(5)), "env", true).unwrap();
+        let path = dir.path().join(KEYRING_FILE_NAME);
+
+        let mut file: KeyringFile = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        // Tamper an authenticated field while keeping encrypted=true.
+        file.key_epoch = 999;
+        fs::write(&path, serde_json::to_vec_pretty(&file).unwrap()).unwrap();
+
+        let err = load_or_init(dir.path(), Some(&kek(5)), "env", false).unwrap_err();
+        assert!(matches!(err, SochDBError::Encryption(_)));
+    }
+
+    #[test]
+    fn key_provided_for_existing_plaintext_db_without_create_fails() {
+        let dir = tempdir().unwrap();
+        // Simulate an existing plaintext DB: a wal.log but no keyring.
+        fs::write(dir.path().join("wal.log"), b"legacy").unwrap();
+        let err = load_or_init(dir.path(), Some(&kek(3)), "env", false).unwrap_err();
+        assert!(matches!(err, SochDBError::Encryption(_)));
+    }
+}

--- a/sochdb-storage/src/lib.rs
+++ b/sochdb-storage/src/lib.rs
@@ -85,8 +85,7 @@ pub mod correctness_testing; // Property-based correctness testing (Task 13)
 pub mod database; // Database Kernel (shared by embedded + server)
 pub mod durability_contract; // Durability contract hardening (Task 4)
 pub mod durable_storage; // Fully wired durable storage with MVCC
-#[cfg(feature = "experimental")]
-pub mod encryption; // Data-at-rest encryption (AES-256-GCM-SIV) [quarantined: unwired]
+pub mod encryption; // Data-at-rest encryption (AES-256-GCM-SIV envelope) — now wired (Task 3B)
 pub mod ffi;
 pub mod group_commit; // Event-driven Group Commit (Task 4)
 pub mod hlc; // Hybrid Logical Clock for commit timestamps (mm.md Task 1.3)
@@ -95,6 +94,7 @@ pub mod io_isolation; // I/O isolation policy with cache partitioning (Task 5)
 pub mod ipc; // IPC Protocol with multiplexing (mm.md Task 7.1)
 #[cfg(unix)]
 pub mod ipc_server; // Unix Socket IPC Server (Task 3)
+pub mod keyring; // KEK/DEK envelope: HKDF-derived DEK, wrapped + persisted, fail-closed (Task 3B)
 pub mod learned_index_integration;
 pub mod lock; // Advisory file locking for database exclusivity
 pub mod lscs;
@@ -320,10 +320,14 @@ pub use durable_storage::{
 pub struct DurabilityCapabilities {
     /// Crash-consistent WAL recovery (txn_wal / RecoveryStats / durability_contract). Live.
     pub crash_recovery: bool,
-    /// At-rest encryption (AES-256-GCM-SIV). The `encryption` module exists but
-    /// is quarantined behind `experimental` and unwired — not on the live path.
+    /// At-rest encryption (AES-256-GCM-SIV envelope). Wired into the live WAL path
+    /// (Task 3B): inactive by default, active per-database when a key is configured.
+    /// The build-level `durability_capabilities()` reports the DEFAULT (false);
+    /// query `DurableStorage::durability_capabilities()` for the live per-instance
+    /// state.
     pub at_rest_encryption: bool,
-    /// Point-in-time recovery via WAL archiving. `pitr` module, quarantined/unwired.
+    /// Point-in-time recovery via WAL archiving. `pitr` module — substrate landing
+    /// incrementally (Task 3B); reported true per-instance once archiving is active.
     pub point_in_time_recovery: bool,
     /// ARIES-style checkpointing. `aries_recovery` / `checkpoint` modules, quarantined/unwired.
     pub aries_checkpoint: bool,
@@ -331,10 +335,12 @@ pub struct DurabilityCapabilities {
     pub wal_fencing: bool,
 }
 
-/// The durability capabilities of the current build — a function of what is
-/// actually wired, not of documentation. The quarantined subsystems require the
-/// `experimental` feature AND live wiring that does not yet exist (Task 3B), so
-/// they report `false` here regardless of feature flags.
+/// The DEFAULT durability capabilities of the current build — a function of what
+/// is actually wired, not of documentation. At-rest encryption is now wired into
+/// the live WAL path (Task 3B) but is INACTIVE unless a key is configured, so the
+/// build default reports it `false`. For the live per-database state (which
+/// reflects whether encryption is actually active on that instance), call
+/// [`durable_storage::DurableStorage::durability_capabilities`].
 pub const fn durability_capabilities() -> DurabilityCapabilities {
     DurabilityCapabilities {
         crash_recovery: true,

--- a/sochdb-storage/src/txn_wal.rs
+++ b/sochdb-storage/src/txn_wal.rs
@@ -48,6 +48,7 @@
 //! 3. **Uncommitted Rollback**: Transactions without commit record are discarded
 //! 4. **Checkpoint Safety**: Checkpoint marker allows safe WAL truncation
 
+use crate::encryption::EncryptionEngine;
 use byteorder::{LittleEndian, ReadBytesExt};
 use parking_lot::Mutex;
 use sochdb_core::{Result, SochDBError, WalRecordType};
@@ -56,6 +57,7 @@ use std::collections::HashSet;
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
@@ -118,6 +120,75 @@ const CHECKSUM_SIZE: usize = 4;
 
 /// Default capacity for transaction-local WAL buffer (32 KB - typical batch of 100-500 writes)
 const DEFAULT_TXN_BUFFER_CAPACITY: usize = 32 * 1024;
+
+// =============================================================================
+// At-rest encryption framing (Task 3B)
+// =============================================================================
+//
+// When the WAL's `EncryptionEngine` is enabled, each record is written as an
+// encrypted frame instead of the plaintext frame above:
+//
+// ```text
+//   plaintext frame:  [content_len:u32][type|txn|ts|klen|vlen|key|val|crc32]
+//   encrypted frame:  [outer_len:u32  ][ver|nonce(12)|ciphertext+tag(16)]
+// ```
+//
+// `outer_len` is the length of the AEAD envelope (ciphertext.len()); the inner
+// plaintext that the envelope protects is the record BODY — exactly the bytes
+// after `content_len` in the plaintext frame (`type..crc32`). On decrypt the
+// body is parsed by [`TxnWalEntry::parse_body`], reusing the same field layout +
+// CRC check as the plaintext path.
+//
+// The per-record AAD binds {format_version, db_uuid, dek_epoch, file-relative
+// record ordinal} so a record cannot be reordered, duplicated, spliced from
+// another DB, or read under a downgraded format without failing authentication.
+// The reader reconstructs the identical AAD from its own trusted state (the
+// keyring's db_uuid/epoch and a 0-based counter of records read from this file),
+// NEVER from the attacker-controllable on-disk bytes.
+
+/// Encode a record BODY (`type|txn|ts|klen|vlen|key|val|crc32`) — the bytes the
+/// AEAD envelope protects, identical to `to_bytes()` minus the length prefix.
+/// Used by the encrypted write paths to materialize a record before sealing it.
+fn encode_record_body(
+    record_type: WalRecordType,
+    txn_id: u64,
+    timestamp_us: u64,
+    key: &[u8],
+    value: &[u8],
+) -> Vec<u8> {
+    let body_len = (RECORD_HEADER_SIZE - 4) + key.len() + value.len() + CHECKSUM_SIZE;
+    let mut body = Vec::with_capacity(body_len);
+    let mut hasher = crc32fast::Hasher::new();
+    let rt = record_type as u8;
+    body.push(rt);
+    hasher.update(&[rt]);
+    let t = txn_id.to_le_bytes();
+    body.extend_from_slice(&t);
+    hasher.update(&t);
+    let ts = timestamp_us.to_le_bytes();
+    body.extend_from_slice(&ts);
+    hasher.update(&ts);
+    let kl = (key.len() as u32).to_le_bytes();
+    body.extend_from_slice(&kl);
+    hasher.update(&kl);
+    let vl = (value.len() as u32).to_le_bytes();
+    body.extend_from_slice(&vl);
+    hasher.update(&vl);
+    body.extend_from_slice(key);
+    hasher.update(key);
+    body.extend_from_slice(value);
+    hasher.update(value);
+    body.extend_from_slice(&hasher.finalize().to_le_bytes());
+    body
+}
+
+/// AAD layout version for the WAL record binding. Part of the on-disk contract.
+const WAL_AAD_VERSION: u8 = 1;
+/// AAD length: version(1) + db_uuid(16) + dek_epoch(4) + record_ordinal(8).
+const WAL_AAD_LEN: usize = 1 + 16 + 4 + 8;
+/// Upper bound on a single WAL frame's on-disk length, to reject a corrupted
+/// length prefix before it triggers a multi-GB `read_exact` allocation/DoS.
+const MAX_WAL_FRAME_LEN: u32 = 512 * 1024 * 1024;
 
 // =============================================================================
 // Transaction-Local WAL Buffer - Zero Lock Overhead During Transaction
@@ -444,10 +515,16 @@ impl TxnWalEntry {
         buf
     }
 
-    /// Deserialize from bytes with torn write detection
+    /// Deserialize a PLAINTEXT WAL frame from a reader, with torn-write detection.
+    ///
+    /// This is the legacy / unencrypted reader. The live replay path on an
+    /// encrypted WAL does NOT use this — it uses [`TxnWal::read_record`], which
+    /// decrypts first and then calls [`Self::parse_body`]. Keeping this method
+    /// plaintext-only ensures a stray caller can never silently mis-parse
+    /// ciphertext as a plaintext frame.
     ///
     /// Returns error if:
-    /// - Length field indicates data is too short
+    /// - Length field indicates data is too short or implausibly large
     /// - CRC32 checksum mismatch (corruption or torn write)
     /// - Invalid record type
     pub fn from_reader<R: Read>(reader: &mut R) -> Result<Self> {
@@ -456,35 +533,42 @@ impl TxnWalEntry {
         if content_len < (RECORD_HEADER_SIZE - 4 + CHECKSUM_SIZE) as u32 {
             return Err(SochDBError::Corruption("WAL entry too short".into()));
         }
+        if content_len > MAX_WAL_FRAME_LEN {
+            return Err(SochDBError::Corruption(format!(
+                "WAL entry length {content_len} exceeds maximum {MAX_WAL_FRAME_LEN}"
+            )));
+        }
 
-        // Record type
-        let record_type_byte = reader.read_u8()?;
+        // Read the whole body, then parse. A short read here (torn tail) surfaces
+        // as Io(UnexpectedEof), which replay treats as a clean end-of-WAL.
+        let mut body = vec![0u8; content_len as usize];
+        reader.read_exact(&mut body)?;
+        Self::parse_body(&body)
+    }
+
+    /// Parse a record BODY (`type|txn|ts|klen|vlen|key|val|crc32`) and verify its
+    /// CRC. This is the bytes after the `content_len` prefix in a plaintext frame,
+    /// and is exactly what the AEAD envelope protects in an encrypted frame — so
+    /// both the plaintext and decrypt paths share this single parser.
+    pub fn parse_body(body: &[u8]) -> Result<Self> {
+        let mut cur = std::io::Cursor::new(body);
+
+        let record_type_byte = cur.read_u8()?;
         let record_type = WalRecordType::try_from(record_type_byte).map_err(|_| {
             SochDBError::Corruption(format!("Invalid record type: {}", record_type_byte))
         })?;
 
-        // Transaction ID
-        let txn_id = reader.read_u64::<LittleEndian>()?;
+        let txn_id = cur.read_u64::<LittleEndian>()?;
+        let timestamp_us = cur.read_u64::<LittleEndian>()?;
+        let key_len = cur.read_u32::<LittleEndian>()? as usize;
+        let value_len = cur.read_u32::<LittleEndian>()? as usize;
 
-        // Timestamp
-        let timestamp_us = reader.read_u64::<LittleEndian>()?;
-
-        // Key length
-        let key_len = reader.read_u32::<LittleEndian>()? as usize;
-
-        // Value length
-        let value_len = reader.read_u32::<LittleEndian>()? as usize;
-
-        // Key data
         let mut key = vec![0u8; key_len];
-        reader.read_exact(&mut key)?;
-
-        // Value data
+        cur.read_exact(&mut key)?;
         let mut value = vec![0u8; value_len];
-        reader.read_exact(&mut value)?;
+        cur.read_exact(&mut value)?;
 
-        // CRC32 Checksum
-        let stored_checksum = reader.read_u32::<LittleEndian>()?;
+        let stored_checksum = cur.read_u32::<LittleEndian>()?;
 
         let entry = Self {
             record_type,
@@ -506,6 +590,14 @@ impl TxnWalEntry {
 
         Ok(entry)
     }
+
+    /// The record BODY bytes (`type..crc32`) — i.e. `to_bytes()` without the
+    /// leading 4-byte content_len. This is what gets fed to the AEAD on the
+    /// encrypted write path.
+    fn body_bytes(&self) -> Vec<u8> {
+        let full = self.to_bytes();
+        full[4..].to_vec()
+    }
 }
 
 /// Transaction-aware Write-Ahead Log
@@ -523,11 +615,47 @@ pub struct TxnWal {
     /// Cached timestamp (microseconds since epoch)
     /// Updated periodically to avoid syscall per write
     cached_timestamp_us: AtomicU64,
+    /// At-rest encryption engine. `disabled()` (identity passthrough) for a
+    /// plaintext WAL — in which case every write/read path is byte-identical to
+    /// the pre-3B format. When enabled, records are written/read as encrypted
+    /// frames (see the framing notes above).
+    encryption: Arc<EncryptionEngine>,
+    /// 16-byte database identity bound into each record's AAD (cross-DB splice
+    /// defense). All-zero / unused when encryption is disabled.
+    db_uuid: [u8; 16],
+    /// Active DEK epoch bound into each record's AAD (downgrade-across-rotation
+    /// defense). 0 / unused when encryption is disabled.
+    dek_epoch: u32,
+    /// File-relative count of records written to the CURRENT WAL file (reset on
+    /// truncate). Used as the per-record AAD ordinal so reorder/duplication
+    /// within a file fails authentication. All writes hold the `writer` lock, so
+    /// this counter is only mutated under that lock; it is read locklessly by the
+    /// (single-threaded) replay paths.
+    records_in_file: AtomicU64,
 }
 
 impl TxnWal {
-    /// Create a new WAL or open existing one
+    /// Create a new plaintext WAL or open an existing one.
+    ///
+    /// Uses a disabled (passthrough) encryption engine, so the on-disk format is
+    /// byte-identical to the pre-encryption WAL. This is the constructor used by
+    /// every non-live caller (tests, tools); the live durable-storage path uses
+    /// [`Self::new_with_encryption`] to thread the keyring's engine in.
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
+        Self::new_with_encryption(path, Arc::new(EncryptionEngine::disabled()), [0u8; 16], 0)
+    }
+
+    /// Create/open a WAL with an explicit at-rest encryption engine.
+    ///
+    /// When `engine` is enabled, records are written and replayed as encrypted
+    /// frames bound to `db_uuid` + `dek_epoch` (see framing notes). When it is
+    /// disabled, this behaves exactly like [`Self::new`].
+    pub fn new_with_encryption<P: AsRef<Path>>(
+        path: P,
+        encryption: Arc<EncryptionEngine>,
+        db_uuid: [u8; 16],
+        dek_epoch: u32,
+    ) -> Result<Self> {
         let path = path.as_ref().to_path_buf();
 
         // Ensure parent directory exists
@@ -552,12 +680,76 @@ impl TxnWal {
             sequence: AtomicU64::new(0),
             bytes_since_sync: AtomicU64::new(0),
             cached_timestamp_us: AtomicU64::new(now_us),
+            encryption,
+            db_uuid,
+            dek_epoch,
+            records_in_file: AtomicU64::new(0),
         };
 
         // Recover state from existing WAL
         wal.recover_state()?;
 
         Ok(wal)
+    }
+
+    /// Build the per-record AAD for a given file-relative ordinal. The reader
+    /// reconstructs this from its own trusted state, never from on-disk bytes.
+    #[inline]
+    fn record_aad(&self, ordinal: u64) -> [u8; WAL_AAD_LEN] {
+        let mut aad = [0u8; WAL_AAD_LEN];
+        aad[0] = WAL_AAD_VERSION;
+        aad[1..17].copy_from_slice(&self.db_uuid);
+        aad[17..21].copy_from_slice(&self.dek_epoch.to_le_bytes());
+        aad[21..29].copy_from_slice(&ordinal.to_le_bytes());
+        aad
+    }
+
+    /// Frame a single record body for the encrypted write path:
+    /// `[outer_len:u32][version|nonce|ciphertext+tag]`, AAD-bound to `ordinal`.
+    #[inline]
+    fn encrypt_frame(&self, body: &[u8], ordinal: u64) -> Result<Vec<u8>> {
+        let env = self
+            .encryption
+            .encrypt_with_aad(body, &self.record_aad(ordinal))?;
+        let mut out = Vec::with_capacity(4 + env.len());
+        out.extend_from_slice(&(env.len() as u32).to_le_bytes());
+        out.extend_from_slice(&env);
+        Ok(out)
+    }
+
+    /// Read the next record from a replay reader, decrypting if the WAL is
+    /// encrypted. Returns the record and advances `*ordinal`.
+    ///
+    /// Error taxonomy (the linchpin of fail-loud recovery):
+    /// - `Io(UnexpectedEof)` reading the length prefix or a short body read at
+    ///   the physical tail ⇒ clean torn-tail / end-of-WAL (callers tolerate).
+    /// - `Encryption(_)` (AEAD auth failure / wrong key / bad envelope) or
+    ///   `Corruption(_)` (CRC / bad framing) ⇒ HARD error; callers MUST abort
+    ///   recovery rather than treat it as EOF.
+    fn read_record<R: Read>(&self, reader: &mut R, ordinal: &mut u64) -> Result<TxnWalEntry> {
+        if !self.encryption.is_enabled() {
+            let entry = TxnWalEntry::from_reader(reader)?;
+            *ordinal += 1;
+            return Ok(entry);
+        }
+        // Encrypted frame: [outer_len][envelope]
+        let outer_len = reader.read_u32::<LittleEndian>()?; // EOF here = clean end
+        if outer_len > MAX_WAL_FRAME_LEN {
+            return Err(SochDBError::Corruption(format!(
+                "encrypted WAL frame length {outer_len} exceeds maximum {MAX_WAL_FRAME_LEN}"
+            )));
+        }
+        let mut env = vec![0u8; outer_len as usize];
+        reader.read_exact(&mut env)?; // short read = torn tail (UnexpectedEof)
+        // Decrypt with the AAD reconstructed for THIS ordinal. A wrong key, a
+        // reordered/spliced record, or tampering fails here as Encryption(_),
+        // which is a hard error — never a silent EOF.
+        let body = self
+            .encryption
+            .decrypt_with_aad(&env, &self.record_aad(*ordinal))?;
+        let entry = TxnWalEntry::parse_body(&body)?;
+        *ordinal += 1;
+        Ok(entry)
     }
 
     /// Recover state (next txn ID, sequence) from existing WAL
@@ -578,9 +770,10 @@ impl TxnWal {
         let our_pid = std::process::id() as u64;
         let pid_base = our_pid << 32;
         let mut max_our_counter: u64 = 0;
+        let mut ordinal: u64 = 0;
 
         loop {
-            match TxnWalEntry::from_reader(&mut reader) {
+            match self.read_record(&mut reader, &mut ordinal) {
                 Ok(entry) => {
                     count += 1;
                     // Only track counters from entries that belong to our PID
@@ -595,8 +788,14 @@ impl TxnWal {
                 Err(SochDBError::Io(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
                     break;
                 }
-                Err(_) => {
-                    // Ignore corruption at end of WAL (incomplete write)
+                Err(e) => {
+                    // Encrypted: a non-EOF error (AEAD auth failure / tamper /
+                    // corruption) is NEVER a torn tail — fail loud rather than
+                    // silently truncate. Plaintext: tolerate trailing corruption
+                    // as an incomplete final write (legacy behavior).
+                    if self.encryption.is_enabled() {
+                        return Err(e);
+                    }
                     break;
                 }
             }
@@ -611,6 +810,9 @@ impl TxnWal {
 
         self.next_txn_id.store(next_id, Ordering::SeqCst);
         self.sequence.store(count, Ordering::SeqCst);
+        // The current file already holds `count` records, so the next encrypted
+        // write must continue the AAD ordinal sequence from there.
+        self.records_in_file.store(count, Ordering::SeqCst);
 
         Ok(())
     }
@@ -653,8 +855,8 @@ impl TxnWal {
     /// The group commit path (`EventDrivenGroupCommit`) is responsible for
     /// calling `flush()` + `sync()` after batching multiple commit records.
     pub fn append(&self, entry: &TxnWalEntry) -> Result<u64> {
-        let bytes = entry.to_bytes();
         let mut writer = self.writer.lock();
+        let bytes = self.frame_under_lock(entry)?;
 
         writer.write_all(&bytes)?;
         // Don't flush here - BufWriter will batch writes automatically.
@@ -667,13 +869,26 @@ impl TxnWal {
         Ok(seq)
     }
 
+    /// Serialize one entry into its on-disk frame, allocating the per-record
+    /// ordinal when encrypted. MUST be called with the `writer` lock held so the
+    /// ordinal matches the order bytes hit the file.
+    #[inline]
+    fn frame_under_lock(&self, entry: &TxnWalEntry) -> Result<Vec<u8>> {
+        if self.encryption.is_enabled() {
+            let ord = self.records_in_file.fetch_add(1, Ordering::SeqCst);
+            self.encrypt_frame(&entry.body_bytes(), ord)
+        } else {
+            Ok(entry.to_bytes())
+        }
+    }
+
     /// Append entry without flushing (for batched writes)
     ///
     /// Caller must call flush() or sync() afterward to ensure durability.
     #[inline]
     pub fn append_no_flush(&self, entry: &TxnWalEntry) -> Result<u64> {
-        let bytes = entry.to_bytes();
         let mut writer = self.writer.lock();
+        let bytes = self.frame_under_lock(entry)?;
 
         writer.write_all(&bytes)?;
         // No flush - let BufWriter buffer the writes
@@ -702,9 +917,25 @@ impl TxnWal {
         let timestamp_us = self.get_cached_timestamp();
 
         let total_len = RECORD_HEADER_SIZE + key.len() + value.len() + CHECKSUM_SIZE;
-        let mut hasher = crc32fast::Hasher::new();
 
         let mut writer = self.writer.lock();
+
+        // Encrypted mode cannot stream field-by-field (the AEAD needs the whole
+        // body to compute its synthetic IV + tag), so materialize the body into a
+        // scratch buffer, seal it, and write one framed envelope. The plaintext
+        // path below keeps its zero-alloc streaming fast path untouched.
+        if self.encryption.is_enabled() {
+            let body = encode_record_body(WalRecordType::Data, txn_id, timestamp_us, key, value);
+            let ord = self.records_in_file.fetch_add(1, Ordering::SeqCst);
+            let frame = self.encrypt_frame(&body, ord)?;
+            writer.write_all(&frame)?;
+            let seq = self.sequence.fetch_add(1, Ordering::SeqCst);
+            self.bytes_since_sync
+                .fetch_add(frame.len() as u64, Ordering::Relaxed);
+            return Ok(seq);
+        }
+
+        let mut hasher = crc32fast::Hasher::new();
 
         // Length (not included in CRC)
         let content_len = (total_len - 4) as u32;
@@ -802,6 +1033,40 @@ impl TxnWal {
         }
 
         let mut writer = self.writer.lock();
+
+        if self.encryption.is_enabled() {
+            // The buffer holds concatenated plaintext frames
+            // `[content_len][body]...`. Re-frame each as an AEAD envelope bound to
+            // its own file-relative ordinal, preserving per-record framing (so a
+            // torn tail discards exactly one record).
+            let buf = &buffer.buffer;
+            let mut pos = 0usize;
+            let mut total_written = 0u64;
+            while pos + 4 <= buf.len() {
+                let content_len =
+                    u32::from_le_bytes([buf[pos], buf[pos + 1], buf[pos + 2], buf[pos + 3]])
+                        as usize;
+                pos += 4;
+                if pos + content_len > buf.len() {
+                    return Err(SochDBError::Corruption(
+                        "txn buffer truncated mid-record during encrypted flush".into(),
+                    ));
+                }
+                let body = &buf[pos..pos + content_len];
+                pos += content_len;
+                let ord = self.records_in_file.fetch_add(1, Ordering::SeqCst);
+                let frame = self.encrypt_frame(body, ord)?;
+                writer.write_all(&frame)?;
+                total_written += frame.len() as u64;
+            }
+            let seq = self
+                .sequence
+                .fetch_add(buffer.entry_count as u64, Ordering::SeqCst);
+            self.bytes_since_sync
+                .fetch_add(total_written, Ordering::Relaxed);
+            return Ok(seq);
+        }
+
         writer.write_all(&buffer.buffer)?;
 
         let seq = self
@@ -911,13 +1176,14 @@ impl TxnWal {
             std::collections::HashMap::new();
         let mut result = Vec::new();
         let mut txn_count = 0;
+        let mut ordinal: u64 = 0;
 
         // Single pass in WAL order. Transaction ids are process-local and
         // short-lived CLI processes can reuse the same ids after restart, so
         // grouping the entire WAL by txn_id would merge unrelated transactions
         // and replay older writes after newer ones.
         loop {
-            match TxnWalEntry::from_reader(&mut reader) {
+            match self.read_record(&mut reader, &mut ordinal) {
                 Ok(entry) => match entry.record_type {
                     WalRecordType::TxnBegin => {
                         pending_writes.insert(entry.txn_id, Vec::new());
@@ -945,7 +1211,15 @@ impl TxnWal {
                 Err(SochDBError::Io(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
                     break;
                 }
-                Err(_) => {
+                Err(e) => {
+                    // Encrypted WALs must fail loud on a non-EOF error so a wrong
+                    // key / tamper / corruption can never masquerade as EOF and
+                    // silently drop committed data. (Wrong key is already excluded
+                    // earlier by the keyring canary, so this is genuine corruption
+                    // or tampering.) Plaintext keeps the legacy torn-tail tolerance.
+                    if self.encryption.is_enabled() {
+                        return Err(e);
+                    }
                     break;
                 }
             }
@@ -962,9 +1236,10 @@ impl TxnWal {
         let file = File::open(&self.path)?;
         let mut reader = BufReader::new(file);
         let mut count = 0u64;
+        let mut ordinal: u64 = 0;
 
         loop {
-            match TxnWalEntry::from_reader(&mut reader) {
+            match self.read_record(&mut reader, &mut ordinal) {
                 Ok(entry) => {
                     callback(entry)?;
                     count += 1;
@@ -973,7 +1248,11 @@ impl TxnWal {
                     break;
                 }
                 Err(e) => {
-                    // Log warning but continue (may be incomplete entry at end)
+                    // Encrypted: fail loud (never silently drop committed data on a
+                    // non-EOF error). Plaintext: tolerate a trailing incomplete entry.
+                    if self.encryption.is_enabled() {
+                        return Err(e);
+                    }
                     eprintln!("WAL replay warning: {:?}", e);
                     break;
                 }
@@ -1002,6 +1281,9 @@ impl TxnWal {
         file.sync_all()?;
         self.sequence.store(0, Ordering::SeqCst);
         self.bytes_since_sync.store(0, Ordering::Relaxed);
+        // The file restarts at offset 0, so per-record AAD ordinals restart too;
+        // a fresh reader of the truncated file will count from 0 to match.
+        self.records_in_file.store(0, Ordering::SeqCst);
         Ok(())
     }
 
@@ -1331,8 +1613,9 @@ impl TxnWal {
         let mut all_txns: HashSet<u64> = HashSet::new();
 
         // Read all records, stopping at first corruption (torn write)
+        let mut ordinal: u64 = 0;
         loop {
-            match TxnWalEntry::from_reader(&mut reader) {
+            match self.read_record(&mut reader, &mut ordinal) {
                 Ok(entry) => {
                     stats.total_records += 1;
                     if entry.txn_id > stats.max_txn_id {
@@ -1363,8 +1646,15 @@ impl TxnWal {
                     // Clean EOF
                     break;
                 }
-                Err(_) => {
-                    // Corruption or torn write - stop here
+                Err(e) => {
+                    // Encrypted: an AEAD auth failure / tamper / corruption is a
+                    // hard error — abort recovery rather than silently truncating
+                    // committed data (wrong key is already caught by the keyring
+                    // canary at open). Plaintext: treat trailing corruption as a
+                    // torn write and stop.
+                    if self.encryption.is_enabled() {
+                        return Err(e);
+                    }
                     stats.torn_records += 1;
                     break;
                 }
@@ -1613,5 +1903,163 @@ mod tests {
         let mut cursor = std::io::Cursor::new(bytes);
         let recovered = TxnWalEntry::from_reader(&mut cursor).unwrap();
         assert_eq!(recovered.checksum(), entry1.checksum());
+    }
+}
+
+#[cfg(test)]
+mod encryption_wal_tests {
+    use super::*;
+    use crate::encryption::EncryptionEngine;
+    use tempfile::tempdir;
+
+    fn enc(key: u8) -> Arc<EncryptionEngine> {
+        Arc::new(EncryptionEngine::new(&[key; 32]))
+    }
+    const UUID: [u8; 16] = [9u8; 16];
+
+    /// Write a committed txn (begin/data/commit) and one aborted txn via the
+    /// encrypted paths, then reopen with the same key and crash-recover.
+    #[test]
+    fn encrypted_write_then_recover_roundtrip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("enc.wal");
+
+        {
+            let wal = TxnWal::new_with_encryption(&path, enc(7), UUID, 0).unwrap();
+            // committed txn via append + write_no_flush_refs + flush_buffer paths
+            let t1 = wal.begin_transaction().unwrap();
+            wal.write(t1, b"alpha".to_vec(), b"one".to_vec()).unwrap();
+            wal.write_no_flush_refs(t1, b"beta", b"two").unwrap();
+            // also exercise the buffer/flush_buffer batch path
+            let mut buf = TxnWalBuffer::new(t1);
+            buf.append(b"gamma", b"three");
+            wal.flush_buffer(&buf).unwrap();
+            wal.commit_transaction(t1).unwrap();
+
+            // aborted txn must NOT survive
+            let t2 = wal.begin_transaction().unwrap();
+            wal.write(t2, b"ghost".to_vec(), b"x".to_vec()).unwrap();
+            wal.abort_transaction(t2).unwrap();
+            wal.sync().unwrap();
+        }
+
+        // On-disk bytes must NOT contain the plaintext values.
+        let raw = std::fs::read(&path).unwrap();
+        assert!(!contains(&raw, b"alpha"));
+        assert!(!contains(&raw, b"three"));
+
+        let wal = TxnWal::new_with_encryption(&path, enc(7), UUID, 0).unwrap();
+        let (writes, stats) = wal.crash_recovery().unwrap();
+        let keys: Vec<_> = writes.iter().map(|(k, _)| k.clone()).collect();
+        assert!(keys.contains(&b"alpha".to_vec()));
+        assert!(keys.contains(&b"beta".to_vec()));
+        assert!(keys.contains(&b"gamma".to_vec()));
+        assert!(!keys.contains(&b"ghost".to_vec()), "aborted txn leaked");
+        assert_eq!(stats.committed_txns, 1);
+    }
+
+    /// Wrong key at the WAL layer must FAIL LOUD, not silently return empty.
+    /// (In production the keyring canary catches this even earlier; this proves
+    /// the replay path itself never swallows an AEAD failure as EOF.)
+    #[test]
+    fn wrong_key_fails_loud_not_empty() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("enc.wal");
+        {
+            let wal = TxnWal::new_with_encryption(&path, enc(1), UUID, 0).unwrap();
+            let t = wal.begin_transaction().unwrap();
+            wal.write(t, b"k".to_vec(), b"v".to_vec()).unwrap();
+            wal.commit_transaction(t).unwrap();
+            wal.sync().unwrap();
+        }
+        // Reopen with the WRONG key: recover_state runs in the constructor and
+        // must surface a hard error rather than an "empty" success.
+        let opened = TxnWal::new_with_encryption(&path, enc(2), UUID, 0);
+        assert!(opened.is_err(), "wrong key opened silently (data-loss bug)");
+        match opened.err().unwrap() {
+            SochDBError::Encryption(_) => {}
+            other => panic!("expected Encryption error, got {other:?}"),
+        }
+    }
+
+    /// Tampering with a committed encrypted record must fail recovery loud.
+    #[test]
+    fn tamper_midstream_fails_loud() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("enc.wal");
+        {
+            let wal = TxnWal::new_with_encryption(&path, enc(5), UUID, 0).unwrap();
+            let t = wal.begin_transaction().unwrap();
+            wal.write(t, b"k1".to_vec(), b"v1".to_vec()).unwrap();
+            wal.commit_transaction(t).unwrap();
+            wal.sync().unwrap();
+        }
+        // Flip a byte well inside the file (not the final torn-tail region).
+        let mut raw = std::fs::read(&path).unwrap();
+        let mid = raw.len() / 2;
+        raw[mid] ^= 0xFF;
+        std::fs::write(&path, &raw).unwrap();
+
+        let opened = TxnWal::new_with_encryption(&path, enc(5), UUID, 0);
+        // Either the constructor's recover_state errors, or a later crash_recovery
+        // does — but it must NEVER silently accept tampered ciphertext.
+        let failed = opened.is_err()
+            || opened
+                .ok()
+                .map(|w| w.crash_recovery().is_err())
+                .unwrap_or(true);
+        assert!(failed, "tampered encrypted WAL was silently accepted");
+    }
+
+    /// The disabled engine must write a record's bytes EXACTLY as the legacy
+    /// `to_bytes()` frame (no added encryption framing / format drift), while the
+    /// enabled engine must NOT (it adds the AEAD envelope and is unreadable by the
+    /// plaintext reader). Records embed wall-clock timestamps, so we compare a
+    /// single fixed entry object against its own `to_bytes()` for determinism.
+    #[test]
+    fn disabled_engine_is_byte_identical_to_plaintext() {
+        let dir = tempdir().unwrap();
+
+        let entry = TxnWalEntry::data(42, b"k1".to_vec(), b"v1".to_vec());
+        let golden = entry.to_bytes();
+
+        // Disabled engine: file bytes == to_bytes() exactly.
+        let p_dis = dir.path().join("disabled.wal");
+        {
+            let wal = TxnWal::new_with_encryption(
+                &p_dis,
+                Arc::new(EncryptionEngine::disabled()),
+                [0u8; 16],
+                0,
+            )
+            .unwrap();
+            wal.append(&entry).unwrap();
+            wal.sync().unwrap();
+        }
+        assert_eq!(
+            std::fs::read(&p_dis).unwrap(),
+            golden,
+            "disabled-engine append diverged from legacy plaintext frame"
+        );
+
+        // Enabled engine: file bytes differ and are NOT plaintext-parseable.
+        let p_enc = dir.path().join("enc.wal");
+        {
+            let wal = TxnWal::new_with_encryption(&p_enc, enc(3), UUID, 0).unwrap();
+            wal.append(&entry).unwrap();
+            wal.sync().unwrap();
+        }
+        let enc_bytes = std::fs::read(&p_enc).unwrap();
+        assert_ne!(enc_bytes, golden);
+        let mut cur = std::io::Cursor::new(&enc_bytes);
+        assert!(
+            TxnWalEntry::from_reader(&mut cur).is_err()
+                || cur.position() as usize != enc_bytes.len(),
+            "ciphertext frame must not parse cleanly as a plaintext record"
+        );
+    }
+
+    fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+        haystack.windows(needle.len()).any(|w| w == needle)
     }
 }


### PR DESCRIPTION
…k 3B, phase 1)

AES-256-GCM-SIV envelope encryption for the live WAL path — fail-closed and fail-loud by construction. Encryption is inert unless a key is configured, and the plaintext path stays byte-identical to pre-3B (737 storage tests green).

- core: add SochDBError::Encryption (distinct from Io so replay can tell a torn-tail EOF from an AEAD auth failure) + From<EncryptionError>.
- encryption: AAD-aware encrypt_with_aad/decrypt_with_aad, HKDF derive_subkey (operator KEK never used verbatim as cipher key), from_key, and an integrity-failure discriminator.
- keyring (new): KEK/DEK envelope persisted to keyring.json with an HMAC-authenticated descriptor (downgrade-forgery proof) + a DEK canary, so a wrong/missing key fails closed at open BEFORE the WAL is read.
- txn_wal: per-record encrypted frames bound to {version,db_uuid,epoch,ordinal} AAD; all write paths + all four replay loops made crypto-aware; replay fails loud on integrity errors (no silent committed-data loss) while preserving plaintext torn-tail tolerance; anti-DoS frame-length bound.
- durable_storage: open_with_encryption(StorageEncryption); per-instance durability_capabilities() reports real at-rest state; lib const matrix stays build-default.

Tests: engine(15) + keyring(8) + encrypted-WAL(4: roundtrip/abort-exclusion, wrong-key-fails-loud, tamper-fails-loud, disabled-byte-identical) + e2e DurableStorage (roundtrip + wrong-key/no-key fail-closed). Full workspace builds.