### PR TITLE
Track a/3b pitr phase1

### DIFF
--- a/sochdb-client/src/connection.rs
+++ b/sochdb-client/src/connection.rs
@@ -2949,7 +2949,9 @@ impl EmbeddedConnection {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```ignore
+    /// // `EmbeddedConnection` is part of the `embedded` feature surface; this
+    /// // example is illustrative (not compiled under default features).
     /// let conn = EmbeddedConnection::open("my.db").unwrap();
     /// conn.execute_sql("CREATE TABLE users (id INT, name TEXT)").unwrap();
     /// conn.execute_sql("INSERT INTO users VALUES (1, 'Alice')").unwrap();

--- a/sochdb-client/src/connection.rs
+++ b/sochdb-client/src/connection.rs
@@ -3118,6 +3118,33 @@ pub struct DurableConnection {
     _ephemeral_dir: Option<tempfile::TempDir>,
 }
 
+/// A 32-byte Key-Encryption-Key (KEK) for at-rest encryption.
+///
+/// `Debug` is redacted so the key never leaks into logs. The bytes are the KEK
+/// that *wraps* a per-database data key (see `sochdb_storage::keyring`); they are
+/// never used verbatim as the cipher key. Convert to the storage KEK at open
+/// time. Note: this client-side copy is not zeroized on drop (the storage
+/// `EncryptionKey` it is converted into is); avoid holding it longer than needed.
+#[derive(Clone)]
+pub struct ClientKek([u8; 32]);
+
+impl ClientKek {
+    /// Build a KEK from raw 32 bytes.
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    pub(crate) fn bytes(&self) -> [u8; 32] {
+        self.0
+    }
+}
+
+impl std::fmt::Debug for ClientKek {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ClientKek(<redacted 32 bytes>)")
+    }
+}
+
 /// Connection configuration for DurableConnection
 ///
 /// Mirrors sochdb_storage::DatabaseConfig but exposed at the client level.
@@ -3138,6 +3165,10 @@ pub struct ConnectionConfig {
     pub group_commit_batch_size: usize,
     /// Maximum wait time for group commit in microseconds
     pub group_commit_max_wait_us: u64,
+    /// At-rest encryption KEK. `None` => plaintext (default). When set, the
+    /// database is opened (or created on first open) encrypted; a wrong/missing
+    /// key for an already-encrypted database fails closed at open.
+    pub encryption_key: Option<ClientKek>,
 }
 
 /// Durability contract for a [`DurableConnection`] (Task 4 — Explicit Durability
@@ -3202,6 +3233,7 @@ impl Default for ConnectionConfig {
             enable_ordered_index: true,
             group_commit_batch_size: 100,
             group_commit_max_wait_us: 10_000,
+            encryption_key: None,
         }
     }
 }
@@ -3219,6 +3251,7 @@ impl ConnectionConfig {
             enable_ordered_index: false,
             group_commit_batch_size: 1000,
             group_commit_max_wait_us: 50_000,
+            encryption_key: None,
         }
     }
 
@@ -3234,6 +3267,7 @@ impl ConnectionConfig {
             enable_ordered_index: true,
             group_commit_batch_size: 10,
             group_commit_max_wait_us: 1_000,
+            encryption_key: None,
         }
     }
 
@@ -3249,7 +3283,15 @@ impl ConnectionConfig {
             enable_ordered_index: true,
             group_commit_batch_size: 1,
             group_commit_max_wait_us: 0,
+            encryption_key: None,
         }
+    }
+
+    /// Set the at-rest encryption KEK (32 raw bytes). The database will be
+    /// opened (or created) encrypted; the KEK wraps a per-database data key.
+    pub fn with_encryption_key(mut self, kek: [u8; 32]) -> Self {
+        self.encryption_key = Some(ClientKek::from_bytes(kek));
+        self
     }
 }
 
@@ -3281,12 +3323,26 @@ impl DurableConnection {
     /// )?;
     /// ```
     pub fn open_with_config(path: impl AsRef<Path>, config: ConnectionConfig) -> Result<Self> {
-        // Map client config to storage config
-        let storage = if config.enable_ordered_index {
-            DurableStorage::open(path.as_ref())
-        } else {
-            DurableStorage::open_with_config(path.as_ref(), false) // No ordered index
-        }
+        use sochdb_storage::durable_storage::MemTableType;
+        use sochdb_storage::{EncryptionKey, StorageEncryption};
+
+        // Resolve at-rest encryption from the config KEK (None => plaintext).
+        let encryption = match &config.encryption_key {
+            Some(kek) => StorageEncryption::with_kek(
+                EncryptionKey::new(kek.bytes()),
+                "embedded:sochdb-client",
+            ),
+            None => StorageEncryption::disabled(),
+        };
+
+        // Map client config to storage config. Both legacy branches used the
+        // Standard memtable, so preserve that while threading encryption through.
+        let storage = DurableStorage::open_with_encryption(
+            path.as_ref(),
+            config.enable_ordered_index,
+            MemTableType::Standard,
+            encryption,
+        )
         .map_err(|e| ClientError::Storage(e.to_string()))?;
 
         // Apply sync mode from config
@@ -4298,6 +4354,62 @@ mod tests {
             let v = conn.get(b"persist").unwrap();
             assert_eq!(v, Some(b"this data".to_vec()));
             conn.abort_txn().unwrap();
+        }
+    }
+
+    #[test]
+    fn test_durable_connection_encryption_roundtrip() {
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        let kek = [0xC7u8; 32];
+
+        // Phase 1: create encrypted via the SDK config channel, write + commit.
+        {
+            let conn = DurableConnection::open_with_config(
+                dir.path(),
+                ConnectionConfig::default().with_encryption_key(kek),
+            )
+            .unwrap();
+            conn.begin_txn().unwrap();
+            conn.put(b"secret", b"value").unwrap();
+            conn.commit_txn().unwrap();
+        }
+        assert!(dir.path().join("keyring.json").exists());
+        let wal = std::fs::read(dir.path().join("wal.log")).unwrap();
+        assert!(
+            !wal.windows(5).any(|w| w == b"value"),
+            "plaintext value leaked into WAL"
+        );
+
+        // Phase 2: reopen with the correct KEK, recover, read back.
+        {
+            let conn = DurableConnection::open_with_config(
+                dir.path(),
+                ConnectionConfig::default().with_encryption_key(kek),
+            )
+            .unwrap();
+            conn.recover().unwrap();
+            conn.begin_txn().unwrap();
+            assert_eq!(conn.get(b"secret").unwrap(), Some(b"value".to_vec()));
+            conn.abort_txn().unwrap();
+        }
+
+        // Phase 3: wrong KEK fails closed.
+        {
+            let wrong = DurableConnection::open_with_config(
+                dir.path(),
+                ConnectionConfig::default().with_encryption_key([0u8; 32]),
+            );
+            assert!(wrong.is_err(), "wrong KEK must fail closed");
+        }
+
+        // Phase 4: opening the encrypted DB with no key fails closed.
+        {
+            let no_key = DurableConnection::open(dir.path());
+            assert!(
+                no_key.is_err(),
+                "encrypted DB opened without key must fail closed"
+            );
         }
     }
 

--- a/sochdb-grpc/Cargo.toml
+++ b/sochdb-grpc/Cargo.toml
@@ -29,6 +29,8 @@ sochdb-storage = { version = "2.0.9", path = "../sochdb-storage" }
 sochdb-query = { version = "2.0.9", path = "../sochdb-query" }
 sochdb-memory = { version = "2.0.9", path = "../sochdb-memory" }
 sochdb-vector = { version = "2.0.9", path = "../sochdb-vector" }
+# Wipe the transient at-rest encryption KEK stack copy after handing it to storage.
+zeroize = "1.8"
 
 # gRPC / Protocol Buffers
 tonic = { version = "0.13", features = ["tls-ring", "transport"] }

--- a/sochdb-grpc/src/main.rs
+++ b/sochdb-grpc/src/main.rs
@@ -239,16 +239,39 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // or a mounted `encryption-key`), open the SQL database encrypted.
                 // Absent a key it opens plaintext (back-compatible); the keyring
                 // still fails closed if this dir was previously encrypted.
+                //
+                // A key that is *present but invalid* (bad base64 / not 32 bytes)
+                // must NOT silently degrade to plaintext — that would create an
+                // unencrypted DB despite clear operator intent. encryption_key()
+                // returns None for BOTH absent and invalid, so disambiguate via
+                // the raw secret and fail fast on present-but-invalid.
+                let key_configured = secrets
+                    .as_ref()
+                    .map(|s| s.get_string("encryption-key").is_some())
+                    .unwrap_or(false);
                 let encryption = match secrets.as_ref().and_then(|s| s.encryption_key()) {
                     Some(mut kek) => {
                         use zeroize::Zeroize;
+                        // Provenance label reflects the actual key source.
+                        let source_id = match args.secrets_path.as_deref() {
+                            Some(p) => format!("mount:{p}"),
+                            None => "env:SOCHDB_ENCRYPTION_KEY".to_string(),
+                        };
                         let enc = sochdb_storage::StorageEncryption::with_kek(
                             sochdb_storage::EncryptionKey::new(kek),
-                            "env:SOCHDB_ENCRYPTION_KEY",
+                            source_id,
                         );
                         kek.zeroize(); // wipe the transient stack copy of the KEK
                         tracing::info!("PG SQL database: at-rest encryption ENABLED");
                         enc
+                    }
+                    None if key_configured => {
+                        return Err(format!(
+                            "encryption key is configured but invalid (must be base64 of \
+                             exactly 32 bytes); refusing to start the PG SQL database at '{}'",
+                            dir
+                        )
+                        .into());
                     }
                     None => sochdb_storage::StorageEncryption::disabled(),
                 };

--- a/sochdb-grpc/src/main.rs
+++ b/sochdb-grpc/src/main.rs
@@ -190,6 +190,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None
     };
 
