### PR TITLE
release version 2.0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "2.0.8"
+version = "2.0.9"
 edition = "2024"
 authors = ["Sushanth <sushanth@sochdb.dev>"]
 license = "AGPL-3.0-or-later"

--- a/deploy/helm/sochdb/Chart.yaml
+++ b/deploy/helm/sochdb/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sochdb
 description: SochDB - LLM-Optimized Embedded Database for Kubernetes
 type: application
-version: 2.0.8
-appVersion: "2.0.8"
+version: 2.0.9
+appVersion: "2.0.9"
 keywords:
   - database
   - llm

--- a/deploy/helm/sochdb/values-minikube.yaml
+++ b/deploy/helm/sochdb/values-minikube.yaml
@@ -3,7 +3,7 @@
 
 image:
   repository: sochdb/sochdb-grpc
-  tag: "2.0.8"
+  tag: "2.0.9"
   pullPolicy: Never  # Use locally built image in minikube
 
 replicaCount: 1

--- a/deploy/marketplace/aws/product.yaml
+++ b/deploy/marketplace/aws/product.yaml
@@ -13,8 +13,8 @@
 # === Image Publishing ===
 # Push to AWS Marketplace ECR:
 #   aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin <marketplace-ecr>
-#   docker tag sochdb/sochdb-grpc:latest <marketplace-ecr>/sochdb-grpc:2.0.8
-#   docker push <marketplace-ecr>/sochdb-grpc:2.0.8
+#   docker tag sochdb/sochdb-grpc:latest <marketplace-ecr>/sochdb-grpc:2.0.9
+#   docker push <marketplace-ecr>/sochdb-grpc:2.0.9
 
 # === Metering Integration ===
 # For paid plans, the SochDB server integrates with AWS Marketplace Metering API:
@@ -53,7 +53,7 @@ delivery:
   container_images:
     - name: sochdb-grpc
       repository: "<marketplace-ecr>/sochdb-grpc"
-      tag: "2.0.8"
+      tag: "2.0.9"
 
 pricing_models:
   - type: free

--- a/deploy/marketplace/azure/offer.yaml
+++ b/deploy/marketplace/azure/offer.yaml
@@ -14,8 +14,8 @@
 # === Image Publishing ===
 # Push to ACR (linked to Partner Center):
 #   az acr login --name sochdbregistry
-#   docker tag sochdb/sochdb-grpc:latest sochdbregistry.azurecr.io/sochdb-grpc:2.0.8
-#   docker push sochdbregistry.azurecr.io/sochdb-grpc:2.0.8
+#   docker tag sochdb/sochdb-grpc:latest sochdbregistry.azurecr.io/sochdb-grpc:2.0.9
+#   docker push sochdbregistry.azurecr.io/sochdb-grpc:2.0.9
 
 # === CNAB Bundle Structure ===
 # The Helm chart at deploy/helm/sochdb/ is packaged as a CNAB bundle:
@@ -46,7 +46,7 @@ description: |
   - Non-root container, read-only rootfs, mTLS support
 
   Deploy on any AKS cluster with:
-    helm install sochdb oci://sochdbregistry.azurecr.io/helm/sochdb --version 2.0.8
+    helm install sochdb oci://sochdbregistry.azurecr.io/helm/sochdb --version 2.0.9
 
 plans:
   - plan_id: free

--- a/deploy/marketplace/gcp/schema.yaml
+++ b/deploy/marketplace/gcp/schema.yaml
@@ -19,18 +19,18 @@
 # === Image Publishing ===
 # Push to Artifact Registry:
 #   gcloud auth configure-docker us-docker.pkg.dev
-#   docker tag sochdb/sochdb-grpc:latest us-docker.pkg.dev/sochdb-public/sochdb/sochdb-grpc:2.0.8
-#   docker push us-docker.pkg.dev/sochdb-public/sochdb/sochdb-grpc:2.0.8
+#   docker tag sochdb/sochdb-grpc:latest us-docker.pkg.dev/sochdb-public/sochdb/sochdb-grpc:2.0.9
+#   docker push us-docker.pkg.dev/sochdb-public/sochdb/sochdb-grpc:2.0.9
 
 # === Application Schema ===
 # GCP Marketplace apps use a schema.yaml to define parameters:
 x-google-marketplace:
   schemaVersion: v2
   applicationApiVersion: v1beta1
-  publishedVersion: "2.0.8"
+  publishedVersion: "2.0.9"
   publishedVersionMetadata:
     releaseNote: >
-      SochDB 2.0.8 — MultiShardHnswIndex production readiness,
+      SochDB 2.0.9 — MultiShardHnswIndex production readiness,
       Context Queries, token budgeting, gRPC + REST API.
   images:
     sochdb-grpc:

--- a/sochdb-client/Cargo.toml
+++ b/sochdb-client/Cargo.toml
@@ -15,10 +15,10 @@ readme = "README.md"
 
 [dependencies]
 # Internal crates
-sochdb-core = { version = "2.0.8", path = "../sochdb-core", features = ["analytics"] }
-sochdb-storage = { version = "2.0.8", path = "../sochdb-storage" }
-sochdb-index = { version = "2.0.8", path = "../sochdb-index" }
-sochdb-query = { version = "2.0.8", path = "../sochdb-query" }
+sochdb-core = { version = "2.0.9", path = "../sochdb-core", features = ["analytics"] }
+sochdb-storage = { version = "2.0.9", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.9", path = "../sochdb-index" }
+sochdb-query = { version = "2.0.9", path = "../sochdb-query" }
 
 # Synchronization
 parking_lot = "0.12"

--- a/sochdb-grpc/Cargo.toml
+++ b/sochdb-grpc/Cargo.toml
@@ -21,14 +21,14 @@ default = []
 async = []
 
 [dependencies]
-sochdb-index = { version = "2.0.8", path = "../sochdb-index" }
-sochdb-core = { version = "2.0.8", path = "../sochdb-core", features = ["analytics"] }
-sochdb-kernel = { version = "2.0.8", path = "../sochdb-kernel" }
-sochdb-storage = { version = "2.0.8", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.9", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.9", path = "../sochdb-core", features = ["analytics"] }
+sochdb-kernel = { version = "2.0.9", path = "../sochdb-kernel" }
+sochdb-storage = { version = "2.0.9", path = "../sochdb-storage" }
 # Real SQL engine for the PostgreSQL wire protocol (DatabasePgExecutor).
-sochdb-query = { version = "2.0.8", path = "../sochdb-query" }
-sochdb-memory = { version = "2.0.8", path = "../sochdb-memory" }
-sochdb-vector = { version = "2.0.8", path = "../sochdb-vector" }
+sochdb-query = { version = "2.0.9", path = "../sochdb-query" }
+sochdb-memory = { version = "2.0.9", path = "../sochdb-memory" }
+sochdb-vector = { version = "2.0.9", path = "../sochdb-vector" }
 
 # gRPC / Protocol Buffers
 tonic = { version = "0.13", features = ["tls-ring", "transport"] }

--- a/sochdb-index/Cargo.toml
+++ b/sochdb-index/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 rustc-hash = "2"  # fast non-crypto hasher for hot-path integer-keyed maps
-sochdb-core = { version = "2.0.8", path = "../sochdb-core" }
+sochdb-core = { version = "2.0.9", path = "../sochdb-core" }
 dashmap = { workspace = true }
 parking_lot = { workspace = true }
 moka = { workspace = true }  # LRU cache for path resolution

--- a/sochdb-kernel/Cargo.toml
+++ b/sochdb-kernel/Cargo.toml
@@ -14,7 +14,7 @@ wasm-plugins = ["wasmtime", "toml"]
 
 [dependencies]
 # Minimal dependencies - only what's needed for ACID core
-sochdb-core = { version = "2.0.8", path = "../sochdb-core" }
+sochdb-core = { version = "2.0.9", path = "../sochdb-core" }
 thiserror = { workspace = true }
 parking_lot = "0.12"
 crossbeam-channel = "0.5"

--- a/sochdb-mcp/Cargo.toml
+++ b/sochdb-mcp/Cargo.toml
@@ -35,9 +35,9 @@ toon-format = { version = "0.4", default-features = false }
 fastembed = { version = "4", optional = true }
 
 # SochDB crates
-sochdb = { version = "2.0.8", path = "../sochdb-client", features = ["embedded"] }
-sochdb-core = { version = "2.0.8", path = "../sochdb-core" }
-sochdb-query = { version = "2.0.8", path = "../sochdb-query" }
+sochdb = { version = "2.0.9", path = "../sochdb-client", features = ["embedded"] }
+sochdb-core = { version = "2.0.9", path = "../sochdb-core" }
+sochdb-query = { version = "2.0.9", path = "../sochdb-query" }
 
 # Minimal additional deps
 tracing = "0.1"

--- a/sochdb-memory/Cargo.toml
+++ b/sochdb-memory/Cargo.toml
@@ -8,10 +8,10 @@ repository.workspace = true
 description = "Bi-temporal agent memory layer with write-time lexical recall"
 
 [dependencies]
-sochdb-core = { version = "2.0.8", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.8", path = "../sochdb-storage", features = ["embedded-sync"] }
-sochdb-query = { version = "2.0.8", path = "../sochdb-query" }
-sochdb-vector = { version = "2.0.8", path = "../sochdb-vector" }
+sochdb-core = { version = "2.0.9", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.9", path = "../sochdb-storage", features = ["embedded-sync"] }
+sochdb-query = { version = "2.0.9", path = "../sochdb-query" }
+sochdb-vector = { version = "2.0.9", path = "../sochdb-vector" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/sochdb-plugin-logging/Cargo.toml
+++ b/sochdb-plugin-logging/Cargo.toml
@@ -6,7 +6,7 @@ description = "JSON structured logging plugin for SochDB"
 license.workspace = true
 
 [dependencies]
-sochdb-kernel = { version = "2.0.8", path = "../sochdb-kernel" }
+sochdb-kernel = { version = "2.0.9", path = "../sochdb-kernel" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"

--- a/sochdb-python/Cargo.toml
+++ b/sochdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sochdb-python"
-version = "2.0.8"
+version = "2.0.9"
 edition = "2024"
 authors = ["Sushanth <sushanth@sochdb.dev>"]
 license = "AGPL-3.0-or-later"

--- a/sochdb-python/pyproject.toml
+++ b/sochdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "sochdb"
-version = "2.0.8"
+version = "2.0.9"
 description = "SochDB - AI-native database with zero-copy vector search via PyO3"
 readme = "README.md"
 license = {text = "AGPL-3.0-or-later"}

--- a/sochdb-python/python/sochdb/__init__.py
+++ b/sochdb-python/python/sochdb/__init__.py
@@ -70,7 +70,7 @@ __all__ = [
     "bulk_build_index",
 ]
 
-__version__ = "2.0.8"
+__version__ = "2.0.9"
 
 
 def _check_native():

--- a/sochdb-query/Cargo.toml
+++ b/sochdb-query/Cargo.toml
@@ -22,9 +22,9 @@ default = []
 experimental = []
 
 [dependencies]
-sochdb-core = { version = "2.0.8", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.8", path = "../sochdb-storage" }
-sochdb-index = { version = "2.0.8", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.9", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.9", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.9", path = "../sochdb-index" }
 ndarray = "0.15"
 rayon = "1.10" # Parallel partitioned GROUP BY aggregation
 thiserror = { workspace = true }

--- a/sochdb-sdk/node/package.json
+++ b/sochdb-sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sochdb/sdk",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "SochDB Node.js SDK — Thin gRPC client for the LLM-optimized database",
   "main": "dist/client.js",
   "types": "dist/client.d.ts",

--- a/sochdb-sdk/python/pyproject.toml
+++ b/sochdb-sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sochdb-sdk"
-version = "2.0.8"
+version = "2.0.9"
 description = "SochDB Python SDK — Thin gRPC client for the LLM-optimized database"
 requires-python = ">=3.9"
 license = {text = "AGPL-3.0-or-later"}

--- a/sochdb-sdk/python/sochdb_sdk/__init__.py
+++ b/sochdb-sdk/python/sochdb_sdk/__init__.py
@@ -11,7 +11,7 @@ from .client import (
     NamespaceClient,
 )
 
-__version__ = "2.0.8"
+__version__ = "2.0.9"
 __all__ = [
     "SochDB",
     "VectorClient",

--- a/sochdb-sdk/python/sochdb_sdk/client.py
+++ b/sochdb-sdk/python/sochdb_sdk/client.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import grpc
 from typing import Any, Dict, List, Optional, Sequence
 
-__version__ = "2.0.8"
+__version__ = "2.0.9"
 __all__ = ["SochDB", "VectorClient", "KvClient", "GraphClient", "SqlClient"]
 
 

--- a/sochdb-storage/Cargo.toml
+++ b/sochdb-storage/Cargo.toml
@@ -40,8 +40,8 @@ encryption = []
 pitr = ["encryption"]
 
 [dependencies]
-sochdb-core = { version = "2.0.8", path = "../sochdb-core" }
-sochdb-index = { version = "2.0.8", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.9", path = "../sochdb-core" }
+sochdb-index = { version = "2.0.9", path = "../sochdb-index" }
 # Tokio is optional - only included when "async" feature is enabled
 tokio = { version = "1.35", features = ["sync", "time", "macros", "rt"], optional = true }
 serde = { workspace = true }

--- a/sochdb-tools/Cargo.toml
+++ b/sochdb-tools/Cargo.toml
@@ -19,10 +19,10 @@ name = "sochdb"
 path = "src/cli.rs"
 
 [dependencies]
-sochdb-index = { version = "2.0.8", path = "../sochdb-index" }
-sochdb-core = { version = "2.0.8", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.8", path = "../sochdb-storage" }
-sochdb-query = { version = "2.0.8", path = "../sochdb-query" }
+sochdb-index = { version = "2.0.9", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.9", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.9", path = "../sochdb-storage" }
+sochdb-query = { version = "2.0.9", path = "../sochdb-query" }
 
 # CLI
 clap = { version = "4.5", features = ["derive", "color", "env"] }

--- a/sochdb-vector/Cargo.toml
+++ b/sochdb-vector/Cargo.toml
@@ -12,9 +12,9 @@ path = "src/lib.rs"
 
 [dependencies]
 # SochDB dependencies
-sochdb-core = { version = "2.0.8", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.8", path = "../sochdb-storage" }
-sochdb-index = { version = "2.0.8", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.9", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.9", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.9", path = "../sochdb-index" }
 
 # Memory mapping for segment files
 memmap2 = "0.9"


### PR DESCRIPTION
This pull request updates the SochDB project and all related components from version 2.0.8 to 2.0.9. The version bump is applied consistently across the Rust crates, Python and Node.js SDKs, Helm charts, and cloud marketplace deployment files to ensure all components reference the latest release.

Version updates across the project:

* All Rust crate versions in their respective `Cargo.toml` files are updated from `2.0.8` to `2.0.9`, including internal dependencies between crates. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L61-R61) [[2]](diffhunk://#diff-044b5e2eb3bff89918a30e968bc85f937358a509e0f095a12c0b99b2e8215199L18-R21) [[3]](diffhunk://#diff-cadd320c1b6aa98e7755ab6b2b344347bf7e26fb6fbc46100d011d65265609dfL24-R31) [[4]](diffhunk://#diff-533499856c2a7a544f03eec04052c627bd8ecae6fefaa2d3dcbf147d0969d5d3L20-R20) [[5]](diffhunk://#diff-97050b5ecfbe310aa23e00304c8f99dd9786f80cf19b291d3f9e0c61f30260f2L17-R17) [[6]](diffhunk://#diff-cbdb8ee740e560dc453afad0ab78b1b6b98b3843fe801e60724de3929918dbbdL38-R40) [[7]](diffhunk://#diff-26189c3400ff8b1fcd4b6e93ad34aff3b0721b03972ee0c3142b8db1ef1817c2L11-R14) [[8]](diffhunk://#diff-d338b8152c390f5f5febe6d3f16e0b6abd1a3ce66ca1b7c1436cc994427c99fcL9-R9) [[9]](diffhunk://#diff-b3b0490a7775d4cb7ccf2bc89cebb7b664711aa5060cdaba995f82e019d2d6c5L25-R27) [[10]](diffhunk://#diff-bb1d23ef87004d0593f2e7baf173f11c19e41d6fb7871e56fa1b80296fd3e859L3-R3)
* Python and Node.js SDK versions are updated to `2.0.9` in both their package metadata and `__version__` attributes. [[1]](diffhunk://#diff-6b334b3dec2991b23f56d8264637c817ac9e80348bd9de304cf498029aef385bL3-R3) [[2]](diffhunk://#diff-a846e883910c34eadb06c4c94d28f3dd44eaf16c6f5511c0850082656d4547a7L7-R7) [[3]](diffhunk://#diff-8cf5ed843736edd888974efc00b5d89b9b7a4564fba3265a892cb34f01c78f0bL14-R14) [[4]](diffhunk://#diff-29a9d409369abc7e0e8d8675810b0bd013f33b99966f48508b028a7512b0f971L7-R7) [[5]](diffhunk://#diff-3ed9affd117d84e9bebfc3bc15cc98d44d854e5c2a58f2b0e6659c40f574db27L73-R73)
* Helm chart and deployment YAMLs are updated to reference the `2.0.9` image tag and chart version. [[1]](diffhunk://#diff-ef664bc376a29e5fd6ae57b3cb7a3f2836b63e4f3a80459d81cf0ee99bd508dfL5-R6) [[2]](diffhunk://#diff-83bd7c6eb8872041233a217961b5b4a2d5839b0fe857da0eb6c100ef4c34c571L6-R6)
* Cloud marketplace deployment files for AWS, Azure, and GCP are updated to reference the `2.0.9` image tag and version in documentation, publishing instructions, and metadata. [[1]](diffhunk://#diff-fe02266bddcc339dd74132ba2a4ab7b1ed548a612df7f0b6dcc14fafc5016423L16-R17) [[2]](diffhunk://#diff-fe02266bddcc339dd74132ba2a4ab7b1ed548a612df7f0b6dcc14fafc5016423L56-R56) [[3]](diffhunk://#diff-e9e32655cdda7710a4cea79b6e81a1f342340d343bcfa621fa99652fb06df3bbL17-R18) [[4]](diffhunk://#diff-e9e32655cdda7710a4cea79b6e81a1f342340d343bcfa621fa99652fb06df3bbL49-R49) [[5]](diffhunk://#diff-a7bd7a19fa7db107808c76d072abcf2edc48e648e34bad8dd732c9bcfe8bac89L22-R33)

No functional or behavioral changes are introduced in this pull request; it is strictly a coordinated version update across all project components for the new release.