### PR TITLE
Security/grpc auth dos fixes

### DIFF
--- a/sochdb-grpc/src/main.rs
+++ b/sochdb-grpc/src/main.rs
@@ -167,7 +167,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Start Prometheus metrics HTTP server (Task 8)
     let _metrics_handle = if args.metrics_port > 0 {
-        Some(sochdb_grpc::metrics_server::start(args.metrics_port))
+        Some(sochdb_grpc::metrics_server::start(
+            args.host.clone(),
+            args.metrics_port,
+        ))
     } else {
         tracing::info!("Prometheus metrics endpoint disabled");
         None
@@ -414,11 +417,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     builder
         .add_service(health_service)
-        .add_service(
+        // SECURITY: the vector service MUST be wrapped with the auth interceptor
+        // like every other service — otherwise the interceptor never runs for
+        // vector RPCs, extract_principal falls back to an (over-privileged)
+        // anonymous principal, and the entire vector data plane is readable /
+        // writable / destroyable with no credentials EVEN WHEN --auth is on.
+        // Configure the message-size limits on the inner server first, then wrap
+        // it in the interceptor (max_*_message_size is not available post-wrap).
+        .add_service(tonic::codegen::InterceptedService::new(
             VectorIndexServiceServer::new(vector_server)
                 .max_decoding_message_size(64 * 1024 * 1024)
                 .max_encoding_message_size(64 * 1024 * 1024),
-        )
+            auth.clone(),
+        ))
         .add_service(GraphServiceServer::with_interceptor(
             graph_server,
             auth.clone(),

--- a/sochdb-grpc/src/main.rs
+++ b/sochdb-grpc/src/main.rs
@@ -181,11 +181,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let ws_addr = format!("{}:{}", args.host, args.ws_port).parse()?;
         let kv_store: sochdb_grpc::ws_server::KvStore =
             std::sync::Arc::new(dashmap::DashMap::new());
+        // Optional WS bearer token. Without one the gateway is unauthenticated;
+        // warn so the operator knows (it operates on an isolated KV store).
+        let ws_token = std::env::var("SOCHDB_WS_TOKEN")
+            .ok()
+            .filter(|t| !t.is_empty());
+        if ws_token.is_none() {
+            tracing::warn!(
+                "WebSocket gateway is UNAUTHENTICATED (set SOCHDB_WS_TOKEN to require a bearer token)"
+            );
+        }
         Some(sochdb_grpc::ws_server::start(
             sochdb_grpc::ws_server::WsConfig {
                 addr: ws_addr,
                 kv_store,
                 cdc_log: None,
+                auth_token: ws_token,
             },
         ))
     } else {
@@ -196,9 +207,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Start PG wire protocol server (Task 5)
     let _pg_handle = if args.pg_port > 0 {
         let pg_addr = format!("{}:{}", args.host, args.pg_port).parse()?;
+        // Optional PG-wire password (cleartext over the wire — pair with TLS or a
+        // loopback bind). When unset, the server uses trust auth (legacy).
+        let pg_password = std::env::var("SOCHDB_PG_PASSWORD")
+            .ok()
+            .filter(|p| !p.is_empty());
+        if pg_password.is_some() {
+            tracing::info!("PG wire: cleartext-password authentication ENABLED");
+        }
         let config = sochdb_grpc::pg_wire::PgWireConfig {
             addr: pg_addr,
             server_version: format!("SochDB {}", env!("CARGO_PKG_VERSION")),
+            password: pg_password,
         };
         match args.pg_data_dir.as_deref() {
             // Real SQL engine over a persistent database.

--- a/sochdb-grpc/src/metrics_server.rs
+++ b/sochdb-grpc/src/metrics_server.rs
@@ -40,7 +40,7 @@
 //! use sochdb_grpc::metrics_server;
 //!
 //! // Spawns the HTTP server in a background thread
-//! let handle = metrics_server::start(9090);
+//! let handle = metrics_server::start("127.0.0.1".to_string(), 9090);
 //! ```
 
 use lazy_static::lazy_static;
@@ -258,7 +258,7 @@ impl Drop for MetricsServerHandle {
 /// Returns a handle that can be used to shut down the server.
 /// The server runs in a background OS thread (not a tokio task)
 /// to avoid blocking the async runtime.
-pub fn start(port: u16) -> MetricsServerHandle {
+pub fn start(host: String, port: u16) -> MetricsServerHandle {
     let shutdown = Arc::new(AtomicBool::new(false));
     let shutdown_clone = shutdown.clone();
 
@@ -270,7 +270,7 @@ pub fn start(port: u16) -> MetricsServerHandle {
     let thread = thread::Builder::new()
         .name("sochdb-metrics-http".to_string())
         .spawn(move || {
-            run_server(port, shutdown_clone);
+            run_server(&host, port, shutdown_clone);
         })
         .expect("failed to spawn metrics HTTP thread");
 
@@ -280,8 +280,11 @@ pub fn start(port: u16) -> MetricsServerHandle {
     }
 }
 
-fn run_server(port: u16, shutdown: Arc<AtomicBool>) {
-    let addr = format!("0.0.0.0:{}", port);
+fn run_server(host: &str, port: u16, shutdown: Arc<AtomicBool>) {
+    // Bind to the operator-chosen host (default loopback) rather than a
+    // hardcoded 0.0.0.0 — the unauthenticated /metrics endpoint must not be
+    // forced onto all interfaces when the operator asked for 127.0.0.1.
+    let addr = format!("{}:{}", host, port);
     let server = match tiny_http::Server::http(&addr) {
         Ok(s) => s,
         Err(e) => {

--- a/sochdb-grpc/src/namespace_server.rs
+++ b/sochdb-grpc/src/namespace_server.rs
@@ -222,13 +222,18 @@ impl NamespaceService for NamespaceServer {
 
     async fn list_namespaces(
         &self,
-        _request: Request<ListNamespacesRequest>,
+        request: Request<ListNamespacesRequest>,
     ) -> Result<Response<ListNamespacesResponse>, Status> {
-        let principal = extract_principal(&_request);
+        let principal = extract_principal(&request);
         require_capability(&principal, &Capability::Read)?;
+        // SECURITY: scope the listing to namespaces the caller may actually
+        // access (Admin sees all; a tenant sees only its own + "default"),
+        // mirroring get_namespace/delete_namespace. Returning every namespace
+        // leaks all tenants' names, descriptions and quotas to any Read principal.
         let namespaces: Vec<Namespace> = self
             .namespaces
             .iter()
+            .filter(|entry| require_namespace_access(&principal, entry.key()).is_ok())
             .map(|entry| entry.value().clone())
             .collect();
 
@@ -379,5 +384,56 @@ mod tests {
         assert!(server.check_collection_quota("prod").is_err());
         server.decrement_collection_count("prod");
         assert!(server.check_collection_quota("prod").is_ok());
+    }
+
+    /// SECURITY (CWE-639/200): list_namespaces must be tenant-scoped — a
+    /// non-admin tenant sees only its own namespace (+ "default"), never other
+    /// tenants' names/quotas.
+    #[tokio::test]
+    async fn list_namespaces_is_tenant_scoped() {
+        use crate::security::{AuthMethod, Principal};
+        use std::collections::HashSet;
+
+        let server = NamespaceServer::new();
+        for n in ["tenant-a", "tenant-b", "default"] {
+            server.namespaces.insert(
+                n.to_string(),
+                Namespace {
+                    name: n.to_string(),
+                    ..Default::default()
+                },
+            );
+        }
+
+        // Non-admin principal for tenant-a, Read capability only.
+        let principal = Principal {
+            id: "ua".to_string(),
+            tenant_id: "tenant-a".to_string(),
+            capabilities: HashSet::from([Capability::Read]),
+            expires_at: None,
+            auth_method: AuthMethod::Anonymous,
+        };
+        let mut req = Request::new(ListNamespacesRequest {});
+        req.extensions_mut().insert(principal);
+
+        let names: Vec<String> = server
+            .list_namespaces(req)
+            .await
+            .unwrap()
+            .into_inner()
+            .namespaces
+            .iter()
+            .map(|n| n.name.clone())
+            .collect();
+
+        assert!(
+            names.contains(&"tenant-a".to_string()),
+            "own namespace visible"
+        );
+        assert!(names.contains(&"default".to_string()), "default visible");
+        assert!(
+            !names.contains(&"tenant-b".to_string()),
+            "must NOT leak another tenant's namespace"
+        );
     }
 }

--- a/sochdb-grpc/src/pg_wire.rs
+++ b/sochdb-grpc/src/pg_wire.rs
@@ -57,6 +57,8 @@ const CANCEL_REQUEST: i32 = 80877102;
 // Message type identifiers (frontend → backend)
 const MSG_QUERY: u8 = b'Q';
 const MSG_TERMINATE: u8 = b'X';
+/// Client PasswordMessage ('p') sent in response to an auth request.
+const MSG_PASSWORD: u8 = b'p';
 
 // Message type identifiers (backend → frontend)
 const MSG_AUTH: u8 = b'R';
@@ -342,6 +344,11 @@ fn pg_command_tag(sql: &str, affected: usize) -> String {
 pub struct PgWireConfig {
     pub addr: SocketAddr,
     pub server_version: String,
+    /// Optional password. When `Some`, the server requires cleartext-password
+    /// authentication (CWE-306 fix); when `None` it uses trust auth (the legacy
+    /// behavior — only safe on loopback). Cleartext goes over the wire, so pair
+    /// with TLS and/or a loopback bind.
+    pub password: Option<String>,
 }
 
 /// Start the PG wire protocol server.
@@ -363,6 +370,7 @@ pub fn start<E: PgSqlExecutor + Clone>(
         };
 
         let server_version = Arc::new(config.server_version);
+        let password = Arc::new(config.password);
         let mut conn_id: u32 = 0;
 
         loop {
@@ -372,9 +380,12 @@ pub fn start<E: PgSqlExecutor + Clone>(
                     tracing::debug!("PG wire connection from {} (id={})", peer, conn_id);
                     let exec = executor.clone();
                     let ver = server_version.clone();
+                    let pw = password.clone();
                     let cid = conn_id;
                     tokio::spawn(async move {
-                        if let Err(e) = handle_connection(stream, exec, &ver, cid).await {
+                        if let Err(e) =
+                            handle_connection(stream, exec, &ver, pw.as_deref(), cid).await
+                        {
                             tracing::debug!("PG wire connection {} error: {}", cid, e);
                         }
                     });
@@ -392,13 +403,30 @@ async fn handle_connection<E: PgSqlExecutor>(
     mut stream: TcpStream,
     executor: Arc<E>,
     server_version: &str,
+    password: Option<&str>,
     conn_id: u32,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Phase 1: Startup
     let _startup = read_startup(&mut stream).await?;
 
-    // Send AuthenticationOk
-    send_auth_ok(&mut stream).await?;
+    // Phase 1b: Authentication. With a configured password, require cleartext-
+    // password auth before exposing the SQL surface (CWE-306). Without one, fall
+    // back to trust auth (legacy; only safe on loopback).
+    match password {
+        Some(expected) => {
+            send_auth_cleartext_password(&mut stream).await?;
+            let supplied = read_password_message(&mut stream).await?;
+            if !constant_time_eq(supplied.as_bytes(), expected.as_bytes()) {
+                tracing::warn!("PG wire: password authentication failed (conn={})", conn_id);
+                send_error_response(&mut stream, "28P01", "password authentication failed")
+                    .await
+                    .ok();
+                return Ok(()); // close the connection
+            }
+            send_auth_ok(&mut stream).await?;
+        }
+        None => send_auth_ok(&mut stream).await?,
+    }
 
     // Send parameter status messages (psql expects these)
     send_parameter_status(&mut stream, "server_version", server_version).await?;
@@ -620,6 +648,71 @@ async fn send_auth_ok(
     write_i32(stream, 0).await?; // auth type: 0 = ok
     stream.flush().await?;
     Ok(())
+}
+
+/// Request cleartext-password authentication (AuthenticationCleartextPassword).
+async fn send_auth_cleartext_password(
+    stream: &mut TcpStream,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    stream.write_u8(MSG_AUTH).await?;
+    write_i32(stream, 8).await?; // length: 4 (len) + 4 (auth type)
+    write_i32(stream, 3).await?; // auth type: 3 = cleartext password
+    stream.flush().await?;
+    Ok(())
+}
+
+/// Read a client PasswordMessage ('p') and return the (null-stripped) password.
+/// The length is bounded to reject an oversized allocation from a hostile client.
+async fn read_password_message(
+    stream: &mut TcpStream,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    let msg_type = stream.read_u8().await?;
+    if msg_type != MSG_PASSWORD {
+        return Err("expected PasswordMessage".into());
+    }
+    let msg_len = stream.read_i32().await?;
+    if msg_len < 4 || msg_len > MAX_PG_MSG_LEN {
+        return Err("invalid PasswordMessage length".into());
+    }
+    let mut buf = vec![0u8; (msg_len - 4) as usize];
+    stream.read_exact(&mut buf).await?;
+    if buf.last() == Some(&0) {
+        buf.pop();
+    }
+    Ok(String::from_utf8_lossy(&buf).to_string())
+}
+
+/// Send an ErrorResponse ('E') with SQLSTATE `code` and `message`.
+async fn send_error_response(
+    stream: &mut TcpStream,
+    code: &str,
+    message: &str,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Body: field-type byte + null-terminated value, repeated, then a final null.
+    let mut body = Vec::new();
+    for (tag, val) in [(b'S', "FATAL"), (b'C', code), (b'M', message)] {
+        body.push(tag);
+        body.extend_from_slice(val.as_bytes());
+        body.push(0);
+    }
+    body.push(0); // terminator
+    stream.write_u8(MSG_ERROR_RESPONSE).await?;
+    write_i32(stream, (body.len() + 4) as i32).await?;
+    stream.write_all(&body).await?;
+    stream.flush().await?;
+    Ok(())
+}
+
+/// Constant-time byte-slice equality for password comparison.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
 }
 
 /// Send a ParameterStatus message.
@@ -996,6 +1089,7 @@ mod tests {
         let config = PgWireConfig {
             addr,
             server_version: "SochDB 0.5.0-test".into(),
+            password: None,
         };
 
         let _handle = start(config, EchoPgExecutor);
@@ -1046,6 +1140,7 @@ mod tests {
         let config = PgWireConfig {
             addr,
             server_version: "SochDB-test".into(),
+            password: None,
         };
 
         let _handle = start(config, EchoPgExecutor);

--- a/sochdb-grpc/src/pg_wire.rs
+++ b/sochdb-grpc/src/pg_wire.rs
@@ -40,6 +40,12 @@ use sochdb_query::sql::{BridgeExecutionResult, SqlBridge};
 // ============================================================================
 
 /// Protocol version 3.0 (major=3, minor=0 → 196608)
+/// Upper bound on a PG-wire message length (incl. the 4-byte length field).
+/// Rejects an attacker-controlled length from triggering an unbounded / sign-
+/// extended `vec![0u8; n]` allocation (CWE-770/789). 16 MiB is generous for SQL
+/// text while preventing the ~2 GB-per-connection memory-exhaustion DoS.
+const MAX_PG_MSG_LEN: i32 = 16 * 1024 * 1024;
+
 const PROTOCOL_VERSION_3: i32 = 196608;
 
 /// SSL request magic number
@@ -417,11 +423,15 @@ async fn handle_connection<E: PgSqlExecutor>(
             Ok(t) => t,
             Err(_) => break, // Client disconnected
         };
-        let msg_len = stream.read_i32().await? as usize;
-        if msg_len < 4 {
+        // Validate the length as a signed i32 BEFORE the usize cast: a negative
+        // value would sign-extend to a huge usize and bypass a `< 4` check, and a
+        // large positive value would trigger a multi-GB allocation below. Reject
+        // out-of-range lengths (drop the connection) — mirrors the startup cap.
+        let msg_len = stream.read_i32().await?;
+        if msg_len < 4 || msg_len > MAX_PG_MSG_LEN {
             break;
         }
-        let payload_len = msg_len - 4;
+        let payload_len = (msg_len - 4) as usize;
 
         match msg_type {
             MSG_QUERY => {

--- a/sochdb-grpc/src/server.rs
+++ b/sochdb-grpc/src/server.rs
@@ -156,9 +156,13 @@ impl VectorIndexService for VectorIndexServer {
         let req = request.into_inner();
         require_capability(&principal, &Capability::ManageCollections)?;
         let name = req.name.clone();
+        // SECURITY: scope the index key to the caller's tenant so two tenants
+        // cannot read/overwrite/destroy each other's indexes by reusing a name.
+        // The key is derived from the AUTHENTICATED principal, never from input.
+        let key = Self::index_key(&principal.tenant_id, &name);
 
         // Check if index already exists
-        if self.indexes.contains_key(&name) {
+        if self.indexes.contains_key(&key) {
             return Ok(Response::new(CreateIndexResponse {
                 success: false,
                 error: format!("Index '{}' already exists", name),
@@ -217,7 +221,7 @@ impl VectorIndexService for VectorIndexServer {
             created_at,
         };
 
-        self.indexes.insert(name.clone(), entry);
+        self.indexes.insert(key, entry);
 
         tracing::info!("Created index '{}' with dimension {}", name, dimension);
 
@@ -241,8 +245,9 @@ impl VectorIndexService for VectorIndexServer {
         let principal = extract_principal(&request);
         require_capability(&principal, &Capability::ManageCollections)?;
         let name = request.into_inner().name;
+        let key = Self::index_key(&principal.tenant_id, &name);
 
-        match self.indexes.remove(&name) {
+        match self.indexes.remove(&key) {
             Some(_) => {
                 tracing::info!("Dropped index '{}'", name);
                 Ok(Response::new(DropIndexResponse {
@@ -266,7 +271,8 @@ impl VectorIndexService for VectorIndexServer {
         let req = request.into_inner();
         require_capability(&principal, &Capability::Write)?;
 
-        let (index, dimension) = self.get_index_with_dim(&req.index_name)?;
+        let key = Self::index_key(&principal.tenant_id, &req.index_name);
+        let (index, dimension) = self.get_index_with_dim(&key)?;
 
         // Validate input
         if req.vectors.len() != req.ids.len() * dimension {
@@ -345,7 +351,8 @@ impl VectorIndexService for VectorIndexServer {
                             continue;
                         }
                         index_name = Some(req.index_name.clone());
-                        match self.get_index_with_dim(&req.index_name) {
+                        let key = Self::index_key(&principal.tenant_id, &req.index_name);
+                        match self.get_index_with_dim(&key) {
                             Ok((idx, dim)) => {
                                 dimension = dim;
                                 batch_vectors.reserve(MICRO_BATCH_SIZE * dim);
@@ -420,7 +427,8 @@ impl VectorIndexService for VectorIndexServer {
         let req = request.into_inner();
         require_capability(&principal, &Capability::Read)?;
 
-        let (index, dimension, metric_enum) = self.get_index_with_meta(&req.index_name)?;
+        let key = Self::index_key(&principal.tenant_id, &req.index_name);
+        let (index, dimension, metric_enum) = self.get_index_with_meta(&key)?;
         let metric = Self::metric_label(metric_enum);
 
         // Validate dimension
@@ -482,7 +490,8 @@ impl VectorIndexService for VectorIndexServer {
         let req = request.into_inner();
         require_capability(&principal, &Capability::Read)?;
 
-        let (index, dimension, metric_enum) = self.get_index_with_meta(&req.index_name)?;
+        let key = Self::index_key(&principal.tenant_id, &req.index_name);
+        let (index, dimension, metric_enum) = self.get_index_with_meta(&key)?;
         let metric = Self::metric_label(metric_enum);
         let num_queries = req.num_queries as usize;
         let k = req.k.max(1) as usize;
@@ -539,8 +548,9 @@ impl VectorIndexService for VectorIndexServer {
         let principal = extract_principal(&request);
         require_capability(&principal, &Capability::Read)?;
         let name = request.into_inner().index_name;
+        let key = Self::index_key(&principal.tenant_id, &name);
 
-        match self.indexes.get(&name) {
+        match self.indexes.get(&key) {
             Some(entry) => {
                 let stats = entry.index.stats();
                 Ok(Response::new(GetStatsResponse {
@@ -700,5 +710,87 @@ mod tests {
             }
         }
         assert!(saw_result, "expected at least one batch result");
+    }
+
+    /// SECURITY (CWE-639): vector indexes are scoped to the authenticated tenant.
+    /// Two tenants using the SAME index name get isolated indexes; neither can
+    /// read, overwrite, or drop the other's.
+    #[tokio::test]
+    async fn vector_indexes_are_tenant_isolated() {
+        use crate::security::{AuthMethod, Principal};
+        use std::collections::HashSet;
+
+        fn authed<T>(msg: T, tenant: &str) -> Request<T> {
+            let mut r = Request::new(msg);
+            r.extensions_mut().insert(Principal {
+                id: "u".to_string(),
+                tenant_id: tenant.to_string(),
+                capabilities: HashSet::from([
+                    Capability::Read,
+                    Capability::Write,
+                    Capability::ManageCollections,
+                ]),
+                expires_at: None,
+                auth_method: AuthMethod::Anonymous,
+            });
+            r
+        }
+
+        let server = VectorIndexServer::new();
+
+        // tenant-a creates "shared" and inserts a vector.
+        server
+            .create_index(authed(
+                CreateIndexRequest {
+                    name: "shared".to_string(),
+                    dimension: 4,
+                    config: None,
+                    metric: proto::DistanceMetric::Cosine as i32,
+                },
+                "tenant-a",
+            ))
+            .await
+            .unwrap();
+        server
+            .insert_batch(authed(
+                InsertBatchRequest {
+                    index_name: "shared".to_string(),
+                    ids: vec![1],
+                    vectors: vec![1.0, 0.0, 0.0, 0.0],
+                },
+                "tenant-a",
+            ))
+            .await
+            .unwrap();
+
+        // tenant-b searching "shared" must NOT find tenant-a's index.
+        let resp_b = server
+            .search(authed(
+                SearchRequest {
+                    index_name: "shared".to_string(),
+                    query: vec![1.0, 0.0, 0.0, 0.0],
+                    k: 1,
+                    ef: 0,
+                },
+                "tenant-b",
+            ))
+            .await;
+        assert!(resp_b.is_err(), "tenant-b must not access tenant-a's index");
+
+        // tenant-a sees its own index fine.
+        let resp_a = server
+            .search(authed(
+                SearchRequest {
+                    index_name: "shared".to_string(),
+                    query: vec![1.0, 0.0, 0.0, 0.0],
+                    k: 1,
+                    ef: 0,
+                },
+                "tenant-a",
+            ))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(resp_a.error.is_empty() && !resp_a.results.is_empty());
     }
 }

--- a/sochdb-grpc/src/server.rs
+++ b/sochdb-grpc/src/server.rs
@@ -575,12 +575,15 @@ impl VectorIndexService for VectorIndexServer {
         &self,
         _request: Request<HealthCheckRequest>,
     ) -> Result<Response<HealthCheckResponse>, Status> {
-        let indexes: Vec<String> = self.indexes.iter().map(|e| e.name.clone()).collect();
-
+        // SECURITY (CWE-200): a health probe is typically unauthenticated and is
+        // not tenant-scoped, so it must NOT enumerate index names — doing so
+        // leaked every tenant's index inventory across the tenant boundary. Use
+        // the authenticated, tenant-scoped GetStats RPC to inspect a specific
+        // index instead. The probe reports only liveness + version.
         Ok(Response::new(HealthCheckResponse {
             status: proto::health_check_response::Status::Serving.into(),
             version: VERSION.to_string(),
-            indexes,
+            indexes: Vec::new(),
         }))
     }
 }

--- a/sochdb-grpc/src/ws_server.rs
+++ b/sochdb-grpc/src/ws_server.rs
@@ -131,6 +131,22 @@ pub struct WsConfig {
     pub addr: SocketAddr,
     pub kv_store: KvStore,
     pub cdc_log: Option<Arc<sochdb_storage::cdc::CdcLog>>,
+    /// Optional bearer token. When `Some`, the WebSocket upgrade requires an
+    /// `Authorization: Bearer <token>` header (CWE-306 fix); when `None` the
+    /// gateway is open (legacy — note it operates on an isolated KV store).
+    pub auth_token: Option<String>,
+}
+
+/// Constant-time byte-slice equality for the WS bearer-token comparison.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
 }
 
 /// Start the WebSocket server on a background tokio task.
@@ -151,6 +167,7 @@ pub fn start(config: WsConfig) -> tokio::task::JoinHandle<()> {
 
         let kv_store = config.kv_store;
         let cdc_log = config.cdc_log;
+        let auth_token = config.auth_token;
 
         loop {
             match listener.accept().await {
@@ -158,8 +175,9 @@ pub fn start(config: WsConfig) -> tokio::task::JoinHandle<()> {
                     tracing::debug!("WebSocket connection from {}", peer);
                     let kv = kv_store.clone();
                     let cdc = cdc_log.clone();
+                    let token = auth_token.clone();
                     tokio::spawn(async move {
-                        if let Err(e) = handle_connection(stream, kv, cdc).await {
+                        if let Err(e) = handle_connection(stream, kv, cdc, token).await {
                             tracing::debug!("WebSocket connection error: {}", e);
                         }
                     });
@@ -177,8 +195,43 @@ async fn handle_connection(
     stream: TcpStream,
     kv_store: KvStore,
     cdc_log: Option<Arc<sochdb_storage::cdc::CdcLog>>,
+    auth_token: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let ws_stream = tokio_tungstenite::accept_async(stream).await?;
+    // Gate the WebSocket upgrade on a bearer token when configured. Rejecting at
+    // the handshake means an unauthenticated client never reaches the kv/sql
+    // dispatch loop.
+    let ws_stream = match auth_token {
+        Some(expected) => {
+            use tokio_tungstenite::tungstenite::handshake::server::{
+                ErrorResponse, Request, Response,
+            };
+            tokio_tungstenite::accept_hdr_async(
+                stream,
+                |req: &Request, resp: Response| -> Result<Response, ErrorResponse> {
+                    let ok = req
+                        .headers()
+                        .get("authorization")
+                        .and_then(|v| v.to_str().ok())
+                        .map(|h| {
+                            let supplied = h.strip_prefix("Bearer ").unwrap_or(h);
+                            constant_time_eq(supplied.as_bytes(), expected.as_bytes())
+                        })
+                        .unwrap_or(false);
+                    if ok {
+                        Ok(resp)
+                    } else {
+                        let err = ErrorResponse::new(Some("Unauthorized".to_string()));
+                        let (mut parts, body) = err.into_parts();
+                        parts.status =
+                            tokio_tungstenite::tungstenite::http::StatusCode::UNAUTHORIZED;
+                        Err(ErrorResponse::from_parts(parts, body))
+                    }
+                },
+            )
+            .await?
+        }
+        None => tokio_tungstenite::accept_async(stream).await?,
+    };
     let (mut ws_sender, mut ws_receiver) = ws_stream.split();
 
     // Channel for subscription events (pushed asynchronously)

--- a/sochdb-vector/src/segment/reader.rs
+++ b/sochdb-vector/src/segment/reader.rs
@@ -9,6 +9,99 @@ use super::format::*;
 use crate::error::{Error, Result};
 use crate::types::*;
 
+/// Bounds-check every segment section's `[offset, offset+size)` against the real
+/// mmap length, with overflow-checked size arithmetic. Rejects crafted segments
+/// before any `from_raw_parts` accessor can read out of bounds.
+fn validate_segment_layout(h: &SegmentHeader, mmap_len: usize) -> Result<()> {
+    // A section of `bytes` at `off` must lie fully within the mapping.
+    let fits = |name: &str, off: u64, bytes: usize| -> Result<()> {
+        let off = off as usize;
+        let end = off
+            .checked_add(bytes)
+            .ok_or_else(|| Error::Segment(format!("segment section '{name}' size overflow")))?;
+        if end > mmap_len {
+            return Err(Error::Segment(format!(
+                "segment section '{name}' [{off}..{end}) exceeds file length {mmap_len}"
+            )));
+        }
+        Ok(())
+    };
+    // Overflow-checked element-count -> byte-size.
+    let bytes = |count: usize, elem: usize, name: &str| -> Result<usize> {
+        count
+            .checked_mul(elem)
+            .ok_or_else(|| Error::Segment(format!("segment section '{name}' byte-size overflow")))
+    };
+
+    let n_vec = h.n_vec as usize;
+    let dim = h.dim as usize;
+    let blocks = h.num_bps_blocks() as usize;
+
+    // Always-read sections (the accessors read these unconditionally).
+    fits("bps", h.off_bps, h.bps_size())?;
+    fits("i8", h.off_i8, bytes(n_vec, dim, "i8")?)?; // i8 = 1 byte
+    fits(
+        "scales",
+        h.off_scales,
+        bytes(bytes(blocks, n_vec, "scales")?, 4, "scales")?, // f32
+    )?;
+    fits(
+        "tombstone",
+        h.off_tombstone,
+        bytes(n_vec.div_ceil(64), 8, "tombstone")?, // u64 words
+    )?;
+
+    // Flag-gated optional sections.
+    if h.flags.has(SegmentFlags::HAS_OUTLIERS) {
+        let cnt = bytes(n_vec, h.num_outliers as usize, "outliers")?;
+        fits(
+            "outliers",
+            h.off_outliers,
+            bytes(cnt, std::mem::size_of::<OutlierEntry>(), "outliers")?,
+        )?;
+    }
+    if h.flags.has(SegmentFlags::HAS_RDF) {
+        fits(
+            "rdf_dir",
+            h.off_rdf_dir,
+            bytes(dim, std::mem::size_of::<PostingListEntry>(), "rdf_dir")?,
+        )?;
+        fits(
+            "dim_weights",
+            h.off_dim_weights,
+            bytes(dim, 4, "dim_weights")?,
+        )?;
+        // rdf_data is variable-length (posting lists indexed via the directory);
+        // bound the base offset here. Per-posting offsets are still consumed via
+        // the directory and should be validated at access time.
+        if h.off_rdf_data as usize > mmap_len {
+            return Err(Error::Segment(
+                "segment section 'rdf_data' offset exceeds file".into(),
+            ));
+        }
+    }
+    if h.flags.has(SegmentFlags::HAS_FP32) {
+        fits(
+            "fp32",
+            h.off_fp32,
+            bytes(bytes(n_vec, dim, "fp32")?, 4, "fp32")?,
+        )?;
+    }
+    if h.off_bps_qparams != 0 {
+        let cnt = bytes(blocks, h.bps_proj as usize, "bps_qparams")?;
+        fits(
+            "bps_qparams",
+            h.off_bps_qparams,
+            bytes(
+                cnt,
+                std::mem::size_of::<super::bps::BpsQParam>(),
+                "bps_qparams",
+            )?,
+        )?;
+    }
+    Ok(())
+}
+
 /// An immutable segment backed by mmap
 pub struct Segment {
     /// Memory-mapped file
@@ -43,6 +136,15 @@ impl Segment {
                 header.file_len
             )));
         }
+
+        // SECURITY: header.validate() only checks magic+version. The offset table
+        // and element counts (n_vec/dim) are attacker-controlled for any on-disk
+        // segment, and the accessors below build slices via from_raw_parts from
+        // them — so a crafted segment with an out-of-range offset or huge count
+        // yields an out-of-bounds read (crash / adjacent-memory disclosure into
+        // query results). Bounds-check every section against the real mmap length
+        // ONCE here, so the unsafe accessors are sound thereafter.
+        validate_segment_layout(&header, mmap.len())?;
 
         Ok(Self {
             mmap: Arc::new(mmap),
@@ -332,6 +434,48 @@ mod tests {
 
         assert_eq!(segment.num_vectors(), 100);
         assert_eq!(segment.dim(), 64);
+    }
+
+    #[test]
+    fn rejects_out_of_bounds_offsets() {
+        // SECURITY (CWE-125): a crafted segment with a valid magic/version/file_len
+        // but a huge n_vec/dim makes the section sizes point far past the mapping.
+        // Without layout validation the from_raw_parts accessors would read out of
+        // bounds; Segment::open must reject it instead.
+        let mut file = NamedTempFile::new().unwrap();
+        let mut header = SegmentHeader::new(1_000_000_000, 512);
+        header.flags.set(SegmentFlags::HAS_BPS);
+        header.off_bps = SegmentHeader::SIZE as u64;
+        header.off_i8 = SegmentHeader::SIZE as u64;
+        // The file contains ONLY the header — every data section is out of range.
+        header.file_len = SegmentHeader::SIZE as u64;
+        file.write_all(bytemuck::bytes_of(&header)).unwrap();
+        file.flush().unwrap();
+
+        assert!(
+            Segment::open(file.path()).is_err(),
+            "segment with out-of-bounds section offsets must be rejected"
+        );
+    }
+
+    #[test]
+    fn rejects_offset_past_eof() {
+        // A single out-of-range offset (i8 section starts beyond the file) must be
+        // caught even when n_vec/dim are small.
+        let valid = create_test_segment();
+        let bytes = std::fs::read(valid.path()).unwrap();
+        let mut header: SegmentHeader = *bytemuck::from_bytes(&bytes[..SegmentHeader::SIZE]);
+        header.off_i8 = header.file_len + 4096; // point i8 past EOF
+        let mut tampered = bytes.clone();
+        tampered[..SegmentHeader::SIZE].copy_from_slice(bytemuck::bytes_of(&header));
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(&tampered).unwrap();
+        file.flush().unwrap();
+
+        assert!(
+            Segment::open(file.path()).is_err(),
+            "segment with an offset past EOF must be rejected"
+        );
     }
 
     #[test]


### PR DESCRIPTION
This pull request introduces several important security and configuration improvements across the codebase, focusing on tenant isolation, authentication, and resource binding. The most significant changes are grouped below:

**Security and Tenant Isolation:**

* The `list_namespaces` gRPC API now scopes results to only namespaces accessible by the authenticated principal, preventing tenants from viewing other tenants' namespace names, descriptions, or quotas. A test is added to enforce this behavior. [[1]](diffhunk://#diff-52394cd6def837471d0dcdb23690e125cb029db87a2741265bf6e3a88cd40e32L225-R236) [[2]](diffhunk://#diff-52394cd6def837471d0dcdb23690e125cb029db87a2741265bf6e3a88cd40e32R388-R438)
* All vector index operations (`CreateIndex`, `DropIndex`, etc.) are now strictly scoped to the calling tenant by deriving the index key from the authenticated principal, preventing cross-tenant access or manipulation. [[1]](diffhunk://#diff-b8cd6166114582fbd6a50eab21955f99a8db1fadbbc851b8447626144b455fcbR159-R165) [[2]](diffhunk://#diff-b8cd6166114582fbd6a50eab21955f99a8db1fadbbc851b8447626144b455fcbL220-R224) [[3]](diffhunk://#diff-b8cd6166114582fbd6a50eab21955f99a8db1fadbbc851b8447626144b455fcbR248-R250) [[4]](diffhunk://#diff-b8cd6166114582fbd6a50eab21955f99a8db1fadbbc851b8447626144b455fcbL269-R275)
* The vector service is now always wrapped with the authentication interceptor, ensuring all vector RPCs are authenticated and authorized.

**Authentication and Authorization:**

* The PG wire protocol server now supports optional cleartext password authentication, controlled via the `SOCHDB_PG_PASSWORD` environment variable. When set, clients must authenticate with a password; otherwise, legacy trust authentication is used. Passwords are compared in constant time to avoid timing attacks, and detailed error responses are sent on failure. [[1]](diffhunk://#diff-b4f7357252421ce39e486a9eac43ea28909e382c19e19c606f913444ea6ac303R210-R221) [[2]](diffhunk://#diff-6a944f8bd3822f55623ea4e278634e915b9452039f202cbe29536d255723ad57R347-R351) [[3]](diffhunk://#diff-6a944f8bd3822f55623ea4e278634e915b9452039f202cbe29536d255723ad57R373) [[4]](diffhunk://#diff-6a944f8bd3822f55623ea4e278634e915b9452039f202cbe29536d255723ad57R383-R388) [[5]](diffhunk://#diff-6a944f8bd3822f55623ea4e278634e915b9452039f202cbe29536d255723ad57R406-R429) [[6]](diffhunk://#diff-6a944f8bd3822f55623ea4e278634e915b9452039f202cbe29536d255723ad57R653-R717)
* The WebSocket gateway can now be protected with a bearer token via the `SOCHDB_WS_TOKEN` environment variable; a warning is logged if the gateway is left unauthenticated.

**Resource Binding and Configuration:**

* The Prometheus metrics HTTP server now binds to an operator-specified host (defaulting to loopback), rather than always binding to all interfaces. This prevents exposing the unauthenticated `/metrics` endpoint on unintended network interfaces. [[1]](diffhunk://#diff-869ea98e91435055e59886d7e0933e7fbace91afe801ff8587981d2f0eb8f9c5L43-R43) [[2]](diffhunk://#diff-869ea98e91435055e59886d7e0933e7fbace91afe801ff8587981d2f0eb8f9c5L261-R261) [[3]](diffhunk://#diff-869ea98e91435055e59886d7e0933e7fbace91afe801ff8587981d2f0eb8f9c5L273-R273) [[4]](diffhunk://#diff-869ea98e91435055e59886d7e0933e7fbace91afe801ff8587981d2f0eb8f9c5L283-R287) [[5]](diffhunk://#diff-b4f7357252421ce39e486a9eac43ea28909e382c19e19c606f913444ea6ac303L170-R173)

**Protocol Robustness:**

* The PG wire protocol implementation now enforces a strict upper bound (16 MiB) on message lengths, preventing denial-of-service attacks via oversized allocations or sign-extension bugs. [[1]](diffhunk://#diff-6a944f8bd3822f55623ea4e278634e915b9452039f202cbe29536d255723ad57R43-R48) [[2]](diffhunk://#diff-6a944f8bd3822f55623ea4e278634e915b9452039f202cbe29536d255723ad57L420-R462) [[3]](diffhunk://#diff-6a944f8bd3822f55623ea4e278634e915b9452039f202cbe29536d255723ad57R60-R61)

**Test and Documentation Updates:**

* Tests and documentation are updated to reflect new configuration options and security behaviors, including password authentication and metrics server binding. [[1]](diffhunk://#diff-6a944f8bd3822f55623ea4e278634e915b9452039f202cbe29536d255723ad57R1092) [[2]](diffhunk://#diff-6a944f8bd3822f55623ea4e278634e915b9452039f202cbe29536d255723ad57R1143) [[3]](diffhunk://#diff-869ea98e91435055e59886d7e0933e7fbace91afe801ff8587981d2f0eb8f9c5L43-R43)

These changes collectively harden the system against cross-tenant data leaks, unauthorized access, and resource exhaustion attacks.