+    // Load secrets (JWT, API keys, and the at-rest encryption KEK) from a
+    // Kubernetes Secrets mount or environment variables. Hoisted above the
+    // PG-wire open so the persistent SQL database can be opened with at-rest
+    // encryption when SOCHDB_ENCRYPTION_KEY (or a mounted `encryption-key`) is
+    // configured.
+    let secrets = if let Some(ref path) = args.secrets_path {
+        let provider = sochdb_grpc::security::SecretsProvider::from_mount(path);
+        if let Err(e) = provider.refresh() {
+            tracing::warn!("Failed to load secrets from {}: {}", path, e);
+        }
+        Some(provider)
+    } else {
+        let provider = sochdb_grpc::security::SecretsProvider::from_env();
+        let _ = provider.refresh();
+        Some(provider)
+    };
+
     // Start PG wire protocol server (Task 5)
     let _pg_handle = if args.pg_port > 0 {
         let pg_addr = format!("{}:{}", args.host, args.pg_port).parse()?;
@@ -218,8 +235,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // the database cannot be opened, refuse to start rather than
                 // silently degrading to the echo executor (which would return
                 // fabricated rows that look like real results).
-                let db = sochdb_storage::Database::open(dir)
-                    .map_err(|e| format!("failed to open PG SQL database at '{}': {}", dir, e))?;
+                // At-rest encryption: if a KEK is configured (SOCHDB_ENCRYPTION_KEY
+                // or a mounted `encryption-key`), open the SQL database encrypted.
+                // Absent a key it opens plaintext (back-compatible); the keyring
+                // still fails closed if this dir was previously encrypted.
+                let encryption = match secrets.as_ref().and_then(|s| s.encryption_key()) {
+                    Some(mut kek) => {
+                        use zeroize::Zeroize;
+                        let enc = sochdb_storage::StorageEncryption::with_kek(
+                            sochdb_storage::EncryptionKey::new(kek),
+                            "env:SOCHDB_ENCRYPTION_KEY",
+                        );
+                        kek.zeroize(); // wipe the transient stack copy of the KEK
+                        tracing::info!("PG SQL database: at-rest encryption ENABLED");
+                        enc
+                    }
+                    None => sochdb_storage::StorageEncryption::disabled(),
+                };
+                let db = sochdb_storage::Database::open_with_config_and_encryption(
+                    dir,
+                    sochdb_storage::DatabaseConfig::default(),
+                    encryption,
+                )
+                .map_err(|e| format!("failed to open PG SQL database at '{}': {}", dir, e))?;
                 tracing::info!(
                     "PG wire protocol executing real SQL against database at '{}'",
                     dir
@@ -261,19 +299,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let trace_server = TraceServer::new();
     let checkpoint_server = CheckpointServer::new();
     let mcp_server = McpServer::new();
-
-    // Load secrets from Kubernetes Secrets mount or environment variables
-    let secrets = if let Some(ref path) = args.secrets_path {
-        let provider = sochdb_grpc::security::SecretsProvider::from_mount(path);
-        if let Err(e) = provider.refresh() {
-            tracing::warn!("Failed to load secrets from {}: {}", path, e);
-        }
-        Some(provider)
-    } else {
-        let provider = sochdb_grpc::security::SecretsProvider::from_env();
-        let _ = provider.refresh();
-        Some(provider)
-    };
 
     // Create CDC log for subscriptions
     let cdc_log = sochdb_storage::cdc::CdcLog::new(sochdb_storage::cdc::CdcConfig {

--- a/sochdb-grpc/src/security.rs
+++ b/sochdb-grpc/src/security.rs
@@ -1288,24 +1288,39 @@ impl SecretsProvider {
     }
 
     /// Get the data-at-rest encryption key (base64-decoded to 32 bytes).
+    ///
+    /// The transient base64 string and decoded buffer (both copies of the key
+    /// material) are zeroized before return, and the caller is expected to wipe
+    /// the returned array after handing it to the crypto layer. NOTE: the secrets
+    /// cache (`Vec<u8>`) still holds the raw secret un-zeroized — a fuller fix is
+    /// a zeroizing cache; until then, run the server with core dumps disabled and
+    /// the key pages mlock'd.
     pub fn encryption_key(&self) -> Option<[u8; 32]> {
-        self.get_string("encryption-key").and_then(|b64| {
-            use base64::Engine;
-            let decoded = base64::engine::general_purpose::STANDARD
-                .decode(b64.trim())
-                .ok()?;
-            if decoded.len() == 32 {
-                let mut key = [0u8; 32];
-                key.copy_from_slice(&decoded);
-                Some(key)
-            } else {
-                tracing::error!(
-                    "Encryption key must be exactly 32 bytes, got {}",
-                    decoded.len()
-                );
-                None
+        use base64::Engine;
+        use zeroize::Zeroize;
+
+        let mut b64 = self.get_string("encryption-key")?;
+        let mut decoded = match base64::engine::general_purpose::STANDARD.decode(b64.trim()) {
+            Ok(d) => d,
+            Err(_) => {
+                b64.zeroize();
+                return None;
             }
-        })
+        };
+        b64.zeroize();
+
+        if decoded.len() != 32 {
+            tracing::error!(
+                "Encryption key must be exactly 32 bytes, got {}",
+                decoded.len()
+            );
+            decoded.zeroize();
+            return None;
+        }
+        let mut key = [0u8; 32];
+        key.copy_from_slice(&decoded);
+        decoded.zeroize();
+        Some(key)
     }
 
     /// Apply loaded secrets to a SecurityService (JWT key, API keys, etc.).

--- a/sochdb-storage/src/database.rs
+++ b/sochdb-storage/src/database.rs
@@ -82,6 +82,7 @@ use sochdb_core::{Result, SochDBError, SochValue};
 
 // Re-export key types
 pub use crate::durable_storage::RecoveryStats;
+use crate::durable_storage::StorageEncryption;
 
 /// Database configuration
 #[derive(Debug, Clone)]
@@ -1016,14 +1017,31 @@ impl Database {
 
     /// Open with custom configuration
     pub fn open_with_config<P: AsRef<Path>>(path: P, config: DatabaseConfig) -> Result<Arc<Self>> {
+        Self::open_with_config_and_encryption(path, config, StorageEncryption::disabled())
+    }
+
+    /// Open with custom configuration AND at-rest encryption.
+    ///
+    /// Threads the supplied [`StorageEncryption`] (the KEK envelope) down to the
+    /// keyring + WAL. `StorageEncryption::disabled()` is exactly plaintext
+    /// [`Self::open_with_config`]. With a KEK the database is opened (or created
+    /// on first open) encrypted; a wrong/missing key for an already-encrypted DB
+    /// fails closed. `StorageEncryption` is move-only (zeroizing), so it is a
+    /// by-value parameter rather than a `DatabaseConfig` field.
+    pub fn open_with_config_and_encryption<P: AsRef<Path>>(
+        path: P,
+        config: DatabaseConfig,
+        encryption: StorageEncryption,
+    ) -> Result<Arc<Self>> {
         let path = path.as_ref().to_path_buf();
 
         // Use IndexPolicy-based storage configuration for automatic memtable selection
         // This derives ordered index and memtable type from the policy
-        let storage = Arc::new(DurableStorage::open_with_policy(
+        let storage = Arc::new(DurableStorage::open_with_policy_encrypted(
             &path,
             config.default_index_policy,
             config.group_commit,
+            encryption,
         )?);
 
         // Propagate sync_mode from config to storage engine.
@@ -1098,6 +1116,23 @@ impl Database {
         path: P,
         config: DatabaseConfig,
     ) -> Result<Arc<Self>> {
+        Self::open_concurrent_with_config_and_encryption(
+            path,
+            config,
+            StorageEncryption::disabled(),
+        )
+    }
+
+    /// Open in concurrent (multi-reader) mode with at-rest encryption.
+    ///
+    /// The encryption-aware sibling of [`Self::open_concurrent_with_config`] —
+    /// makes the multi-process path able to open an encrypted database instead of
+    /// failing closed for lack of a key channel.
+    pub fn open_concurrent_with_config_and_encryption<P: AsRef<Path>>(
+        path: P,
+        config: DatabaseConfig,
+        encryption: StorageEncryption,
+    ) -> Result<Arc<Self>> {
         use crate::mvcc_concurrent::ConcurrentMvcc;
 
         let path = path.as_ref().to_path_buf();
@@ -1108,9 +1143,10 @@ impl Database {
 
         // Open storage WITHOUT exclusive lock (concurrent MVCC handles coordination)
         // We use a special internal method that skips the file lock
-        let storage = Arc::new(DurableStorage::open_for_concurrent(
+        let storage = Arc::new(DurableStorage::open_for_concurrent_encrypted(
             &path,
             config.default_index_policy,
+            encryption,
         )?);
 
         // Propagate sync_mode from config to storage engine
@@ -2688,6 +2724,100 @@ mod tests {
         let val = db.get(txn2, b"key1").unwrap();
         assert_eq!(val, Some(b"value1".to_vec()));
         db.abort(txn2).unwrap();
+    }
+
+    #[test]
+    fn test_database_encryption_end_to_end() {
+        use crate::durable_storage::StorageEncryption;
+        use crate::encryption::EncryptionKey;
+
+        let dir = tempdir().unwrap();
+        let kek = [0x5Au8; 32];
+        let enc = || StorageEncryption::with_kek(EncryptionKey::new(kek), "test");
+
+        // Create encrypted DB through the kernel, write committed data.
+        {
+            let db = Database::open_with_config_and_encryption(
+                dir.path(),
+                DatabaseConfig::default(),
+                enc(),
+            )
+            .unwrap();
+            assert!(db.storage.is_encrypted());
+            let txn = db.begin_transaction().unwrap();
+            db.put(txn, b"secret", b"value").unwrap();
+            db.commit(txn).unwrap();
+            db.shutdown().unwrap();
+        }
+        assert!(dir.path().join("keyring.json").exists());
+
+        // Reopen with the correct KEK -> committed data round-trips.
+        {
+            let db = Database::open_with_config_and_encryption(
+                dir.path(),
+                DatabaseConfig::default(),
+                enc(),
+            )
+            .unwrap();
+            let txn = db.begin_transaction().unwrap();
+            assert_eq!(db.get(txn, b"secret").unwrap(), Some(b"value".to_vec()));
+            db.abort(txn).unwrap();
+            db.shutdown().unwrap();
+        }
+
+        // Wrong KEK -> fail closed (no silent plaintext/empty open).
+        {
+            let wrong = Database::open_with_config_and_encryption(
+                dir.path(),
+                DatabaseConfig::default(),
+                StorageEncryption::with_kek(EncryptionKey::new([0u8; 32]), "test"),
+            );
+            assert!(wrong.is_err(), "wrong KEK must fail closed at the kernel");
+        }
+
+        // No key on an encrypted DB -> fail closed.
+        {
+            let no_key = Database::open_with_config(dir.path(), DatabaseConfig::default());
+            assert!(
+                no_key.is_err(),
+                "encrypted DB opened without key must fail closed"
+            );
+        }
+    }
+
+    #[test]
+    fn test_database_concurrent_encryption() {
+        use crate::durable_storage::StorageEncryption;
+        use crate::encryption::EncryptionKey;
+
+        let dir = tempdir().unwrap();
+        let kek = [0x33u8; 32];
+
+        {
+            let db = Database::open_concurrent_with_config_and_encryption(
+                dir.path(),
+                DatabaseConfig::default(),
+                StorageEncryption::with_kek(EncryptionKey::new(kek), "test"),
+            )
+            .unwrap();
+            assert!(db.storage.is_encrypted());
+            let txn = db.begin_transaction().unwrap();
+            db.put(txn, b"ck", b"cv").unwrap();
+            db.commit(txn).unwrap();
+            db.shutdown().unwrap();
+        }
+
+        // Reopen concurrent with correct key.
+        let db = Database::open_concurrent_with_config_and_encryption(
+            dir.path(),
+            DatabaseConfig::default(),
+            StorageEncryption::with_kek(EncryptionKey::new(kek), "test"),
+        )
+        .unwrap();
+        let txn = db.begin_transaction().unwrap();
+        assert_eq!(db.get(txn, b"ck").unwrap(), Some(b"cv".to_vec()));
+        db.abort(txn).unwrap();
+        db.shutdown().unwrap();
     }
 
     #[test]

--- a/sochdb-storage/src/durable_storage.rs
+++ b/sochdb-storage/src/durable_storage.rs
@@ -101,7 +101,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use dashmap::DashMap;
 use smallvec::SmallVec;
@@ -2469,6 +2469,13 @@ pub struct DurableStorage {
     /// Whether at-rest encryption is active for this instance (drives the live
     /// per-instance durability matrix). Set from the resolved keyring at open.
     at_rest_encrypted: bool,
+    /// Whether Point-in-Time Recovery is enabled for this database (Task 3B PITR
+    /// phase 1). Derived from the presence of `wal.manifest` at open (the manifest
+    /// is the single source of truth), or set by `enable_point_in_time_recovery`.
+    /// When enabled, the destructive `truncate_wal()` is forbidden (segment
+    /// sealing is the PITR-safe replacement, landing in a later phase) so the WAL
+    /// record ordinal stays a stable, durable monotonic LSN across restarts.
+    pitr_enabled: AtomicBool,
 }
 
 /// Encryption configuration for opening a [`DurableStorage`].
@@ -2731,6 +2738,17 @@ impl DurableStorage {
             enc_state.key_epoch(),
         )?);
 
+        // PITR anchor: the presence of wal.manifest is the single source of truth
+        // that this DB is PITR-enabled. If present, seed last_checkpoint_lsn from
+        // it (it is otherwise in-memory and lost on restart).
+        let (pitr_enabled, initial_checkpoint_lsn) =
+            if crate::wal_manifest::WalManifest::exists(&path) {
+                let m = crate::wal_manifest::WalManifest::load(&path)?;
+                (true, m.last_checkpoint_lsn)
+            } else {
+                (false, 0)
+            };
+
         let storage = Self {
             path,
             wal: wal.clone(),
@@ -2739,7 +2757,7 @@ impl DurableStorage {
             txn_write_buffers: DashMap::new(),
             group_commit: None,
             needs_recovery: AtomicU64::new(0),
-            last_checkpoint_lsn: AtomicU64::new(0),
+            last_checkpoint_lsn: AtomicU64::new(initial_checkpoint_lsn),
             sync_mode: AtomicU64::new(1), // Default: NORMAL (like SQLite)
             commits_since_sync: AtomicU64::new(0),
             // Adaptive batch sizing (Little's Law)
@@ -2748,6 +2766,7 @@ impl DurableStorage {
             fsync_latency_us: AtomicU64::new(5000), // 5ms default
             db_lock,
             at_rest_encrypted,
+            pitr_enabled: AtomicBool::new(pitr_enabled),
         };
 
         // Check if recovery needed
@@ -3387,7 +3406,58 @@ impl DurableStorage {
         let entry = TxnWalEntry::checkpoint(txn_id);
         let lsn = self.wal.append_sync(&entry)?;
         self.last_checkpoint_lsn.store(lsn, Ordering::SeqCst);
+        // PITR: persist the checkpoint LSN to the durable manifest so it survives
+        // restart. This piggybacks the fsync that append_sync already performed;
+        // the manifest write is itself crash-safe (temp + fsync + atomic rename).
+        // No-op (and no manifest write) when PITR is not enabled.
+        if self.pitr_enabled.load(Ordering::SeqCst) {
+            self.persist_pitr_manifest(lsn)?;
+        }
         Ok(lsn)
+    }
+
+    /// The current durable monotonic LSN (the WAL record ordinal). In PITR mode
+    /// the WAL is never truncated, so this is stable and monotonic across
+    /// restarts (`recover_state` rebuilds it by re-counting on reopen).
+    pub fn current_lsn(&self) -> u64 {
+        self.wal.sequence()
+    }
+
+    /// Whether Point-in-Time Recovery is enabled for this database.
+    pub fn is_pitr_enabled(&self) -> bool {
+        self.pitr_enabled.load(Ordering::SeqCst)
+    }
+
+    /// Enable Point-in-Time Recovery for this database (one-way, explicit opt-in).
+    ///
+    /// Writes the durable `wal.manifest` whose presence marks the DB PITR-enabled
+    /// on every future open. Once enabled, the destructive [`Self::truncate_wal`]
+    /// is forbidden so the WAL record ordinal stays a stable durable LSN (segment
+    /// sealing — the PITR-safe space-reclaim — lands in a later phase). Idempotent.
+    pub fn enable_point_in_time_recovery(&self) -> Result<()> {
+        if self.pitr_enabled.swap(true, Ordering::SeqCst) {
+            return Ok(()); // already enabled
+        }
+        // Preserve any existing manifest's identity; otherwise mint a fresh one.
+        let lsn = self.last_checkpoint_lsn.load(Ordering::SeqCst);
+        if crate::wal_manifest::WalManifest::exists(&self.path) {
+            self.persist_pitr_manifest(lsn)
+        } else {
+            crate::wal_manifest::WalManifest::new(lsn).write_atomic(&self.path)
+        }
+    }
+
+    /// Persist the PITR manifest with the given checkpoint LSN, preserving the
+    /// existing db identity if a manifest is already present.
+    fn persist_pitr_manifest(&self, lsn: u64) -> Result<()> {
+        let manifest = match crate::wal_manifest::WalManifest::load(&self.path) {
+            Ok(mut m) => {
+                m.last_checkpoint_lsn = lsn;
+                m
+            }
+            Err(_) => crate::wal_manifest::WalManifest::new(lsn),
+        };
+        manifest.write_atomic(&self.path)
     }
 
     /// Truncate the WAL file after checkpoint.
@@ -3399,7 +3469,18 @@ impl DurableStorage {
     ///
     /// Call after `checkpoint()` when WAL durability across restarts is
     /// not required (e.g. desktop telemetry viewers, caches).
+    ///
+    /// Refused when PITR is enabled: truncation resets the WAL record ordinal,
+    /// which would break the durable monotonic LSN that PITR anchors on. The
+    /// PITR-safe way to reclaim space is segment sealing (a later phase).
     pub fn truncate_wal(&self) -> Result<()> {
+        if self.pitr_enabled.load(Ordering::SeqCst) {
+            return Err(SochDBError::InvalidArgument(
+                "truncate_wal is disabled while Point-in-Time Recovery is enabled \
+                 (it would reset the durable LSN); use segment sealing to reclaim space"
+                    .to_string(),
+            ));
+        }
         self.wal.truncate()
     }
 
@@ -3835,6 +3916,116 @@ mod tests {
 
     fn contains(haystack: &[u8], needle: &[u8]) -> bool {
         haystack.windows(needle.len()).any(|w| w == needle)
+    }
+
+    /// PITR phase 1 — durable monotonic LSN anchor.
+    ///
+    /// Enabling PITR writes the durable manifest; the WAL record ordinal (LSN)
+    /// and the last-checkpoint LSN then survive a reopen, and the destructive
+    /// truncate is refused so the anchor can never reset. A non-PITR DB is
+    /// completely unaffected (no manifest, truncate works).
+    #[test]
+    fn test_pitr_durable_lsn_and_truncate_guard() {
+        let dir = tempdir().unwrap();
+
+        // Default DB: not PITR, no manifest, truncate allowed.
+        {
+            let s = DurableStorage::open_without_lock(dir.path()).unwrap();
+            assert!(!s.is_pitr_enabled());
+            assert!(!s.durability_capabilities().point_in_time_recovery);
+            assert!(s.truncate_wal().is_ok());
+        }
+        assert!(!dir.path().join("wal.manifest").exists());
+
+        // Enable PITR, write+checkpoint, capture the LSN.
+        let lsn_before;
+        let ckpt_lsn;
+        {
+            let s = DurableStorage::open_without_lock(dir.path()).unwrap();
+            s.enable_point_in_time_recovery().unwrap();
+            assert!(s.is_pitr_enabled());
+
+            let t = s.begin_transaction().unwrap();
+            s.write(t, b"k1".to_vec(), b"v1".to_vec()).unwrap();
+            s.commit(t).unwrap();
+            ckpt_lsn = s.checkpoint().unwrap();
+            lsn_before = s.current_lsn();
+            assert!(lsn_before > 0);
+
+            // truncate is refused while PITR is on.
+            assert!(
+                s.truncate_wal().is_err(),
+                "truncate must be refused in PITR mode"
+            );
+        }
+        assert!(dir.path().join("wal.manifest").exists());
+
+        // Reopen: PITR auto-detected from the manifest; LSN did NOT reset.
+        {
+            let s = DurableStorage::open_without_lock(dir.path()).unwrap();
+            assert!(
+                s.is_pitr_enabled(),
+                "PITR must be auto-detected from manifest"
+            );
+            s.recover().unwrap();
+            assert_eq!(
+                s.current_lsn(),
+                lsn_before,
+                "durable LSN must survive reopen (not reset to 0/record-recount drift)"
+            );
+            assert_eq!(
+                s.stats().last_checkpoint_lsn,
+                ckpt_lsn,
+                "last_checkpoint_lsn must be restored from the manifest"
+            );
+            // Committed data still readable.
+            let t = s.begin_transaction().unwrap();
+            assert_eq!(s.read(t, b"k1").unwrap(), Some(b"v1".to_vec()));
+            s.abort(t).unwrap();
+        }
+    }
+
+    /// PITR composes with at-rest encryption (the manifest anchor is independent
+    /// of the keyring; an encrypted PITR DB round-trips and stays fail-closed).
+    #[test]
+    fn test_pitr_with_encryption() {
+        use crate::encryption::EncryptionKey;
+
+        let dir = tempdir().unwrap();
+        let kek = [0x2Bu8; 32];
+
+        {
+            let s = DurableStorage::open_with_encryption(
+                dir.path(),
+                true,
+                MemTableType::Standard,
+                StorageEncryption::with_kek(EncryptionKey::new(kek), "test"),
+            )
+            .unwrap();
+            s.enable_point_in_time_recovery().unwrap();
+            let t = s.begin_transaction().unwrap();
+            s.write(t, b"ek".to_vec(), b"ev".to_vec()).unwrap();
+            s.commit(t).unwrap();
+            s.checkpoint().unwrap();
+            s.shutdown().ok();
+        }
+        assert!(dir.path().join("keyring.json").exists());
+        assert!(dir.path().join("wal.manifest").exists());
+
+        // Reopen encrypted + PITR.
+        let s = DurableStorage::open_with_encryption(
+            dir.path(),
+            true,
+            MemTableType::Standard,
+            StorageEncryption::with_kek(EncryptionKey::new(kek), "test"),
+        )
+        .unwrap();
+        assert!(s.is_pitr_enabled());
+        assert!(s.is_encrypted());
+        s.recover().unwrap();
+        let t = s.begin_transaction().unwrap();
+        assert_eq!(s.read(t, b"ek").unwrap(), Some(b"ev".to_vec()));
+        s.abort(t).unwrap();
     }
 
     /// Crash-atomicity invariant (Task 4 — completes the Task 1 single-writer

--- a/sochdb-storage/src/durable_storage.rs
+++ b/sochdb-storage/src/durable_storage.rs
@@ -3003,6 +3003,26 @@ impl DurableStorage {
             ));
         }
 
+        // Single-shot recovery on a fresh open: refuse if state was already
+        // rebuilt (by recover() or a prior recover_to()). Re-applying would layer
+        // a stale set over the point-in-time state under a newer commit_ts and
+        // silently corrupt it (recover()/recover_to() both clear needs_recovery).
+        if self.needs_recovery.load(Ordering::SeqCst) == 0 {
+            return Err(SochDBError::InvalidArgument(
+                "recover_to must be the sole recovery on a fresh open, but state \
+                 was already recovered; reopen the database and call recover_to first"
+                    .to_string(),
+            ));
+        }
+
+        // Make the on-disk WAL match current_lsn() before replaying. Under the
+        // default NORMAL sync mode the commit record(s) may still sit in the
+        // BufWriter, while current_lsn() counts the in-memory sequence — so
+        // without this flush+fsync a captured-LSN cut would silently drop
+        // committed-but-unflushed records (replay reads a fresh on-disk handle).
+        self.wal.flush()?;
+        self.wal.sync()?;
+
         let (writes, txn_count) = self.wal.replay_to_target(target)?;
 
         // Apply the bounded set of committed writes to the (fresh) memtable,
@@ -3479,16 +3499,21 @@ impl DurableStorage {
     /// is forbidden so the WAL record ordinal stays a stable durable LSN (segment
     /// sealing — the PITR-safe space-reclaim — lands in a later phase). Idempotent.
     pub fn enable_point_in_time_recovery(&self) -> Result<()> {
-        if self.pitr_enabled.swap(true, Ordering::SeqCst) {
+        if self.pitr_enabled.load(Ordering::SeqCst) {
             return Ok(()); // already enabled
         }
-        // Preserve any existing manifest's identity; otherwise mint a fresh one.
+        // Persist the durable manifest FIRST; only flip the in-memory flag after
+        // the durable write succeeds. Otherwise a failed manifest write would
+        // leave `durability_capabilities()` reporting PITR (and the truncate
+        // guard active) with no durable anchor on disk.
         let lsn = self.last_checkpoint_lsn.load(Ordering::SeqCst);
         if crate::wal_manifest::WalManifest::exists(&self.path) {
-            self.persist_pitr_manifest(lsn)
+            self.persist_pitr_manifest(lsn)?;
         } else {
-            crate::wal_manifest::WalManifest::new(lsn).write_atomic(&self.path)
+            crate::wal_manifest::WalManifest::new(lsn).write_atomic(&self.path)?;
         }
+        self.pitr_enabled.store(true, Ordering::SeqCst);
+        Ok(())
     }
 
     /// Persist the PITR manifest with the given checkpoint LSN, preserving the
@@ -4124,6 +4149,102 @@ mod tests {
         let s = DurableStorage::open_without_lock(dir.path()).unwrap();
         assert!(s.recover_to(RecoveryTarget::Lsn(1)).is_err());
         assert!(!s.durability_capabilities().point_in_time_recovery);
+    }
+
+    /// Regression (review HIGH): under the DEFAULT NORMAL sync mode a commit
+    /// record may sit unflushed in the BufWriter while current_lsn() counts it.
+    /// recover_to MUST flush+fsync before replaying, or a same-process restore to
+    /// the captured LSN silently drops the committed-but-unflushed tail.
+    #[test]
+    fn test_recover_to_flushes_before_replay() {
+        use crate::txn_wal::RecoveryTarget;
+        let dir = tempdir().unwrap();
+        let s = DurableStorage::open_without_lock(dir.path()).unwrap(); // NORMAL sync
+        s.enable_point_in_time_recovery().unwrap();
+        let t = s.begin_transaction().unwrap();
+        s.write(t, b"k".to_vec(), b"v".to_vec()).unwrap();
+        s.commit(t).unwrap(); // commit record likely unflushed under NORMAL
+        let lsn = s.current_lsn();
+        // No checkpoint, SAME process: replay reads a fresh on-disk handle.
+        let stats = s.recover_to(RecoveryTarget::Lsn(lsn)).unwrap();
+        assert!(
+            stats.writes_recovered >= 1,
+            "committed-but-unflushed data must be recovered (flush before replay)"
+        );
+    }
+
+    /// Regression (review MEDIUM): recover_to must be the SOLE recovery on a
+    /// fresh open. After recover() (or a prior recover_to) it must refuse, rather
+    /// than silently layer a stale set over the point-in-time state.
+    #[test]
+    fn test_recover_to_refuses_after_recovery() {
+        use crate::txn_wal::RecoveryTarget;
+        let dir = tempdir().unwrap();
+        {
+            let s = DurableStorage::open_without_lock(dir.path()).unwrap();
+            s.enable_point_in_time_recovery().unwrap();
+            let t = s.begin_transaction().unwrap();
+            s.write(t, b"k".to_vec(), b"v".to_vec()).unwrap();
+            s.commit(t).unwrap();
+            s.checkpoint().unwrap();
+        }
+        let s = DurableStorage::open_without_lock(dir.path()).unwrap();
+        s.recover().unwrap(); // full recovery first
+        assert!(
+            s.recover_to(RecoveryTarget::Lsn(1)).is_err(),
+            "recover_to after recover() must refuse (would double-apply)"
+        );
+        // And a second recover_to after a first also refuses.
+        let s2 = DurableStorage::open_without_lock(dir.path()).unwrap();
+        s2.recover_to(RecoveryTarget::Lsn(u64::MAX)).unwrap();
+        assert!(s2.recover_to(RecoveryTarget::Lsn(1)).is_err());
+    }
+
+    /// recover_to over an ENCRYPTED WAL: the bounded replay decrypts correctly
+    /// (review LOW: the encrypted bounded path was previously untested).
+    #[test]
+    fn test_pitr_recover_to_encrypted() {
+        use crate::encryption::EncryptionKey;
+        use crate::txn_wal::RecoveryTarget;
+
+        let dir = tempdir().unwrap();
+        let kek = [0x9Fu8; 32];
+        let mk = || StorageEncryption::with_kek(EncryptionKey::new(kek), "test");
+
+        let lsn_after_txn1;
+        {
+            let s = DurableStorage::open_with_encryption(
+                dir.path(),
+                true,
+                MemTableType::Standard,
+                mk(),
+            )
+            .unwrap();
+            s.enable_point_in_time_recovery().unwrap();
+            let t1 = s.begin_transaction().unwrap();
+            s.write(t1, b"k1".to_vec(), b"v1".to_vec()).unwrap();
+            s.commit(t1).unwrap();
+            lsn_after_txn1 = s.current_lsn();
+            let t2 = s.begin_transaction().unwrap();
+            s.write(t2, b"k2".to_vec(), b"v2".to_vec()).unwrap();
+            s.commit(t2).unwrap();
+            s.checkpoint().unwrap();
+            s.shutdown().ok();
+        }
+
+        // Reopen encrypted, restore to the cut between the two txns.
+        let s =
+            DurableStorage::open_with_encryption(dir.path(), true, MemTableType::Standard, mk())
+                .unwrap();
+        s.recover_to(RecoveryTarget::Lsn(lsn_after_txn1)).unwrap();
+        let t = s.begin_transaction().unwrap();
+        assert_eq!(
+            s.read(t, b"k1").unwrap(),
+            Some(b"v1".to_vec()),
+            "encrypted bounded replay must decrypt the in-window record"
+        );
+        assert_eq!(s.read(t, b"k2").unwrap(), None, "txn2 is past the cut");
+        s.abort(t).unwrap();
     }
 
     /// PITR composes with at-rest encryption (the manifest anchor is independent

--- a/sochdb-storage/src/durable_storage.rs
+++ b/sochdb-storage/src/durable_storage.rs
@@ -2600,9 +2600,10 @@ impl DurableStorage {
         DurabilityCapabilities {
             crash_recovery: true,
             at_rest_encryption: self.at_rest_encrypted,
-            // PITR / ARIES / fencing remain unwired on the live path (landing
-            // incrementally in Task 3B).
-            point_in_time_recovery: false,
+            // Point-in-time recovery is live (recover_to) when PITR is enabled:
+            // the WAL is fully retained and can be replayed to an LSN/timestamp.
+            point_in_time_recovery: self.pitr_enabled.load(Ordering::SeqCst),
+            // ARIES / fencing remain unwired on the live path.
             aries_checkpoint: false,
             wal_fencing: false,
         }
@@ -2965,6 +2966,49 @@ impl DurableStorage {
         let commit_ts = self.mvcc.alloc_commit_ts();
 
         // Collect keys being written for efficient commit
+        let mut write_set: HashSet<InlineKey> = HashSet::new();
+        for (key, value) in &writes {
+            write_set.insert(SmallVec::from_slice(key));
+            self.memtable
+                .write(key.clone(), Some(value.clone()), recovery_txn_id)?;
+        }
+        self.memtable.commit(recovery_txn_id, commit_ts, &write_set);
+
+        self.needs_recovery.store(0, Ordering::SeqCst);
+
+        Ok(RecoveryStats {
+            transactions_recovered: txn_count,
+            writes_recovered: writes.len(),
+            commit_ts,
+        })
+    }
+
+    /// Point-in-Time Recovery: rebuild the in-memory state as of `target`.
+    ///
+    /// This is the PITR analogue of [`Self::recover`] — call it on a FRESH open
+    /// INSTEAD of `recover()` (not in addition to it), to materialize the
+    /// database as it existed at a chosen LSN or commit timestamp. Because PITR
+    /// mode never truncates the WAL, the full history is retained and replayed up
+    /// to (and stopping at) the target, with transaction atomicity preserved
+    /// (a transaction is applied only if its commit is within the target).
+    ///
+    /// Requires PITR to be enabled (the WAL must be fully retained); returns an
+    /// error otherwise, since a truncated WAL cannot honor an arbitrary target.
+    pub fn recover_to(&self, target: crate::txn_wal::RecoveryTarget) -> Result<RecoveryStats> {
+        if !self.pitr_enabled.load(Ordering::SeqCst) {
+            return Err(SochDBError::InvalidArgument(
+                "recover_to requires Point-in-Time Recovery to be enabled \
+                 (the full WAL must be retained); call enable_point_in_time_recovery first"
+                    .to_string(),
+            ));
+        }
+
+        let (writes, txn_count) = self.wal.replay_to_target(target)?;
+
+        // Apply the bounded set of committed writes to the (fresh) memtable,
+        // mirroring recover().
+        let recovery_txn_id = self.wal.alloc_txn_id();
+        let commit_ts = self.mvcc.alloc_commit_ts();
         let mut write_set: HashSet<InlineKey> = HashSet::new();
         for (key, value) in &writes {
             write_set.insert(SmallVec::from_slice(key));
@@ -3983,6 +4027,103 @@ mod tests {
             assert_eq!(s.read(t, b"k1").unwrap(), Some(b"v1".to_vec()));
             s.abort(t).unwrap();
         }
+    }
+
+    /// PITR phase 2 — END-TO-END restore to a point in time.
+    ///
+    /// Enable PITR, commit two transactions, then on fresh reopens
+    /// `recover_to(target)` materializes the exact historical state: an LSN cut
+    /// between the two transactions sees only the first; the full LSN / a
+    /// far-future timestamp sees both; timestamp 0 sees nothing. Transaction
+    /// atomicity is preserved at the cut.
+    #[test]
+    fn test_pitr_recover_to_point_in_time() {
+        use crate::txn_wal::RecoveryTarget;
+
+        let dir = tempdir().unwrap();
+
+        // Build history: txn1 sets k1=v1; txn2 overwrites k1=v1b and adds k2=v2.
+        let (lsn_after_txn1, lsn_after_txn2);
+        {
+            let s = DurableStorage::open_without_lock(dir.path()).unwrap();
+            s.enable_point_in_time_recovery().unwrap();
+
+            let t1 = s.begin_transaction().unwrap();
+            s.write(t1, b"k1".to_vec(), b"v1".to_vec()).unwrap();
+            s.commit(t1).unwrap();
+            lsn_after_txn1 = s.current_lsn();
+
+            let t2 = s.begin_transaction().unwrap();
+            s.write(t2, b"k1".to_vec(), b"v1b".to_vec()).unwrap();
+            s.write(t2, b"k2".to_vec(), b"v2".to_vec()).unwrap();
+            s.commit(t2).unwrap();
+            lsn_after_txn2 = s.current_lsn();
+
+            s.checkpoint().unwrap();
+        }
+        assert!(lsn_after_txn2 > lsn_after_txn1);
+
+        // Restore to the cut between txn1 and txn2: only txn1's effect is visible.
+        {
+            let s = DurableStorage::open_without_lock(dir.path()).unwrap();
+            s.recover_to(RecoveryTarget::Lsn(lsn_after_txn1)).unwrap();
+            let t = s.begin_transaction().unwrap();
+            assert_eq!(
+                s.read(t, b"k1").unwrap(),
+                Some(b"v1".to_vec()),
+                "txn1 value"
+            );
+            assert_eq!(
+                s.read(t, b"k2").unwrap(),
+                None,
+                "txn2 must NOT be present at the cut"
+            );
+            s.abort(t).unwrap();
+        }
+
+        // Restore to the full LSN: both transactions visible (txn2 wins on k1).
+        {
+            let s = DurableStorage::open_without_lock(dir.path()).unwrap();
+            s.recover_to(RecoveryTarget::Lsn(lsn_after_txn2)).unwrap();
+            let t = s.begin_transaction().unwrap();
+            assert_eq!(s.read(t, b"k1").unwrap(), Some(b"v1b".to_vec()));
+            assert_eq!(s.read(t, b"k2").unwrap(), Some(b"v2".to_vec()));
+            s.abort(t).unwrap();
+        }
+
+        // Timestamp bounds: MAX => everything; 0 => nothing.
+        {
+            let s = DurableStorage::open_without_lock(dir.path()).unwrap();
+            s.recover_to(RecoveryTarget::Timestamp(u64::MAX)).unwrap();
+            let t = s.begin_transaction().unwrap();
+            assert_eq!(s.read(t, b"k1").unwrap(), Some(b"v1b".to_vec()));
+            assert_eq!(s.read(t, b"k2").unwrap(), Some(b"v2".to_vec()));
+            s.abort(t).unwrap();
+        }
+        {
+            let s = DurableStorage::open_without_lock(dir.path()).unwrap();
+            s.recover_to(RecoveryTarget::Timestamp(0)).unwrap();
+            let t = s.begin_transaction().unwrap();
+            assert_eq!(s.read(t, b"k1").unwrap(), None, "no commit is <= ts 0");
+            s.abort(t).unwrap();
+        }
+
+        // The capability matrix now reports PITR live for this DB.
+        {
+            let s = DurableStorage::open_without_lock(dir.path()).unwrap();
+            assert!(s.durability_capabilities().point_in_time_recovery);
+        }
+    }
+
+    /// recover_to is refused on a non-PITR database (the WAL may be truncated, so
+    /// an arbitrary target cannot be honored).
+    #[test]
+    fn test_recover_to_refused_without_pitr() {
+        use crate::txn_wal::RecoveryTarget;
+        let dir = tempdir().unwrap();
+        let s = DurableStorage::open_without_lock(dir.path()).unwrap();
+        assert!(s.recover_to(RecoveryTarget::Lsn(1)).is_err());
+        assert!(!s.durability_capabilities().point_in_time_recovery);
     }
 
     /// PITR composes with at-rest encryption (the manifest anchor is independent

--- a/sochdb-storage/src/durable_storage.rs
+++ b/sochdb-storage/src/durable_storage.rs
@@ -2809,6 +2809,21 @@ impl DurableStorage {
         policy: crate::index_policy::IndexPolicy,
         group_commit: bool,
     ) -> Result<Self> {
+        Self::open_with_policy_encrypted(path, policy, group_commit, StorageEncryption::disabled())
+    }
+
+    /// Policy-based open with at-rest encryption configured.
+    ///
+    /// Identical to [`Self::open_with_policy`] but threads a [`StorageEncryption`]
+    /// down to the keyring/WAL so the embedded `Database` kernel can open (or
+    /// create) an encrypted database. `StorageEncryption::disabled()` is exactly
+    /// the plaintext behaviour.
+    pub fn open_with_policy_encrypted<P: AsRef<Path>>(
+        path: P,
+        policy: crate::index_policy::IndexPolicy,
+        group_commit: bool,
+        encryption: StorageEncryption,
+    ) -> Result<Self> {
         use crate::index_policy::IndexPolicy;
 
         // Derive configuration from policy
@@ -2829,7 +2844,7 @@ impl DurableStorage {
 
         if group_commit {
             let mut storage =
-                Self::open_with_full_config(path, enable_ordered_index, memtable_type)?;
+                Self::open_with_encryption(path, enable_ordered_index, memtable_type, encryption)?;
 
             let wal = storage.wal.clone();
             let gc = EventDrivenGroupCommit::new(move |txn_ids: &[u64]| {
@@ -2847,7 +2862,7 @@ impl DurableStorage {
             storage.group_commit = Some(Arc::new(gc));
             Ok(storage)
         } else {
-            Self::open_with_full_config(path, enable_ordered_index, memtable_type)
+            Self::open_with_encryption(path, enable_ordered_index, memtable_type, encryption)
         }
     }
 
@@ -2865,6 +2880,20 @@ impl DurableStorage {
         path: P,
         policy: crate::index_policy::IndexPolicy,
     ) -> Result<Self> {
+        Self::open_for_concurrent_encrypted(path, policy, StorageEncryption::disabled())
+    }
+
+    /// Concurrent-mode open with at-rest encryption configured.
+    ///
+    /// Identical to [`Self::open_for_concurrent`] but threads a
+    /// [`StorageEncryption`] through, so an encrypted database can also be opened
+    /// in concurrent (multi-reader) mode rather than failing closed for lack of a
+    /// key channel.
+    pub fn open_for_concurrent_encrypted<P: AsRef<Path>>(
+        path: P,
+        policy: crate::index_policy::IndexPolicy,
+        encryption: StorageEncryption,
+    ) -> Result<Self> {
         use crate::index_policy::IndexPolicy;
 
         let (enable_ordered_index, memtable_type) = match policy {
@@ -2879,7 +2908,7 @@ impl DurableStorage {
             enable_ordered_index,
             memtable_type,
             false,
-            StorageEncryption::disabled(),
+            encryption,
         )
     }
 

--- a/sochdb-storage/src/keyring.rs
+++ b/sochdb-storage/src/keyring.rs
@@ -46,6 +46,8 @@ use std::sync::Arc;
 
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
+use tempfile::NamedTempFile;
+use zeroize::Zeroize;
 
 use crate::encryption::{EncryptionEngine, EncryptionKey, derive_subkey, generate_key};
 use sochdb_core::{Result, SochDBError};
@@ -305,13 +307,31 @@ fn create_encrypted(
     let mac_key = derive_subkey(kek.as_bytes(), &salt, INFO_MAC);
     file.mac = hex::encode(compute_mac(&mac_key, &file));
 
-    write_keyring_atomic(db_dir, path, &file)?;
-
-    Ok(EncryptionState::Encrypted(ActiveEncryption {
-        engine: Arc::new(dek_engine),
-        db_uuid,
-        key_epoch: epoch,
-    }))
+    // Publish the keyring EXCLUSIVELY. The concurrent (multi-process) open path
+    // holds no exclusive file lock, so two processes cold-starting the same fresh
+    // encrypted DB could otherwise BOTH generate a DEK and last-writer-wins clobber
+    // the keyring — orphaning the loser's DEK and silently losing all data it wrote
+    // under it. Exclusive create makes exactly one creator win; the loser ADOPTS
+    // the winner's keyring (re-derives the winner's DEK under the shared KEK), so
+    // both processes converge on a single DEK.
+    if write_keyring_noclobber(db_dir, path, &file)? {
+        Ok(EncryptionState::Encrypted(ActiveEncryption {
+            engine: Arc::new(dek_engine),
+            db_uuid,
+            key_epoch: epoch,
+        }))
+    } else {
+        // Lost the create race: adopt the winner's keyring with our KEK.
+        let existing = read_keyring(path)?;
+        if existing.format_version != KEYRING_FORMAT_VERSION {
+            return Err(SochDBError::Encryption(format!(
+                "unsupported keyring format version {} (expected {})",
+                existing.format_version, KEYRING_FORMAT_VERSION
+            )));
+        }
+        verify_mac(&existing, kek)?;
+        open_encrypted(existing, kek)
+    }
 }
 
 /// Verify the descriptor MAC with the KEK. A wrong KEK or any tampering of an
@@ -320,17 +340,21 @@ fn create_encrypted(
 fn verify_mac(file: &KeyringFile, kek: &EncryptionKey) -> Result<()> {
     let salt = decode_fixed::<16>(&file.salt, "salt")?;
     let mac_key = derive_subkey(kek.as_bytes(), &salt, INFO_MAC);
-    let expected = compute_mac(&mac_key, file);
     let actual = hex::decode(&file.mac)
         .map_err(|_| SochDBError::Encryption("malformed keyring mac".into()))?;
-    if !constant_time_eq(&expected, &actual) {
-        return Err(SochDBError::Encryption(
+    // Use HMAC's own vetted constant-time tag verification rather than a
+    // hand-rolled compare, so the constant-time property is not at the mercy of
+    // optimizer transforms.
+    let mut mac = <HmacSha256 as Mac>::new_from_slice(mac_key.as_bytes())
+        .expect("HMAC accepts any key length");
+    mac.update(&mac_input(file));
+    mac.verify_slice(&actual).map_err(|_| {
+        SochDBError::Encryption(
             "keyring authentication failed: wrong encryption key or tampered \
              keyring; refusing to open"
                 .to_string(),
-        ));
-    }
-    Ok(())
+        )
+    })
 }
 
 fn open_encrypted(file: KeyringFile, kek: &EncryptionKey) -> Result<EncryptionState> {
@@ -344,7 +368,7 @@ fn open_encrypted(file: KeyringFile, kek: &EncryptionKey) -> Result<EncryptionSt
     let wrap_engine = EncryptionEngine::from_key(&wrap_key);
     let wrapped_dek = hex::decode(&file.wrapped_dek)
         .map_err(|_| SochDBError::Encryption("malformed wrapped_dek".into()))?;
-    let dek_bytes = wrap_engine
+    let mut dek_bytes = wrap_engine
         .decrypt_with_aad(
             &wrapped_dek,
             &wrap_aad(&db_uuid, epoch, &file.kek_source_id),
@@ -355,13 +379,19 @@ fn open_encrypted(file: KeyringFile, kek: &EncryptionKey) -> Result<EncryptionSt
             )
         })?;
     if dek_bytes.len() != 32 {
+        dek_bytes.zeroize();
         return Err(SochDBError::Encryption(
             "unwrapped DEK is not 32 bytes".into(),
         ));
     }
+    // Move the plaintext DEK into the zeroize-on-drop wrapper and wipe the
+    // transient heap/stack copies the AEAD left behind — the DEK decrypts ALL
+    // data, so it must not linger in freed memory / swap / core dumps.
     let mut dek_arr = [0u8; 32];
     dek_arr.copy_from_slice(&dek_bytes);
+    dek_bytes.zeroize();
     let dek = EncryptionKey::new(dek_arr);
+    dek_arr.zeroize();
 
     // Canary check: prove the DEK actually decrypts data before touching WAL.
     let dek_engine = EncryptionEngine::from_key(&dek);
@@ -401,35 +431,52 @@ fn decode_fixed<const N: usize>(hexstr: &str, what: &str) -> Result<[u8; N]> {
     Ok(a)
 }
 
-/// Constant-time equality for MAC comparison.
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff = 0u8;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
-}
-
-/// Atomically persist the keyring: write temp, fsync file, rename, fsync dir.
-fn write_keyring_atomic(db_dir: &Path, path: &Path, file: &KeyringFile) -> Result<()> {
+/// Persist the keyring with an EXCLUSIVE (no-clobber) publish: write a temp file,
+/// fsync it, then atomically link it into place only if the target does not yet
+/// exist. Returns `Ok(true)` if this call created the keyring, `Ok(false)` if
+/// another creator won the race (target already existed). Crash-safe (the temp is
+/// fully fsynced before it is linked) AND race-safe (the final create is atomic +
+/// exclusive, so two concurrent creators cannot clobber each other).
+fn write_keyring_noclobber(db_dir: &Path, path: &Path, file: &KeyringFile) -> Result<bool> {
     fs::create_dir_all(db_dir)?;
     let json = serde_json::to_vec_pretty(file)
         .map_err(|e| SochDBError::Encryption(format!("serialize keyring: {e}")))?;
-    let tmp = path.with_extension("json.tmp");
+
+    let mut tmp = NamedTempFile::new_in(db_dir)?;
+    tmp.write_all(&json)?;
+    tmp.as_file().sync_all()?;
+
+    // `persist_noclobber` performs an atomic exclusive create of the final path
+    // (link/rename that fails if it already exists), so it does not clobber a
+    // keyring another process created concurrently.
+    match tmp.persist_noclobber(path) {
+        Ok(f) => {
+            f.sync_all()?;
+            fsync_dir(db_dir);
+            Ok(true)
+        }
+        Err(e) if e.error.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
+        Err(e) => Err(SochDBError::Encryption(format!(
+            "failed to publish keyring: {}",
+            e.error
+        ))),
+    }
+}
+
+/// fsync the directory so a create/link is durable. On Unix a real I/O error
+/// must surface; on other platforms opening a directory handle isn't supported,
+/// so this is best-effort there.
+fn fsync_dir(db_dir: &Path) {
+    #[cfg(unix)]
     {
-        let mut f = fs::File::create(&tmp)?;
-        f.write_all(&json)?;
-        f.sync_all()?;
+        if let Ok(dir) = fs::File::open(db_dir) {
+            let _ = dir.sync_all();
+        }
     }
-    fs::rename(&tmp, path)?;
-    // fsync the directory so the rename is durable.
-    if let Ok(dir) = fs::File::open(db_dir) {
-        let _ = dir.sync_all();
+    #[cfg(not(unix))]
+    {
+        let _ = db_dir;
     }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -528,6 +575,37 @@ mod tests {
 
         let err = load_or_init(dir.path(), Some(&kek(5)), "env", false).unwrap_err();
         assert!(matches!(err, SochDBError::Encryption(_)));
+    }
+
+    #[test]
+    fn concurrent_first_open_converges_on_single_dek() {
+        use std::sync::{Arc as StdArc, Barrier};
+        let dir = tempdir().unwrap();
+        let path = StdArc::new(dir.path().to_path_buf());
+        // All threads cold-start the SAME fresh encrypted dir simultaneously with
+        // the SAME KEK (the multi-process scenario). They MUST converge on one
+        // keyring/DEK (one creator wins, the rest adopt it) rather than each
+        // minting an independent DEK that last-writer-wins would orphan.
+        let n = 8;
+        let barrier = StdArc::new(Barrier::new(n));
+        let handles: Vec<_> = (0..n)
+            .map(|i| {
+                let p = path.clone();
+                let b = barrier.clone();
+                std::thread::spawn(move || {
+                    b.wait();
+                    let k = kek(42);
+                    let st = load_or_init(&p, Some(&k), &format!("t{i}"), true).unwrap();
+                    st.db_uuid()
+                })
+            })
+            .collect();
+        let uuids: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let first = uuids[0];
+        assert!(
+            uuids.iter().all(|u| *u == first),
+            "concurrent creators diverged onto multiple DEKs: {uuids:?}"
+        );
     }
 
     #[test]

--- a/sochdb-storage/src/lib.rs
+++ b/sochdb-storage/src/lib.rs
@@ -235,11 +235,14 @@ pub use transaction::{
     DurabilityLevel, IsolationLevel, RecoveryStats as TxnRecoveryStats, TransactionCoordinator,
     TransactionHandle,
 };
-pub use txn_wal::{CrashRecoveryStats, TxnWal, TxnWalBuffer, TxnWalEntry, TxnWalStats};
+pub use txn_wal::{
+    CrashRecoveryStats, RecoveryTarget, TxnWal, TxnWalBuffer, TxnWalEntry, TxnWalStats,
+};
 pub use wal_integration::{
     GroupCommitBuffer, MvccTransactionManager, RecoveryStats, Transaction, TxnState,
     WalStorageManager,
 };
+pub use wal_manifest::WalManifest;
 
 // Re-exports for performance optimization modules
 #[allow(deprecated)]

--- a/sochdb-storage/src/lib.rs
+++ b/sochdb-storage/src/lib.rs
@@ -124,6 +124,7 @@ pub mod upgrade_contract; // Upgrade compatibility contract (Task 12)
 #[cfg(feature = "experimental")]
 pub mod wal_fencing; // Epoch-based WAL fencing for split-brain detection [quarantined: unwired]
 pub mod wal_integration;
+pub mod wal_manifest; // Durable PITR anchor (last-checkpoint LSN + DB identity), crash-safe (Task 3B PITR)
 pub mod zero_copy_safety; // Zero-Copy Validation Layer (Task 5) // FFI bindings for Python SDK
 
 // Performance optimization modules

--- a/sochdb-storage/src/lib.rs
+++ b/sochdb-storage/src/lib.rs
@@ -303,8 +303,13 @@ pub use validation::{SSTableValidator, validate_sstable_file};
 
 // Re-exports for durable storage
 pub use durable_storage::{
-    ArenaMvccMemTable, DurableStorage, EphemeralHandle, MvccMemTable, TransactionMode,
+    ArenaMvccMemTable, DurableStorage, EphemeralHandle, MvccMemTable, StorageEncryption,
+    TransactionMode,
 };
+// At-rest encryption public surface (Task 3B), reachable from the crate root
+// alongside DurableStorage::open_with_encryption / Database::open_with_config_and_encryption.
+pub use encryption::{EncryptionEngine, EncryptionError, EncryptionKey, generate_key};
+pub use keyring::EncryptionState;
 
 // ============================================================================
 // Truth-in-capabilities: durability feature matrix (Task 3A)

--- a/sochdb-storage/src/txn_wal.rs
+++ b/sochdb-storage/src/txn_wal.rs
@@ -650,7 +650,13 @@ impl TxnWal {
     /// When `engine` is enabled, records are written and replayed as encrypted
     /// frames bound to `db_uuid` + `dek_epoch` (see framing notes). When it is
     /// disabled, this behaves exactly like [`Self::new`].
-    pub fn new_with_encryption<P: AsRef<Path>>(
+    ///
+    /// `pub(crate)` by design: the engine + `db_uuid` + `dek_epoch` MUST come
+    /// from [`crate::keyring::load_or_init`] so the fail-closed open contract
+    /// (MAC + canary) and the AAD binding are enforced. The only public door to
+    /// an encrypted WAL is
+    /// [`crate::durable_storage::DurableStorage::open_with_encryption`].
+    pub(crate) fn new_with_encryption<P: AsRef<Path>>(
         path: P,
         encryption: Arc<EncryptionEngine>,
         db_uuid: [u8; 16],
@@ -856,11 +862,12 @@ impl TxnWal {
     /// calling `flush()` + `sync()` after batching multiple commit records.
     pub fn append(&self, entry: &TxnWalEntry) -> Result<u64> {
         let mut writer = self.writer.lock();
-        let bytes = self.frame_under_lock(entry)?;
+        let bytes = self.frame_for_write(entry)?;
 
         writer.write_all(&bytes)?;
         // Don't flush here - BufWriter will batch writes automatically.
         // Call flush() explicitly before sync() or commit().
+        self.commit_record_ordinal();
 
         let seq = self.sequence.fetch_add(1, Ordering::SeqCst);
         self.bytes_since_sync
@@ -869,16 +876,28 @@ impl TxnWal {
         Ok(seq)
     }
 
-    /// Serialize one entry into its on-disk frame, allocating the per-record
-    /// ordinal when encrypted. MUST be called with the `writer` lock held so the
-    /// ordinal matches the order bytes hit the file.
+    /// Serialize one entry into its on-disk frame using the CURRENT (not-yet-
+    /// advanced) AAD ordinal. MUST be called with the `writer` lock held, and the
+    /// caller MUST call [`Self::commit_record_ordinal`] only AFTER `write_all`
+    /// succeeds — so a failed or partial write never advances the in-memory
+    /// ordinal past what is actually on disk (which would desync every
+    /// subsequent record's AAD from the reader's reconstructed ordinal).
     #[inline]
-    fn frame_under_lock(&self, entry: &TxnWalEntry) -> Result<Vec<u8>> {
+    fn frame_for_write(&self, entry: &TxnWalEntry) -> Result<Vec<u8>> {
         if self.encryption.is_enabled() {
-            let ord = self.records_in_file.fetch_add(1, Ordering::SeqCst);
+            let ord = self.records_in_file.load(Ordering::SeqCst);
             self.encrypt_frame(&entry.body_bytes(), ord)
         } else {
             Ok(entry.to_bytes())
+        }
+    }
+
+    /// Advance the file-relative AAD ordinal by one record. Call ONLY after the
+    /// record's bytes have been handed to the writer (post-`write_all`).
+    #[inline]
+    fn commit_record_ordinal(&self) {
+        if self.encryption.is_enabled() {
+            self.records_in_file.fetch_add(1, Ordering::SeqCst);
         }
     }
 
@@ -888,10 +907,11 @@ impl TxnWal {
     #[inline]
     pub fn append_no_flush(&self, entry: &TxnWalEntry) -> Result<u64> {
         let mut writer = self.writer.lock();
-        let bytes = self.frame_under_lock(entry)?;
+        let bytes = self.frame_for_write(entry)?;
 
         writer.write_all(&bytes)?;
         // No flush - let BufWriter buffer the writes
+        self.commit_record_ordinal();
 
         let seq = self.sequence.fetch_add(1, Ordering::SeqCst);
         self.bytes_since_sync
@@ -926,9 +946,12 @@ impl TxnWal {
         // path below keeps its zero-alloc streaming fast path untouched.
         if self.encryption.is_enabled() {
             let body = encode_record_body(WalRecordType::Data, txn_id, timestamp_us, key, value);
-            let ord = self.records_in_file.fetch_add(1, Ordering::SeqCst);
+            let ord = self.records_in_file.load(Ordering::SeqCst);
             let frame = self.encrypt_frame(&body, ord)?;
             writer.write_all(&frame)?;
+            // Advance the AAD ordinal only after the bytes are committed to the
+            // writer, so a failed write never desyncs writer/reader ordinals.
+            self.records_in_file.fetch_add(1, Ordering::SeqCst);
             let seq = self.sequence.fetch_add(1, Ordering::SeqCst);
             self.bytes_since_sync
                 .fetch_add(frame.len() as u64, Ordering::Relaxed);
@@ -1054,9 +1077,13 @@ impl TxnWal {
                 }
                 let body = &buf[pos..pos + content_len];
                 pos += content_len;
-                let ord = self.records_in_file.fetch_add(1, Ordering::SeqCst);
+                let ord = self.records_in_file.load(Ordering::SeqCst);
                 let frame = self.encrypt_frame(body, ord)?;
                 writer.write_all(&frame)?;
+                // Advance per record only after its bytes are committed, so a
+                // mid-batch write failure leaves records_in_file == records
+                // actually written (no ordinal desync for the survivors).
+                self.records_in_file.fetch_add(1, Ordering::SeqCst);
                 total_written += frame.len() as u64;
             }
             let seq = self

--- a/sochdb-storage/src/txn_wal.rs
+++ b/sochdb-storage/src/txn_wal.rs
@@ -182,6 +182,19 @@ fn encode_record_body(
     body
 }
 
+/// A Point-in-Time Recovery target (Task 3B PITR). See
+/// [`TxnWal::replay_to_target`] for the prefix semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryTarget {
+    /// Recover the first `lsn` WAL records (exact). Matches the value of
+    /// `DurableStorage::current_lsn()` captured at the desired point.
+    Lsn(u64),
+    /// Recover every transaction whose COMMIT timestamp (microseconds since the
+    /// epoch) is `<=` this value; stop at the first commit after it. Best-effort
+    /// on the coarse, possibly non-monotonic commit clock — prefer `Lsn`.
+    Timestamp(u64),
+}
+
 /// AAD layout version for the WAL record binding. Part of the on-disk contract.
 const WAL_AAD_VERSION: u8 = 1;
 /// AAD length: version(1) + db_uuid(16) + dek_epoch(4) + record_ordinal(8).
@@ -1244,6 +1257,89 @@ impl TxnWal {
                     // silently drop committed data. (Wrong key is already excluded
                     // earlier by the keyring canary, so this is genuine corruption
                     // or tampering.) Plaintext keeps the legacy torn-tail tolerance.
+                    if self.encryption.is_enabled() {
+                        return Err(e);
+                    }
+                    break;
+                }
+            }
+        }
+
+        Ok((result, txn_count))
+    }
+
+    /// Replay the WAL up to a PITR target, returning the committed writes whose
+    /// transactions are included by the target (and the count of such txns).
+    ///
+    /// Prefix semantics — recovery "rolls forward" through the WAL and STOPS at
+    /// the target, so the result is always a state the database actually passed
+    /// through:
+    /// - [`RecoveryTarget::Lsn`]`(l)`: include the first `l` WAL records (exact;
+    ///   `l` matches [`Self::sequence`] / `DurableStorage::current_lsn` captured
+    ///   at that point). A transaction whose commit lands after record `l` is
+    ///   excluded (atomic — partial transactions are never applied).
+    /// - [`RecoveryTarget::Timestamp`]`(t)`: stop at the FIRST transaction whose
+    ///   commit timestamp exceeds `t`. Best-effort on the coarse, possibly
+    ///   non-monotonic commit clock; prefer `Lsn` for an exact cut.
+    ///
+    /// Crypto-aware and fail-loud, exactly like [`Self::replay_for_recovery`].
+    #[allow(clippy::type_complexity)]
+    pub fn replay_to_target(
+        &self,
+        target: RecoveryTarget,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, usize)> {
+        let file = File::open(&self.path)?;
+        let mut reader = BufReader::new(file);
+
+        let mut pending_writes: std::collections::HashMap<u64, Vec<(Vec<u8>, Vec<u8>)>> =
+            std::collections::HashMap::new();
+        let mut result = Vec::new();
+        let mut txn_count = 0;
+        let mut ordinal: u64 = 0;
+
+        loop {
+            match self.read_record(&mut reader, &mut ordinal) {
+                Ok(entry) => {
+                    // LSN target: `ordinal` is now this record's 1-based LSN.
+                    // Stop once we pass the target (this record is excluded).
+                    if let RecoveryTarget::Lsn(l) = target {
+                        if ordinal > l {
+                            break;
+                        }
+                    }
+                    match entry.record_type {
+                        WalRecordType::TxnBegin => {
+                            pending_writes.insert(entry.txn_id, Vec::new());
+                        }
+                        WalRecordType::Data => {
+                            pending_writes
+                                .entry(entry.txn_id)
+                                .or_insert_with(Vec::new)
+                                .push((entry.key, entry.value));
+                        }
+                        WalRecordType::TxnCommit => {
+                            // Timestamp target: stop rolling forward at the first
+                            // transaction committed AFTER the target (exclude it).
+                            if let RecoveryTarget::Timestamp(t) = target {
+                                if entry.timestamp_us > t {
+                                    break;
+                                }
+                            }
+                            if let Some(writes) = pending_writes.remove(&entry.txn_id) {
+                                result.extend(writes);
+                                txn_count += 1;
+                            }
+                        }
+                        WalRecordType::TxnAbort => {
+                            pending_writes.remove(&entry.txn_id);
+                        }
+                        _ => {}
+                    }
+                }
+                Err(SochDBError::Io(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    break;
+                }
+                Err(e) => {
                     if self.encryption.is_enabled() {
                         return Err(e);
                     }

--- a/sochdb-storage/src/txn_wal.rs
+++ b/sochdb-storage/src/txn_wal.rs
@@ -189,9 +189,14 @@ pub enum RecoveryTarget {
     /// Recover the first `lsn` WAL records (exact). Matches the value of
     /// `DurableStorage::current_lsn()` captured at the desired point.
     Lsn(u64),
-    /// Recover every transaction whose COMMIT timestamp (microseconds since the
-    /// epoch) is `<=` this value; stop at the first commit after it. Best-effort
-    /// on the coarse, possibly non-monotonic commit clock — prefer `Lsn`.
+    /// Roll the WAL forward and STOP at the first transaction whose COMMIT
+    /// timestamp (microseconds since the epoch) exceeds this value — that
+    /// transaction and everything after it are excluded. This is an exact
+    /// WAL-order PREFIX, NOT a timestamp filter: if commit timestamps are
+    /// non-monotonic in WAL order (coarse ~1ms clock, NTP steps, cross-thread
+    /// group commit), a later-in-WAL transaction with `ts <= t` that follows an
+    /// excluded commit is ALSO excluded. Prefer `Lsn` for an exact, clock-
+    /// independent cut.
     Timestamp(u64),
 }
 

--- a/sochdb-storage/src/wal_manifest.rs
+++ b/sochdb-storage/src/wal_manifest.rs
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SochDB - LLM-Optimized Embedded Database
+// Copyright (C) 2026 Sushanth Reddy Vanagala (https://github.com/sushanthpy)
+
+//! # WAL manifest — durable PITR anchor (Task 3B, PITR phase 1)
+//!
+//! The manifest is the **single source of truth** for a database's Point-in-Time
+//! Recovery state. Its mere PRESENCE marks a database as PITR-enabled (so the
+//! anchor is consistent regardless of how a given process opens the DB), and it
+//! durably records the last-checkpoint LSN so it survives process restarts.
+//!
+//! ## Why a manifest at all
+//!
+//! On the live path `DurableStorage::checkpoint()` does NOT truncate the WAL, so
+//! the per-file record counter (`TxnWal::sequence`) is already a monotonic LSN
+//! that `recover_state` rebuilds by re-counting on every reopen — i.e. it is
+//! durable across restarts *as long as the WAL is never truncated*. PITR mode
+//! therefore forbids the destructive `truncate_wal()` (segment **sealing** is the
+//! PITR-safe replacement, landing in a later phase), which keeps `sequence` a
+//! stable global anchor. The manifest then only needs to persist the
+//! last-checkpoint LSN (which is otherwise in-memory and lost on restart) plus a
+//! DB identity, written crash-safely.
+//!
+//! ## On-disk format (`<db_dir>/wal.manifest`, JSON)
+//!
+//! ```text
+//! { format_version, db_uuid (hex 16), last_checkpoint_lsn }
+//! ```
+//!
+//! Persisted with the same atomic temp→fsync→rename→fsync-dir pattern as the
+//! keyring, so a crash never leaves a torn manifest.
+
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use tempfile::NamedTempFile;
+
+use sochdb_core::{Result, SochDBError};
+
+/// Current manifest format version.
+const WAL_MANIFEST_FORMAT_VERSION: u32 = 1;
+/// Manifest file name within the database directory.
+pub const WAL_MANIFEST_FILE: &str = "wal.manifest";
+
+/// On-disk WAL manifest (the durable PITR anchor).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct WalManifest {
+    /// Format version of this manifest.
+    pub format_version: u32,
+    /// 16-byte database identity (hex-encoded), bound for future segment-catalog
+    /// integrity. Random per database at PITR-enable time.
+    pub db_uuid: String,
+    /// LSN (monotonic WAL record ordinal) as of the most recent checkpoint.
+    pub last_checkpoint_lsn: u64,
+}
+
+impl WalManifest {
+    /// Create a fresh manifest with a random db_uuid and the given starting LSN.
+    pub fn new(last_checkpoint_lsn: u64) -> Self {
+        let mut uuid = [0u8; 16];
+        {
+            use rand::RngCore;
+            rand::rngs::OsRng.fill_bytes(&mut uuid);
+        }
+        Self {
+            format_version: WAL_MANIFEST_FORMAT_VERSION,
+            db_uuid: hex::encode(uuid),
+            last_checkpoint_lsn,
+        }
+    }
+
+    /// Path to the manifest within `db_dir`.
+    pub fn path(db_dir: &Path) -> PathBuf {
+        db_dir.join(WAL_MANIFEST_FILE)
+    }
+
+    /// Whether a manifest exists in `db_dir` (i.e. the DB is PITR-enabled).
+    pub fn exists(db_dir: &Path) -> bool {
+        Self::path(db_dir).exists()
+    }
+
+    /// Load and validate the manifest from `db_dir`.
+    pub fn load(db_dir: &Path) -> Result<Self> {
+        let bytes = fs::read(Self::path(db_dir))?;
+        let m: WalManifest = serde_json::from_slice(&bytes)
+            .map_err(|e| SochDBError::Corruption(format!("malformed wal.manifest: {e}")))?;
+        if m.format_version != WAL_MANIFEST_FORMAT_VERSION {
+            return Err(SochDBError::Corruption(format!(
+                "unsupported wal.manifest version {} (expected {})",
+                m.format_version, WAL_MANIFEST_FORMAT_VERSION
+            )));
+        }
+        Ok(m)
+    }
+
+    /// Atomically persist the manifest: write temp, fsync, rename, fsync dir.
+    /// Crash-safe — a torn write leaves the previous manifest (or none) intact.
+    pub fn write_atomic(&self, db_dir: &Path) -> Result<()> {
+        fs::create_dir_all(db_dir)?;
+        let json = serde_json::to_vec_pretty(self)
+            .map_err(|e| SochDBError::Internal(format!("serialize wal.manifest: {e}")))?;
+        let mut tmp = NamedTempFile::new_in(db_dir)?;
+        tmp.write_all(&json)?;
+        tmp.as_file().sync_all()?;
+        let path = Self::path(db_dir);
+        let f = tmp.persist(&path).map_err(|e| SochDBError::Io(e.error))?;
+        f.sync_all()?;
+        fsync_dir(db_dir);
+        Ok(())
+    }
+}
+
+/// fsync the directory so the rename is durable. Best-effort off Unix (opening a
+/// directory handle isn't supported there).
+fn fsync_dir(db_dir: &Path) {
+    #[cfg(unix)]
+    {
+        if let Ok(dir) = fs::File::open(db_dir) {
+            let _ = dir.sync_all();
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = db_dir;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn roundtrip_and_exists() {
+        let dir = tempdir().unwrap();
+        assert!(!WalManifest::exists(dir.path()));
+        let m = WalManifest::new(42);
+        m.write_atomic(dir.path()).unwrap();
+        assert!(WalManifest::exists(dir.path()));
+        let loaded = WalManifest::load(dir.path()).unwrap();
+        assert_eq!(loaded.last_checkpoint_lsn, 42);
+        assert_eq!(loaded.db_uuid, m.db_uuid);
+        assert_eq!(loaded.format_version, WAL_MANIFEST_FORMAT_VERSION);
+    }
+
+    #[test]
+    fn overwrite_advances_lsn_and_keeps_uuid() {
+        let dir = tempdir().unwrap();
+        let mut m = WalManifest::new(10);
+        m.write_atomic(dir.path()).unwrap();
+        let uuid = m.db_uuid.clone();
+        m.last_checkpoint_lsn = 100;
+        m.write_atomic(dir.path()).unwrap();
+        let loaded = WalManifest::load(dir.path()).unwrap();
+        assert_eq!(loaded.last_checkpoint_lsn, 100);
+        assert_eq!(
+            loaded.db_uuid, uuid,
+            "db identity must be stable across writes"
+        );
+    }
+
+    #[test]
+    fn a_torn_temp_does_not_corrupt_the_committed_manifest() {
+        let dir = tempdir().unwrap();
+        WalManifest::new(7).write_atomic(dir.path()).unwrap();
+        // Simulate a torn in-progress write: a stray *.tmp left in the dir.
+        std::fs::write(dir.path().join("stray.tmp"), b"{ partial").unwrap();
+        // The committed manifest is still intact and parseable.
+        let loaded = WalManifest::load(dir.path()).unwrap();
+        assert_eq!(loaded.last_checkpoint_lsn, 7);
+    }
+
+    #[test]
+    fn load_rejects_garbage() {
+        let dir = tempdir().unwrap();
+        std::fs::write(WalManifest::path(dir.path()), b"not json").unwrap();
+        assert!(WalManifest::load(dir.path()).is_err());
+    }
+}


### PR DESCRIPTION
This pull request adds support for at-rest encryption using a Key-Encryption-Key (KEK) throughout the client and storage layers. It introduces a secure configuration interface for specifying a KEK, ensures the key is handled and zeroized securely, and threads encryption support through the database open paths. Additionally, comprehensive tests and documentation are provided to validate and explain the new encryption functionality.

**At-rest encryption support:**

* Introduced the `ClientKek` struct in `sochdb-client/src/connection.rs` to represent a 32-byte KEK for at-rest encryption, with redacted debug output and a secure interface.
* Added an `encryption_key` field to `ConnectionConfig` and a `with_encryption_key` builder method for ergonomic and explicit configuration of at-rest encryption. [[1]](diffhunk://#diff-3bfba99e525a414a13e60d1d91fe225c093e66ff0a73d3ec232b51de1c9f4e76R3170-R3173) [[2]](diffhunk://#diff-3bfba99e525a414a13e60d1d91fe225c093e66ff0a73d3ec232b51de1c9f4e76R3288-R3297)
* Updated `DurableConnection::open_with_config` to thread the encryption configuration to storage and open the database encrypted if a KEK is provided.

**Secure key handling and integration:**

* Updated the `SecretsProvider` in `sochdb-grpc` to securely load, decode, and zeroize the KEK from environment variables or Kubernetes Secrets, and ensured the transient key material is wiped after use. [[1]](diffhunk://#diff-550521cb2caa57987763cb73c3851599d77b40900896aa426feb1297ea8fbb33R1291-R1323) [[2]](diffhunk://#diff-b4f7357252421ce39e486a9eac43ea28909e382c19e19c606f913444ea6ac303L221-R282)
* Added the `zeroize` crate as a dependency to securely wipe sensitive key material from memory.

**Database and storage API changes:**

* Added new methods to `sochdb-storage::Database` to support opening with encryption (`open_with_config_and_encryption` and `open_concurrent_with_config_and_encryption`), and threaded the new `StorageEncryption` type through to the storage layer. [[1]](diffhunk://#diff-c1ab15b99ecbfd7157f9af4a08ac5a7013b40436693a3e46fe831d308cb97f46R1020-R1044) [[2]](diffhunk://#diff-c1ab15b99ecbfd7157f9af4a08ac5a7013b40436693a3e46fe831d308cb97f46R1118-R1134) [[3]](diffhunk://#diff-c1ab15b99ecbfd7157f9af4a08ac5a7013b40436693a3e46fe831d308cb97f46L1111-R1149)

**Testing and documentation:**

* Added a comprehensive test in `sochdb-client/src/connection.rs` to verify that encrypted databases can be created, reopened with the correct key, and fail closed with the wrong or missing key.
* Improved documentation throughout the codebase to clarify encryption semantics, key handling, and configuration. [[1]](diffhunk://#diff-3bfba99e525a414a13e60d1d91fe225c093e66ff0a73d3ec232b51de1c9f4e76L2952-R2954) [[2]](diffhunk://#diff-3bfba99e525a414a13e60d1d91fe225c093e66ff0a73d3ec232b51de1c9f4e76R3170-R3173) [[3]](diffhunk://#diff-550521cb2caa57987763cb73c3851599d77b40900896aa426feb1297ea8fbb33R1291-R1323)

These changes collectively enable robust and secure at-rest encryption for SochDB databases, with careful handling of cryptographic key material and clear failure modes for misconfiguration.