### PR TITLE
harden(storage): address adversarial-review findings on 3B encryption

### DIFF
--- a/sochdb-storage/src/keyring.rs
+++ b/sochdb-storage/src/keyring.rs
@@ -46,6 +46,7 @@ use std::sync::Arc;
 
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
+use zeroize::Zeroize;
 
 use crate::encryption::{EncryptionEngine, EncryptionKey, derive_subkey, generate_key};
 use sochdb_core::{Result, SochDBError};
@@ -320,17 +321,21 @@ fn create_encrypted(
 fn verify_mac(file: &KeyringFile, kek: &EncryptionKey) -> Result<()> {
     let salt = decode_fixed::<16>(&file.salt, "salt")?;
     let mac_key = derive_subkey(kek.as_bytes(), &salt, INFO_MAC);
-    let expected = compute_mac(&mac_key, file);
     let actual = hex::decode(&file.mac)
         .map_err(|_| SochDBError::Encryption("malformed keyring mac".into()))?;
-    if !constant_time_eq(&expected, &actual) {
-        return Err(SochDBError::Encryption(
+    // Use HMAC's own vetted constant-time tag verification rather than a
+    // hand-rolled compare, so the constant-time property is not at the mercy of
+    // optimizer transforms.
+    let mut mac = <HmacSha256 as Mac>::new_from_slice(mac_key.as_bytes())
+        .expect("HMAC accepts any key length");
+    mac.update(&mac_input(file));
+    mac.verify_slice(&actual).map_err(|_| {
+        SochDBError::Encryption(
             "keyring authentication failed: wrong encryption key or tampered \
              keyring; refusing to open"
                 .to_string(),
-        ));
-    }
-    Ok(())
+        )
+    })
 }
 
 fn open_encrypted(file: KeyringFile, kek: &EncryptionKey) -> Result<EncryptionState> {
@@ -344,7 +349,7 @@ fn open_encrypted(file: KeyringFile, kek: &EncryptionKey) -> Result<EncryptionSt
     let wrap_engine = EncryptionEngine::from_key(&wrap_key);
     let wrapped_dek = hex::decode(&file.wrapped_dek)
         .map_err(|_| SochDBError::Encryption("malformed wrapped_dek".into()))?;
-    let dek_bytes = wrap_engine
+    let mut dek_bytes = wrap_engine
         .decrypt_with_aad(
             &wrapped_dek,
             &wrap_aad(&db_uuid, epoch, &file.kek_source_id),
@@ -355,13 +360,19 @@ fn open_encrypted(file: KeyringFile, kek: &EncryptionKey) -> Result<EncryptionSt
             )
         })?;
     if dek_bytes.len() != 32 {
+        dek_bytes.zeroize();
         return Err(SochDBError::Encryption(
             "unwrapped DEK is not 32 bytes".into(),
         ));
     }
+    // Move the plaintext DEK into the zeroize-on-drop wrapper and wipe the
+    // transient heap/stack copies the AEAD left behind — the DEK decrypts ALL
+    // data, so it must not linger in freed memory / swap / core dumps.
     let mut dek_arr = [0u8; 32];
     dek_arr.copy_from_slice(&dek_bytes);
+    dek_bytes.zeroize();
     let dek = EncryptionKey::new(dek_arr);
+    dek_arr.zeroize();
 
     // Canary check: prove the DEK actually decrypts data before touching WAL.
     let dek_engine = EncryptionEngine::from_key(&dek);
@@ -401,18 +412,6 @@ fn decode_fixed<const N: usize>(hexstr: &str, what: &str) -> Result<[u8; N]> {
     Ok(a)
 }
 
-/// Constant-time equality for MAC comparison.
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff = 0u8;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
-}
-
 /// Atomically persist the keyring: write temp, fsync file, rename, fsync dir.
 fn write_keyring_atomic(db_dir: &Path, path: &Path, file: &KeyringFile) -> Result<()> {
     fs::create_dir_all(db_dir)?;
@@ -425,9 +424,14 @@ fn write_keyring_atomic(db_dir: &Path, path: &Path, file: &KeyringFile) -> Resul
         f.sync_all()?;
     }
     fs::rename(&tmp, path)?;
-    // fsync the directory so the rename is durable.
-    if let Ok(dir) = fs::File::open(db_dir) {
-        let _ = dir.sync_all();
+    // fsync the directory so the rename is durable. On Unix a real I/O error
+    // here must surface (the keyring's durability rests on this — a lost rename
+    // can orphan the DEK). On non-Unix, opening a directory handle isn't
+    // supported, so this is best-effort there.
+    #[cfg(unix)]
+    {
+        let dir = fs::File::open(db_dir)?;
+        dir.sync_all()?;
     }
     Ok(())
 }

--- a/sochdb-storage/src/lib.rs
+++ b/sochdb-storage/src/lib.rs
@@ -303,8 +303,13 @@ pub use validation::{SSTableValidator, validate_sstable_file};
 
 // Re-exports for durable storage
 pub use durable_storage::{
-    ArenaMvccMemTable, DurableStorage, EphemeralHandle, MvccMemTable, TransactionMode,
+    ArenaMvccMemTable, DurableStorage, EphemeralHandle, MvccMemTable, StorageEncryption,
+    TransactionMode,
 };
+// At-rest encryption public surface (Task 3B), reachable from the crate root
+// alongside DurableStorage::open_with_encryption.
+pub use encryption::{EncryptionEngine, EncryptionError, EncryptionKey, generate_key};
+pub use keyring::EncryptionState;
 
 // ============================================================================
 // Truth-in-capabilities: durability feature matrix (Task 3A)

--- a/sochdb-storage/src/txn_wal.rs
+++ b/sochdb-storage/src/txn_wal.rs
@@ -650,7 +650,12 @@ impl TxnWal {
     /// When `engine` is enabled, records are written and replayed as encrypted
     /// frames bound to `db_uuid` + `dek_epoch` (see framing notes). When it is
     /// disabled, this behaves exactly like [`Self::new`].
-    pub fn new_with_encryption<P: AsRef<Path>>(
+    ///
+    /// `pub(crate)` by design: the engine + `db_uuid` + `dek_epoch` MUST come
+    /// from [`crate::keyring::load_or_init`] so the fail-closed open contract
+    /// (MAC + canary) and the AAD binding are enforced. The only public door to
+    /// an encrypted WAL is [`crate::durable_storage::DurableStorage::open_with_encryption`].
+    pub(crate) fn new_with_encryption<P: AsRef<Path>>(
         path: P,
         encryption: Arc<EncryptionEngine>,
         db_uuid: [u8; 16],
@@ -856,11 +861,12 @@ impl TxnWal {
     /// calling `flush()` + `sync()` after batching multiple commit records.
     pub fn append(&self, entry: &TxnWalEntry) -> Result<u64> {
         let mut writer = self.writer.lock();
-        let bytes = self.frame_under_lock(entry)?;
+        let bytes = self.frame_for_write(entry)?;
 
         writer.write_all(&bytes)?;
         // Don't flush here - BufWriter will batch writes automatically.
         // Call flush() explicitly before sync() or commit().
+        self.commit_record_ordinal();
 
         let seq = self.sequence.fetch_add(1, Ordering::SeqCst);
         self.bytes_since_sync
@@ -869,16 +875,28 @@ impl TxnWal {
         Ok(seq)
     }
 
-    /// Serialize one entry into its on-disk frame, allocating the per-record
-    /// ordinal when encrypted. MUST be called with the `writer` lock held so the
-    /// ordinal matches the order bytes hit the file.
+    /// Serialize one entry into its on-disk frame using the CURRENT (not-yet-
+    /// advanced) AAD ordinal. MUST be called with the `writer` lock held, and the
+    /// caller MUST call [`Self::commit_record_ordinal`] only AFTER `write_all`
+    /// succeeds — so a failed or partial write never advances the in-memory
+    /// ordinal past what is actually on disk (which would desync every
+    /// subsequent record's AAD from the reader's reconstructed ordinal).
     #[inline]
-    fn frame_under_lock(&self, entry: &TxnWalEntry) -> Result<Vec<u8>> {
+    fn frame_for_write(&self, entry: &TxnWalEntry) -> Result<Vec<u8>> {
         if self.encryption.is_enabled() {
-            let ord = self.records_in_file.fetch_add(1, Ordering::SeqCst);
+            let ord = self.records_in_file.load(Ordering::SeqCst);
             self.encrypt_frame(&entry.body_bytes(), ord)
         } else {
             Ok(entry.to_bytes())
+        }
+    }
+
+    /// Advance the file-relative AAD ordinal by one record. Call ONLY after the
+    /// record's bytes have been handed to the writer (post-`write_all`).
+    #[inline]
+    fn commit_record_ordinal(&self) {
+        if self.encryption.is_enabled() {
+            self.records_in_file.fetch_add(1, Ordering::SeqCst);
         }
     }
 
@@ -888,10 +906,11 @@ impl TxnWal {
     #[inline]
     pub fn append_no_flush(&self, entry: &TxnWalEntry) -> Result<u64> {
         let mut writer = self.writer.lock();
-        let bytes = self.frame_under_lock(entry)?;
+        let bytes = self.frame_for_write(entry)?;
 
         writer.write_all(&bytes)?;
         // No flush - let BufWriter buffer the writes
+        self.commit_record_ordinal();
 
         let seq = self.sequence.fetch_add(1, Ordering::SeqCst);
         self.bytes_since_sync
@@ -926,9 +945,12 @@ impl TxnWal {
         // path below keeps its zero-alloc streaming fast path untouched.
         if self.encryption.is_enabled() {
             let body = encode_record_body(WalRecordType::Data, txn_id, timestamp_us, key, value);
-            let ord = self.records_in_file.fetch_add(1, Ordering::SeqCst);
+            let ord = self.records_in_file.load(Ordering::SeqCst);
             let frame = self.encrypt_frame(&body, ord)?;
             writer.write_all(&frame)?;
+            // Advance the AAD ordinal only after the bytes are committed to the
+            // writer, so a failed write never desyncs writer/reader ordinals.
+            self.records_in_file.fetch_add(1, Ordering::SeqCst);
             let seq = self.sequence.fetch_add(1, Ordering::SeqCst);
             self.bytes_since_sync
                 .fetch_add(frame.len() as u64, Ordering::Relaxed);
@@ -1054,9 +1076,13 @@ impl TxnWal {
                 }
                 let body = &buf[pos..pos + content_len];
                 pos += content_len;
-                let ord = self.records_in_file.fetch_add(1, Ordering::SeqCst);
+                let ord = self.records_in_file.load(Ordering::SeqCst);
                 let frame = self.encrypt_frame(body, ord)?;
                 writer.write_all(&frame)?;
+                // Advance per record only after its bytes are committed, so a
+                // mid-batch write failure leaves records_in_file == records
+                // actually written (no ordinal desync for the survivors).
+                self.records_in_file.fetch_add(1, Ordering::SeqCst);
                 total_written += frame.len() as u64;
             }
             let seq = self


### PR DESCRIPTION
Follow-up to the at-rest-encryption phase-1 commit, applying the 6 confirmed, worth-fixing findings from a multi-agent adversarial review (10 confirmed / 4 refuted — 2 of the refuted had fabricated evidence the verifiers caught):

- keyring: zeroize the transient unwrapped-DEK copies (heap Vec + stack array) after moving into the zeroize-on-drop EncryptionKey — the DEK decrypts all data and must not linger in freed memory / swap / core dumps. [crypto, med]
- keyring: verify the descriptor MAC with hmac's vetted constant-time verify_slice instead of a hand-rolled compare (removes constant_time_eq). [crypto, low]
- keyring: propagate the directory-fsync result on Unix so a failed dir fsync can't silently break the atomic-rename durability the keyring relies on. [keyring, low]
- txn_wal: advance the per-record AAD ordinal (records_in_file) ONLY after a successful write_all (load-then-commit), across append/append_no_flush/ write_no_flush_refs/flush_buffer — a failed/partial write no longer desyncs writer vs reader ordinals (which would strand all subsequent records). [med]
- txn_wal: make new_with_encryption pub(crate) so the keyring-mediated DurableStorage::open_with_encryption is the only public door to an encrypted WAL (the MAC/canary fail-closed + AAD invariants are enforced one layer up). [integration, low]
- lib: re-export StorageEncryption / EncryptionKey / EncryptionEngine / EncryptionError / generate_key / EncryptionState at the crate root. [low]

Deferred (tracked for the config-plumbing/PITR phases): concurrent-mode encryption support, product-API (Database/FFI/SDK) KEK plumbing + SOCHDB_ENCRYPTION_KEY env read, and an operator salvage path / strict-tail docs for full-length unauthenticatable trailing frames.

737 storage tests green; full workspace builds; fmt clean.