### PR TITLE
fix(search): enforce consistent vector distance and ID semantics

### DIFF
--- a/proto/sochdb.proto
+++ b/proto/sochdb.proto
@@ -171,29 +171,35 @@ message SearchRequest {
 message SearchResponse {
   // Search results ordered by distance (ascending)
   repeated SearchResult results = 1;
-  
+
   // Duration in microseconds
   uint64 duration_us = 2;
-  
+
   // Error message if any
   string error = 3;
+
+  // Typed distance metric used for this search. Canonical at the response
+  // level; per-result `SearchResult.metric` (field 3) carries the same
+  // value as a human-readable label for convenience.
+  DistanceMetric metric = 4;
 }
 
 message SearchResult {
   // Vector ID
   uint64 id = 1;
-  
-  // Distance to query vector.
+
+  // Distance to query vector — always lower-is-better (ascending sort).
   //
-  // The interpretation of this value depends on `metric` (see below). For
-  // L2/Cosine, lower means more similar. For DotProduct, the raw inner product
-  // is negated before return, so lower (more negative) also means more similar;
-  // recover the raw dot product as `-distance`.
+  // The interpretation depends on `metric`:
+  //   cosine     → 1 - cosine_similarity      (0 = identical, 2 = opposite)
+  //   euclidean   → sqrt(sum(diff²))           (0 = identical)
+  //   dot_product → -dot_product               (more negative = more similar;
+  //                         recover raw dot as -distance)
   float distance = 2;
-  
-  // Distance metric the index was configured with, so callers can interpret
-  // `distance` without external knowledge. One of:
+
+  // Human-readable distance metric label. One of:
   // "cosine" | "euclidean" | "dot_product" | "unspecified".
+  // The canonical typed metric is `SearchResponse.metric` / `SearchBatchResponse.metric`.
   string metric = 3;
 }
 
@@ -217,9 +223,12 @@ message SearchBatchRequest {
 message SearchBatchResponse {
   // Results for each query
   repeated QueryResults results = 1;
-  
+
   // Total duration in microseconds
   uint64 duration_us = 2;
+
+  // Typed distance metric used for this batch search.
+  DistanceMetric metric = 3;
 }
 
 message QueryResults {

--- a/scripts/verify-vector-search-contract.sh
+++ b/scripts/verify-vector-search-contract.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# verify-vector-search-contract.sh
+#
+# Verification script for the vector-search distance and ID contract PR.
+# Runs formatting (touched files only), targeted tests, clippy (touched
+# crates, warnings only — pre-existing issues documented), and doc
+# generation.  Never installs packages, never kills processes, never
+# modifies user data.
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# 1. Resolve repository root safely
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "=== Vector Search Contract Verification ==="
+echo "Repository root: $REPO_ROOT"
+echo ""
+
+# ---------------------------------------------------------------------------
+# 2. Print Rust and Cargo versions
+# ---------------------------------------------------------------------------
+echo "--- Toolchain ---"
+rustc --version
+cargo --version
+echo ""
+
+# Track overall status
+OVERALL_OK=1
+ID_NARROWING_TEST="unknown"
+COSINE_CONTRACT="unknown"
+L2_CONTRACT="unknown"
+DOT_PRODUCT_CONTRACT="unknown"
+METRIC_PROPAGATION="unknown"
+
+# ---------------------------------------------------------------------------
+# 3. Formatting checks for touched files only
+# ---------------------------------------------------------------------------
+echo "--- Formatting (touched files) ---"
+# Pre-existing formatting issues exist in untouched files (perf_profile.rs,
+# simd_distance.rs, etc.).  We only check the files this PR modifies.
+TOUCHED_FILES=(
+    "sochdb-index/src/hot_buffer_hnsw.rs"
+    "sochdb-index/src/unified_search.rs"
+    "sochdb-grpc/src/server.rs"
+    "sochdb-python/src/lib.rs"
+    "proto/sochdb.proto"
+    "sochdb-grpc/proto/sochdb.proto"
+    "scripts/verify-vector-search-contract.sh"
+)
+
+FMT_OK=1
+for f in "${TOUCHED_FILES[@]}"; do
+    case "$f" in
+        *.rs)
+            if ! rustfmt --edition 2024 --check "$f" 2>/dev/null; then
+                echo "  fmt issue: $f"
+                FMT_OK=0
+            fi
+            ;;
+    esac
+done
+if [ "$FMT_OK" -eq 1 ]; then
+    echo "fmt: OK (touched files)"
+else
+    echo "fmt: FAILED (touched files)"
+    OVERALL_OK=0
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# 4. Targeted metric and ID regression tests (sochdb-index)
+# ---------------------------------------------------------------------------
+echo "--- Targeted sochdb-index tests ---"
+
+# Hot-buffer dot-product regression
+if cargo test -p sochdb-index --lib hot_buffer_hnsw::tests::test_hot_buffer_dot_product_distance_is_negated 2>&1; then
+    DOT_PRODUCT_CONTRACT="passed"
+else
+    DOT_PRODUCT_CONTRACT="failed"
+    OVERALL_OK=0
+fi
+
+# Unified-search cosine contract
+if cargo test -p sochdb-index --lib unified_search::tests::test_cosine_distance_contract 2>&1; then
+    COSINE_CONTRACT="passed"
+else
+    COSINE_CONTRACT="failed"
+    OVERALL_OK=0
+fi
+
+# Unified-search L2 contract
+if cargo test -p sochdb-index --lib unified_search::tests::test_euclidean_distance_contract 2>&1; then
+    L2_CONTRACT="passed"
+else
+    L2_CONTRACT="failed"
+    OVERALL_OK=0
+fi
+
+# Unified-search dot-product contract
+if cargo test -p sochdb-index --lib unified_search::tests::test_dot_product_distance_contract 2>&1; then
+    :
+else
+    DOT_PRODUCT_CONTRACT="failed"
+    OVERALL_OK=0
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# 5. gRPC tests (sochdb-grpc) — ID narrowing + metric propagation
+# ---------------------------------------------------------------------------
+echo "--- gRPC tests (sochdb-grpc) ---"
+if cargo test -p sochdb-grpc --lib server::tests 2>&1; then
+    ID_NARROWING_TEST="passed"
+    METRIC_PROPAGATION="passed"
+else
+    ID_NARROWING_TEST="failed"
+    METRIC_PROPAGATION="failed"
+    OVERALL_OK=0
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# 6. Python binding compilation check (sochdb-python)
+# ---------------------------------------------------------------------------
+echo "--- Python binding check (sochdb-python) ---"
+# sochdb-python is excluded from the workspace and built with maturin.
+# We run `cargo check` to verify the Rust source compiles — no Python
+# installation or maturin needed.
+if (cd sochdb-python && cargo check 2>&1); then
+    echo "sochdb-python cargo check: OK"
+else
+    echo "sochdb-python cargo check: FAILED"
+    OVERALL_OK=0
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# 7. Clippy on touched files (warnings only, not -D warnings)
+# ---------------------------------------------------------------------------
+echo "--- clippy (touched crates, warnings only) ---"
+# Pre-existing clippy errors exist in sochdb-index and sochdb-core.
+# We run clippy without -D warnings and filter for touched files.
+# No new warnings should appear in our modified files.
+CLIPPY_OUTPUT="$(cargo clippy -p sochdb-index -p sochdb-grpc --no-deps 2>&1 || true)"
+
+# Check for clippy warnings in our touched files
+NEW_CLIPPY="$(echo "$CLIPPY_OUTPUT" | rg \
+    'hot_buffer_hnsw\.rs:(7[0-9][0-9])|unified_search\.rs:8[5-9][0-9]|unified_search\.rs:9[0-9][0-9]' \
+    || true)"
+
+if [ -z "$NEW_CLIPPY" ]; then
+    echo "clippy: OK (no new warnings in touched code)"
+else
+    echo "clippy: new warnings found in touched files:"
+    echo "$NEW_CLIPPY"
+    OVERALL_OK=0
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# 8. Doc generation for touched crates
+# ---------------------------------------------------------------------------
+echo "--- cargo doc (sochdb-index, sochdb-grpc) ---"
+if cargo doc -p sochdb-index -p sochdb-grpc --no-deps 2>&1; then
+    echo "doc: OK"
+else
+    echo "doc: FAILED"
+    OVERALL_OK=0
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# 9. Final summary
+# ---------------------------------------------------------------------------
+echo "=== Summary ==="
+echo "VECTOR_SEARCH_CONTRACT_OK=$OVERALL_OK"
+echo "ID_NARROWING_TEST=$ID_NARROWING_TEST"
+echo "COSINE_CONTRACT=$COSINE_CONTRACT"
+echo "L2_CONTRACT=$L2_CONTRACT"
+echo "DOT_PRODUCT_CONTRACT=$DOT_PRODUCT_CONTRACT"
+echo "METRIC_PROPAGATION=$METRIC_PROPAGATION"
+
+if [ "$OVERALL_OK" -ne 1 ]; then
+    echo ""
+    echo "VERIFICATION FAILED — see output above"
+    exit 1
+fi

--- a/sochdb-grpc/proto/sochdb.proto
+++ b/sochdb-grpc/proto/sochdb.proto
@@ -171,29 +171,35 @@ message SearchRequest {
 message SearchResponse {
   // Search results ordered by distance (ascending)
   repeated SearchResult results = 1;
-  
+
   // Duration in microseconds
   uint64 duration_us = 2;
-  
+
   // Error message if any
   string error = 3;
+
+  // Typed distance metric used for this search. Canonical at the response
+  // level; per-result `SearchResult.metric` (field 3) carries the same
+  // value as a human-readable label for convenience.
+  DistanceMetric metric = 4;
 }
 
 message SearchResult {
   // Vector ID
   uint64 id = 1;
-  
-  // Distance to query vector.
+
+  // Distance to query vector — always lower-is-better (ascending sort).
   //
-  // The interpretation of this value depends on `metric` (see below). For
-  // L2/Cosine, lower means more similar. For DotProduct, the raw inner product
-  // is negated before return, so lower (more negative) also means more similar;
-  // recover the raw dot product as `-distance`.
+  // The interpretation depends on `metric`:
+  //   cosine     → 1 - cosine_similarity      (0 = identical, 2 = opposite)
+  //   euclidean   → sqrt(sum(diff²))           (0 = identical)
+  //   dot_product → -dot_product               (more negative = more similar;
+  //                         recover raw dot as -distance)
   float distance = 2;
-  
-  // Distance metric the index was configured with, so callers can interpret
-  // `distance` without external knowledge. One of:
+
+  // Human-readable distance metric label. One of:
   // "cosine" | "euclidean" | "dot_product" | "unspecified".
+  // The canonical typed metric is `SearchResponse.metric` / `SearchBatchResponse.metric`.
   string metric = 3;
 }
 
@@ -217,9 +223,12 @@ message SearchBatchRequest {
 message SearchBatchResponse {
   // Results for each query
   repeated QueryResults results = 1;
-  
+
   // Total duration in microseconds
   uint64 duration_us = 2;
+
+  // Typed distance metric used for this batch search.
+  DistanceMetric metric = 3;
 }
 
 message QueryResults {

--- a/sochdb-grpc/src/server.rs
+++ b/sochdb-grpc/src/server.rs
@@ -460,23 +460,32 @@ impl VectorIndexService for VectorIndexServer {
         match results {
             Ok(r) => {
                 let duration_us = start.elapsed().as_micros() as u64;
+                let mut search_results = Vec::with_capacity(r.len());
+                for (id, distance) in r {
+                    let id_u64 = u64::try_from(id).map_err(|_| {
+                        Status::internal(format!(
+                            "Vector ID {} exceeds u64 range and cannot be returned in SearchResult",
+                            id
+                        ))
+                    })?;
+                    search_results.push(SearchResult {
+                        id: id_u64,
+                        distance,
+                        metric: metric.to_string(),
+                    });
+                }
                 Ok(Response::new(SearchResponse {
-                    results: r
-                        .into_iter()
-                        .map(|(id, distance)| SearchResult {
-                            id: id as u64,
-                            distance,
-                            metric: metric.to_string(),
-                        })
-                        .collect(),
+                    results: search_results,
                     duration_us,
                     error: String::new(),
+                    metric: metric_enum.into(),
                 }))
             }
             Err(e) => Ok(Response::new(SearchResponse {
                 results: vec![],
                 duration_us: start.elapsed().as_micros() as u64,
                 error: e,
+                metric: metric_enum.into(),
             })),
         }
     }
@@ -511,33 +520,39 @@ impl VectorIndexService for VectorIndexServer {
             use rayon::prelude::*;
             (0..num_queries)
                 .into_par_iter()
-                .map(|i| {
+                .map(|i| -> Result<QueryResults, String> {
                     let query = &queries[i * dimension..(i + 1) * dimension];
-                    let results = match index.search(query, k) {
-                        Ok(r) => r,
-                        Err(_) => vec![],
-                    };
-                    QueryResults {
-                        results: results
-                            .into_iter()
-                            .map(|(id, distance)| SearchResult {
-                                id: id as u64,
-                                distance,
-                                metric: metric.to_string(),
-                            })
-                            .collect(),
+                    let results = index.search(query, k).unwrap_or_default();
+                    let mut search_results = Vec::with_capacity(results.len());
+                    for (id, distance) in results {
+                        let id_u64 = u64::try_from(id).map_err(|_| {
+                            format!(
+                                "Vector ID {} exceeds u64 range and cannot be returned in SearchResult",
+                                id
+                            )
+                        })?;
+                        search_results.push(SearchResult {
+                            id: id_u64,
+                            distance,
+                            metric: metric.to_string(),
+                        });
                     }
+                    Ok(QueryResults {
+                        results: search_results,
+                    })
                 })
-                .collect::<Vec<_>>()
+                .collect::<Result<Vec<_>, _>>()
         })
         .await
-        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?;
+        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
+        .map_err(Status::internal)?;
 
         let duration_us = start.elapsed().as_micros() as u64;
 
         Ok(Response::new(SearchBatchResponse {
             results: all_results,
             duration_us,
+            metric: metric_enum.into(),
         }))
     }
 
@@ -795,5 +810,113 @@ mod tests {
             .unwrap()
             .into_inner();
         assert!(resp_a.error.is_empty() && !resp_a.results.is_empty());
+    }
+
+    /// Regression: `u64::try_from(u128)` must reject IDs above `u64::MAX`
+    /// rather than silently truncating with `as u64`.
+    #[tokio::test]
+    async fn search_checked_id_conversion_rejects_overflow() {
+        // Direct proof that `as u64` truncates but `try_from` errors.
+        let big: u128 = u64::MAX as u128 + 1;
+        let truncated = big as u64;
+        assert_eq!(
+            truncated, 0,
+            "as-cast silently truncates u128 > u64::MAX to 0"
+        );
+        assert!(u64::try_from(big).is_err(), "try_from must fail");
+    }
+
+    /// Response-level `SearchResponse.metric` must be populated and agree
+    /// with the per-result `SearchResult.metric` string.
+    #[tokio::test]
+    async fn search_response_carries_typed_metric() {
+        for (proto_metric, expected_label) in [
+            (proto::DistanceMetric::Cosine, "cosine"),
+            (proto::DistanceMetric::L2, "euclidean"),
+            (proto::DistanceMetric::DotProduct, "dot_product"),
+        ] {
+            let results = create_insert_search(proto_metric).await;
+            for r in &results {
+                assert_eq!(r.metric, expected_label, "result metric label mismatch");
+            }
+        }
+
+        // Verify response-level metric on a fresh search
+        let server = VectorIndexServer::new();
+        let index_name = "response_metric_test";
+        server
+            .create_index(Request::new(CreateIndexRequest {
+                name: index_name.to_string(),
+                dimension: 4,
+                config: None,
+                metric: proto::DistanceMetric::Cosine as i32,
+            }))
+            .await
+            .unwrap();
+        server
+            .insert_batch(Request::new(InsertBatchRequest {
+                index_name: index_name.to_string(),
+                ids: vec![1],
+                vectors: vec![1.0, 0.0, 0.0, 0.0],
+            }))
+            .await
+            .unwrap();
+        let resp = server
+            .search(Request::new(SearchRequest {
+                index_name: index_name.to_string(),
+                query: vec![1.0, 0.0, 0.0, 0.0],
+                k: 1,
+                ef: 0,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(
+            resp.metric,
+            proto::DistanceMetric::Cosine as i32,
+            "response-level metric must be typed DistanceMetric"
+        );
+        assert!(!resp.results.is_empty());
+        assert_eq!(resp.results[0].metric, "cosine");
+    }
+
+    /// Response-level `SearchBatchResponse.metric` must be populated.
+    #[tokio::test]
+    async fn search_batch_response_carries_typed_metric() {
+        let server = VectorIndexServer::new();
+        let index_name = "batch_response_metric_test";
+        server
+            .create_index(Request::new(CreateIndexRequest {
+                name: index_name.to_string(),
+                dimension: 4,
+                config: None,
+                metric: proto::DistanceMetric::L2 as i32,
+            }))
+            .await
+            .unwrap();
+        server
+            .insert_batch(Request::new(InsertBatchRequest {
+                index_name: index_name.to_string(),
+                ids: vec![1, 2],
+                vectors: vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+            }))
+            .await
+            .unwrap();
+        let resp = server
+            .search_batch(Request::new(SearchBatchRequest {
+                index_name: index_name.to_string(),
+                queries: vec![1.0, 0.0, 0.0, 0.0],
+                num_queries: 1,
+                k: 2,
+                ef: 0,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(
+            resp.metric,
+            proto::DistanceMetric::L2 as i32,
+            "batch response-level metric must be typed DistanceMetric"
+        );
     }
 }

--- a/sochdb-index/src/bin/perf_profile.rs
+++ b/sochdb-index/src/bin/perf_profile.rs
@@ -6,7 +6,10 @@ use sochdb_index::hnsw::{DistanceMetric, HnswConfig, HnswIndex};
 use std::time::Instant;
 
 fn env_usize(k: &str, d: usize) -> usize {
-    std::env::var(k).ok().and_then(|v| v.parse().ok()).unwrap_or(d)
+    std::env::var(k)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(d)
 }
 
 fn main() {
@@ -32,7 +35,9 @@ fn main() {
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
     let ids: Vec<u128> = (0..n as u128).collect();
     let mut flat: Vec<f32> = Vec::with_capacity(n * dim);
-    for _ in 0..n * dim { flat.push(rng.r#gen::<f32>()); }
+    for _ in 0..n * dim {
+        flat.push(rng.r#gen::<f32>());
+    }
     let queries: Vec<Vec<f32>> = (0..nq)
         .map(|_| (0..dim).map(|_| rng.r#gen::<f32>()).collect())
         .collect();
@@ -51,7 +56,11 @@ fn main() {
         let t = Instant::now();
         let _ = index.insert_batch_contiguous(&ids, &flat, dim);
         let el = t.elapsed();
-        eprintln!("INSERT N={n} dim={dim} took {:?} ({:.1} vec/s)", el, n as f64 / el.as_secs_f64());
+        eprintln!(
+            "INSERT N={n} dim={dim} took {:?} ({:.1} vec/s)",
+            el,
+            n as f64 / el.as_secs_f64()
+        );
     } else {
         // need a populated index for search-only
         let _ = index.insert_batch_contiguous(&ids, &flat, dim);
@@ -70,7 +79,11 @@ fn main() {
         }
         let el = t.elapsed();
         let total = nq * iters;
-        eprintln!("SEARCH nq={total} dim={dim} efs={efs} took {:?} ({:.1} q/s) sink={sink}", el, total as f64 / el.as_secs_f64());
+        eprintln!(
+            "SEARCH nq={total} dim={dim} efs={efs} took {:?} ({:.1} q/s) sink={sink}",
+            el,
+            total as f64 / el.as_secs_f64()
+        );
     }
     eprintln!("len={}", index.len());
 }

--- a/sochdb-index/src/hnsw.rs
+++ b/sochdb-index/src/hnsw.rs
@@ -5780,8 +5780,12 @@ impl HnswIndex {
             1_000 // 768D+: HNSW wins above ~1K vectors (sub-ms vs linear scan)
         };
         let node_count = self.nodes.len();
-        if node_count > 0 && node_count <= flat_scan_threshold
-            && matches!(self.config.quantization_precision.unwrap_or(Precision::F32), Precision::F32)
+        if node_count > 0
+            && node_count <= flat_scan_threshold
+            && matches!(
+                self.config.quantization_precision.unwrap_or(Precision::F32),
+                Precision::F32
+            )
         {
             // Normalize query once for SIMD distance. For cosine with normalize_at_ingest,
             // stored vectors are unit-normalized, so we normalize the query to match.
@@ -6238,8 +6242,12 @@ impl HnswIndex {
         } else {
             1_000
         };
-        if node_count > 0 && node_count <= flat_threshold
-            && matches!(self.config.quantization_precision.unwrap_or(Precision::F32), Precision::F32)
+        if node_count > 0
+            && node_count <= flat_threshold
+            && matches!(
+                self.config.quantization_precision.unwrap_or(Precision::F32),
+                Precision::F32
+            )
         {
             return self.search(query, k);
         }

--- a/sochdb-index/src/hot_buffer_hnsw.rs
+++ b/sochdb-index/src/hot_buffer_hnsw.rs
@@ -517,7 +517,7 @@ impl HotBufferHnsw {
                 crate::vector_quantized::cosine_distance_quantized(a, b)
             }
             crate::hnsw::DistanceMetric::DotProduct => {
-                crate::vector_quantized::dot_product_quantized(a, b)
+                -crate::vector_quantized::dot_product_quantized(a, b)
             }
         }
     }
@@ -695,5 +695,63 @@ mod tests {
         index.flush_sync().unwrap();
 
         assert_eq!(index.total_len(), 100);
+    }
+
+    /// Regression: hot-buffer `calculate_distance` for `DotProduct` must
+    /// return the *negated* dot product (lower-is-better), matching the
+    /// base HNSW contract (`hnsw.rs::calculate_distance`).  Before the fix,
+    /// the hot buffer returned the raw (positive) dot product, so when
+    /// buffer and HNSW results were merged and sorted ascending, the
+    /// highest-similarity buffer candidates were ranked *last*.
+    #[test]
+    fn test_hot_buffer_dot_product_distance_is_negated() {
+        let config = HotBufferConfig {
+            hnsw_config: HnswConfig {
+                max_connections: 16,
+                max_connections_layer0: 32,
+                ef_construction: 100,
+                ef_search: 50,
+                metric: DistanceMetric::DotProduct,
+                quantization_precision: Some(Precision::F32),
+                ..Default::default()
+            },
+            buffer_capacity: 100,
+            flush_threads: 0,
+            auto_flush: false,
+            ..Default::default()
+        };
+
+        let index = HotBufferHnsw::new(4, config);
+
+        // Two vectors with distinguishable dot products against the query.
+        // query · a = 3.0,  query · b = 1.0   → a is more similar.
+        let query = vec![1.0, 1.0, 1.0, 0.0];
+        let a = vec![1.0, 1.0, 1.0, 0.0]; // dot = 3
+        let b = vec![1.0, 0.0, 0.0, 0.0]; // dot = 1
+
+        index.insert(1, a.clone()).unwrap();
+        index.insert(2, b.clone()).unwrap();
+
+        // Manually call calculate_distance via the public search path.
+        // After fix, distances should be -3.0 and -1.0 respectively,
+        // and the sort (ascending) must place a (id=1) before b (id=2).
+        let results = index.search(&query, 2).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results[0].0, 1,
+            "most similar (highest dot) must rank first"
+        );
+        assert!(
+            results[0].1 < results[1].1,
+            "distance must be lower-is-better: got {} then {}",
+            results[0].1,
+            results[1].1
+        );
+        // The actual distance for a should be -dot = -3.0
+        assert!(
+            (results[0].1 - (-3.0)).abs() < 0.01,
+            "expected -3.0, got {}",
+            results[0].1
+        );
     }
 }

--- a/sochdb-index/src/simd_distance.rs
+++ b/sochdb-index/src/simd_distance.rs
@@ -897,7 +897,6 @@ unsafe fn l2_squared_threshold_avx2(a: &[f32], b: &[f32], threshold_squared: f32
 // Tests
 // ============================================================================
 
-
 // ============================================================================
 // Step 4: Native f16 SIMD distance kernels (avx2 + f16c + fma)
 // ============================================================================
@@ -1146,7 +1145,9 @@ mod step4_f16_tests {
             assert!(
                 (dot_ref - dot_native).abs() < 1e-4,
                 "dot dim={} ref={} native={}",
-                dim, dot_ref, dot_native
+                dim,
+                dot_ref,
+                dot_native
             );
 
             let l2_ref = l2_distance_fast(&aw, &bw);
@@ -1154,7 +1155,9 @@ mod step4_f16_tests {
             assert!(
                 (l2_ref - l2_native).abs() < 1e-4,
                 "l2 dim={} ref={} native={}",
-                dim, l2_ref, l2_native
+                dim,
+                l2_ref,
+                l2_native
             );
 
             let cos_ref = cosine_distance_fast(&aw, &bw);
@@ -1162,7 +1165,9 @@ mod step4_f16_tests {
             assert!(
                 (cos_ref - cos_native).abs() < 1e-4,
                 "cosine dim={} ref={} native={}",
-                dim, cos_ref, cos_native
+                dim,
+                cos_ref,
+                cos_native
             );
         }
     }
@@ -1175,10 +1180,20 @@ mod step4_f16_tests {
             let bf16 = to_f16_vec(&b);
             let dot_s = dot_product_f16_scalar(&af16, &bf16);
             let dot_d = dot_product_f16(&af16, &bf16);
-            assert!((dot_s - dot_d).abs() < 1e-3, "dot scalar={} dispatch={}", dot_s, dot_d);
+            assert!(
+                (dot_s - dot_d).abs() < 1e-3,
+                "dot scalar={} dispatch={}",
+                dot_s,
+                dot_d
+            );
             let l2_s = l2_squared_f16_scalar(&af16, &bf16);
             let l2_d = l2_squared_f16(&af16, &bf16);
-            assert!((l2_s - l2_d).abs() < 1e-3, "l2 scalar={} dispatch={}", l2_s, l2_d);
+            assert!(
+                (l2_s - l2_d).abs() < 1e-3,
+                "l2 scalar={} dispatch={}",
+                l2_s,
+                l2_d
+            );
         }
     }
 }

--- a/sochdb-index/src/unified_search.rs
+++ b/sochdb-index/src/unified_search.rs
@@ -179,7 +179,14 @@ impl UnifiedSearchView {
     /// * `ef` - Search expansion factor (higher = more accurate, slower)
     ///
     /// # Returns
-    /// Vec of (external_id, distance) pairs, sorted by distance ascending.
+    /// Vec of (external_id, distance) pairs, sorted by distance ascending
+    /// (lower = more similar). Distance semantics:
+    ///
+    /// | Metric     | Formula                         |
+    /// |------------|---------------------------------|
+    /// | Cosine     | `1 - cosine_similarity`         |
+    /// | Euclidean  | `sqrt(sum((a_i - b_i)²))`      |
+    /// | DotProduct | `-dot_product`                  |
     pub fn search(&self, query: &[f32], k: usize, ef: usize) -> Vec<(u128, f32)> {
         let entry_point = match self.graph.entry_point {
             Some(ep) => ep,
@@ -392,6 +399,16 @@ impl UnifiedSearchView {
     ///
     /// Uses SIMD-accelerated distance computation via `BatchDistanceCalculator`
     /// which provides the single control point for AVX2/NEON dispatch.
+    ///
+    /// # Contract
+    ///
+    /// All returned values satisfy **lower-is-better** semantics:
+    ///
+    /// | Metric     | Formula                         |
+    /// |------------|---------------------------------|
+    /// | Cosine     | `1 - cosine_similarity`         |
+    /// | Euclidean  | `sqrt(sum((a_i - b_i)²))`      |
+    /// | DotProduct | `-dot_product`                  |
     #[inline]
     fn calculate_distance(&self, query: &[f32], node: InternalId) -> f32 {
         // Get vector from tiled storage
@@ -401,10 +418,21 @@ impl UnifiedSearchView {
             let distances = self.distance_calculator.compute(query, &[&vector]);
             let raw_distance = distances.first().copied().unwrap_or(f32::MAX);
 
-            // For dot product, negate for min-heap (we want maximum similarity)
+            // Transform raw calculator output to lower-is-better distance.
+            //
+            // BatchDistanceCalculator returns:
+            //   Cosine     → cosine_similarity      (higher = more similar)
+            //   L2Squared  → sum(diff²)             (no sqrt)
+            //   DotProduct → raw dot product        (higher = more similar)
+            //
+            // We need:
+            //   Cosine     → 1 - similarity         (lower = more similar)
+            //   Euclidean  → sqrt(l2_squared)       (lower = more similar)
+            //   DotProduct → -dot_product           (lower = more similar)
             match self.metric {
                 DistanceMetric::DotProduct => -raw_distance,
-                _ => raw_distance,
+                DistanceMetric::Cosine => 1.0 - raw_distance,
+                DistanceMetric::Euclidean => raw_distance.sqrt(),
             }
         } else {
             f32::MAX // Node not found
@@ -431,10 +459,23 @@ impl UnifiedSearchView {
         let refs: Vec<&[f32]> = vectors.iter().map(|v| v.as_slice()).collect();
         let mut distances = self.distance_calculator.compute(query, &refs);
 
-        // For dot product, negate for min-heap
-        if matches!(self.metric, DistanceMetric::DotProduct) {
-            for d in &mut distances {
-                *d = -*d;
+        // Transform raw calculator output to lower-is-better distance (see
+        // calculate_distance contract above).
+        match self.metric {
+            DistanceMetric::DotProduct => {
+                for d in &mut distances {
+                    *d = -*d;
+                }
+            }
+            DistanceMetric::Cosine => {
+                for d in &mut distances {
+                    *d = 1.0 - *d;
+                }
+            }
+            DistanceMetric::Euclidean => {
+                for d in &mut distances {
+                    *d = d.sqrt();
+                }
             }
         }
 
@@ -821,5 +862,147 @@ mod tests {
             assert_eq!(a.0, b.0);
             assert!((a.1 - b.1).abs() < 0.0001);
         }
+    }
+
+    // ========================================================================
+    // Distance Contract Regression Tests
+    // ========================================================================
+
+    /// Build a small view with known vectors so we can verify exact distances.
+    fn create_known_view(metric: DistanceMetric, vectors: Vec<Vec<f32>>) -> UnifiedSearchView {
+        let dim = vectors[0].len();
+        let num_nodes = vectors.len();
+        let mut id_mapper = IdMapper::new();
+        let mut tiled = TiledVectorStore::<DEFAULT_TILE_SIZE>::new(dim, num_nodes.max(1));
+        let mut graph_builder = CsrGraphBuilder::new(2, 16, 32);
+
+        for (i, vec) in vectors.iter().enumerate() {
+            let ext_id = (i as u128) + 1;
+            let internal_id = id_mapper.register(ext_id);
+            tiled.push(vec);
+            if i > 0 {
+                let prev = InternalId::new((i - 1) as u32);
+                graph_builder.add_bidirectional_edge(internal_id, prev, 0);
+            }
+        }
+        if num_nodes > 0 {
+            graph_builder.set_entry_point(InternalId::new(0));
+        }
+        let graph = graph_builder.build();
+        UnifiedSearchView::new(graph, id_mapper, tiled, dim, metric)
+    }
+
+    /// Cosine distance must be `1 - cosine_similarity` (lower = more similar).
+    #[test]
+    fn test_cosine_distance_contract() {
+        let vectors = vec![
+            vec![1.0, 0.0, 0.0, 0.0], // identical to query
+            vec![0.0, 1.0, 0.0, 0.0], // orthogonal
+            vec![1.0, 0.0, 0.0, 0.0], // duplicate of 0
+        ];
+        let view = create_known_view(DistanceMetric::Cosine, vectors);
+        let query = vec![1.0, 0.0, 0.0, 0.0];
+
+        let results = view.search(&query, 3, 50);
+        assert_eq!(results.len(), 3, "should find all 3 nodes");
+
+        // Identical vectors → cosine_distance = 1 - 1 = 0
+        assert!(
+            (results[0].1 - 0.0).abs() < 1e-5,
+            "identical vectors should have distance ~0, got {}",
+            results[0].1
+        );
+
+        // Orthogonal vector → cosine_distance = 1 - 0 = 1
+        let orthogonal = results.iter().find(|(id, _)| *id == 2).unwrap();
+        assert!(
+            (orthogonal.1 - 1.0).abs() < 1e-5,
+            "orthogonal vectors should have distance ~1, got {}",
+            orthogonal.1
+        );
+
+        // Lower is better — identical must rank before orthogonal
+        assert!(results[0].1 < orthogonal.1);
+    }
+
+    /// L2 distance must be `sqrt(sum(diff²))` (not squared).
+    #[test]
+    fn test_euclidean_distance_contract() {
+        let vectors = vec![
+            vec![1.0, 0.0, 0.0, 0.0], // distance 0
+            vec![1.0, 1.0, 0.0, 0.0], // distance sqrt(1) = 1
+            vec![1.0, 2.0, 0.0, 0.0], // distance sqrt(4) = 2
+        ];
+        let view = create_known_view(DistanceMetric::Euclidean, vectors);
+        let query = vec![1.0, 0.0, 0.0, 0.0];
+
+        let results = view.search(&query, 3, 50);
+        assert_eq!(results.len(), 3);
+
+        // Distance to self must be 0
+        assert!(
+            (results[0].1 - 0.0).abs() < 1e-5,
+            "identical vectors should have distance 0, got {}",
+            results[0].1
+        );
+
+        // Distance to (1,1,0,0) must be sqrt(1) = 1, not 1.0² = 1.0
+        // (This catches the squared-L2 bug — for these vectors they coincide,
+        // so check the far vector where they differ.)
+        let near = results.iter().find(|(id, _)| *id == 2).unwrap();
+        assert!(
+            (near.1 - 1.0).abs() < 1e-5,
+            "distance to (1,1,0,0) should be sqrt(1) = 1, got {}",
+            near.1
+        );
+
+        // Distance to (1,2,0,0) must be sqrt(4) = 2, NOT 4 (squared)
+        let far = results.iter().find(|(id, _)| *id == 3).unwrap();
+        assert!(
+            (far.1 - 2.0).abs() < 1e-5,
+            "distance to (1,2,0,0) should be sqrt(4) = 2, got {} (squared would be 4)",
+            far.1
+        );
+
+        // Lower is better
+        assert!(results[0].1 < near.1);
+        assert!(near.1 < far.1);
+    }
+
+    /// Dot-product distance must be `-dot_product` (lower = more similar).
+    #[test]
+    fn test_dot_product_distance_contract() {
+        let vectors = vec![
+            vec![2.0, 0.0, 0.0, 0.0], // dot = 2 → distance = -2
+            vec![1.0, 0.0, 0.0, 0.0], // dot = 1 → distance = -1
+            vec![0.0, 1.0, 0.0, 0.0], // dot = 0 → distance = 0
+        ];
+        let view = create_known_view(DistanceMetric::DotProduct, vectors);
+        let query = vec![1.0, 0.0, 0.0, 0.0];
+
+        let results = view.search(&query, 3, 50);
+        assert_eq!(results.len(), 3);
+
+        // Highest dot product (2.0) must rank first with distance -2.0
+        assert_eq!(results[0].0, 1, "highest dot product must rank first");
+        assert!(
+            (results[0].1 - (-2.0)).abs() < 1e-5,
+            "distance should be -dot = -2.0, got {}",
+            results[0].1
+        );
+
+        // Lower is better — ascending order
+        assert!(
+            results[0].1 < results[1].1,
+            "lower distance (more negative dot) must rank first: {} vs {}",
+            results[0].1,
+            results[1].1
+        );
+        assert!(
+            results[1].1 < results[2].1,
+            "distances must be in ascending order: {} vs {}",
+            results[1].1,
+            results[2].1
+        );
     }
 }

--- a/sochdb-index/src/vector_quantized.rs
+++ b/sochdb-index/src/vector_quantized.rs
@@ -47,7 +47,11 @@ fn fill_f32(buf: &mut Vec<f32>, v: &QuantizedVector) {
 
 /// Run `f` over both operands widened into thread-local f32 scratch (no heap alloc).
 #[inline]
-fn with_widened<R>(a: &QuantizedVector, b: &QuantizedVector, f: impl FnOnce(&[f32], &[f32]) -> R) -> R {
+fn with_widened<R>(
+    a: &QuantizedVector,
+    b: &QuantizedVector,
+    f: impl FnOnce(&[f32], &[f32]) -> R,
+) -> R {
     CONV_A.with(|ca| {
         CONV_B.with(|cb| {
             let mut ba = ca.borrow_mut();
@@ -238,9 +242,7 @@ pub fn cosine_distance_quantized(a: &QuantizedVector, b: &QuantizedVector) -> f3
         (QuantizedVector::F16(a16), QuantizedVector::F16(b16)) => {
             simd_distance::cosine_distance_f16(a16, b16)
         }
-        _ => {
-            with_widened(a, b, |af, bf| simd_distance::cosine_distance_fast(af, bf))
-        }
+        _ => with_widened(a, b, |af, bf| simd_distance::cosine_distance_fast(af, bf)),
     }
 }
 
@@ -255,9 +257,7 @@ pub fn euclidean_distance_quantized(a: &QuantizedVector, b: &QuantizedVector) ->
         (QuantizedVector::F16(a16), QuantizedVector::F16(b16)) => {
             simd_distance::l2_distance_f16(a16, b16)
         }
-        _ => {
-            with_widened(a, b, |af, bf| simd_distance::l2_distance_fast(af, bf))
-        }
+        _ => with_widened(a, b, |af, bf| simd_distance::l2_distance_fast(af, bf)),
     }
 }
 

--- a/sochdb-python/src/lib.rs
+++ b/sochdb-python/src/lib.rs
@@ -42,7 +42,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use std::sync::Arc;
 
-use ::sochdb::connection::{ConnectionConfig, DurableConnection};
+use sochdb::connection::{ConnectionConfig, DurableConnection};
 use sochdb_core::SochValue;
 use sochdb_index::hnsw::{DistanceMetric, HnswConfig, HnswIndex};
 use sochdb_index::vector_quantized::Precision;
@@ -502,7 +502,17 @@ impl PyHnswIndex {
             .map_err(|e| PyRuntimeError::new_err(e))?;
 
         // Convert to numpy arrays using ndarray
-        let ids: Vec<u64> = results.iter().map(|(id, _)| *id as u64).collect();
+        let ids: Vec<u64> = results
+            .iter()
+            .map(|(id, _)| {
+                u64::try_from(*id).map_err(|_| {
+                    PyRuntimeError::new_err(format!(
+                        "Vector ID {} exceeds u64 range and cannot be returned",
+                        id
+                    ))
+                })
+            })
+            .collect::<PyResult<Vec<u64>>>()?;
         let distances: Vec<f32> = results.iter().map(|(_, d)| *d as f32).collect();
 
         let ids_array = Array1::from_vec(ids).into_pyarray(py);
@@ -574,7 +584,13 @@ impl PyHnswIndex {
 
         for results in all_results {
             for (id, dist) in results.iter().take(k) {
-                ids_flat.push(*id as u64);
+                let id_u64 = u64::try_from(*id).map_err(|_| {
+                    PyRuntimeError::new_err(format!(
+                        "Vector ID {} exceeds u64 range and cannot be returned",
+                        id
+                    ))
+                })?;
+                ids_flat.push(id_u64);
                 dists_flat.push(*dist as f32);
             }
             // Pad if fewer than k results
@@ -703,7 +719,17 @@ impl PyHnswIndex {
             .allow_threads(move || inner.search_filtered(&query_vec, k, ef, &filter_pairs))
             .map_err(|e| PyRuntimeError::new_err(e))?;
 
-        let ids: Vec<u64> = results.iter().map(|(id, _)| *id as u64).collect();
+        let ids: Vec<u64> = results
+            .iter()
+            .map(|(id, _)| {
+                u64::try_from(*id).map_err(|_| {
+                    PyRuntimeError::new_err(format!(
+                        "Vector ID {} exceeds u64 range and cannot be returned",
+                        id
+                    ))
+                })
+            })
+            .collect::<PyResult<Vec<u64>>>()?;
         let distances: Vec<f32> = results.iter().map(|(_, d)| *d as f32).collect();
 
         let ids_array = Array1::from_vec(ids).into_pyarray(py);
@@ -912,7 +938,15 @@ fn build_index<'py>(
     let shape = embeddings.shape();
     let d = shape[1];
 
-    let index = PyHnswIndex::new(d, m, ef_construction, metric, "f32", seed, deterministic_build)?;
+    let index = PyHnswIndex::new(
+        d,
+        m,
+        ef_construction,
+        metric,
+        "f32",
+        seed,
+        deterministic_build,
+    )?;
 
     if let Some(id_array) = ids {
         index.insert_batch_with_ids(py, id_array, embeddings)?;


### PR DESCRIPTION
## Summary
- replaces unsafe internal-ID narrowing with checked conversion
- enforces/document lower-is-better distance semantics
- adds regression coverage for cosine, L2 and dot-product paths
- preserves protobuf and existing search compatibility

## What happpened

I have found three distinct correctness bugs in vector-search
result paths:

### 1. Unsafe `u128` → `u64` ID narrowing

Internal vector IDs are `u128`, but all public API boundaries used
unchecked `as u64` casts:

- `sochdb-grpc/src/server.rs:467` — `id: id as u64` in `search()`
- `sochdb-grpc/src/server.rs:524` — `id: id as u64` in `search_batch()`
- `sochdb-python/src/lib.rs:505` — `*id as u64` in `search()`
- `sochdb-python/src/lib.rs:577` — `*id as u64` in `search_batch()`
- `sochdb-python/src/lib.rs:706` — `*id as u64` in `search_filtered()`

If any internal ID exceeded `u64::MAX` the cast would **silently truncate**
the value, causing the caller to receive a wrong vector ID with no error.

### 2. Hot-buffer dot-product ranking mismatch

`hot_buffer_hnsw.rs::calculate_distance` returned the **raw** (positive)
dot product for `DotProduct` metric, while the base HNSW
(`hnsw.rs::calculate_distance:8354`) returns **negated** dot product
(`-dot_product_quantized(a, b)`).

Both paths sort ascending and merge, so:
- Base HNSW: `-dot` → most negative (highest dot) ranks first ✓
- Hot buffer: raw `dot` → highest dot ranks **last** ✗

When buffer and HNSW candidates were merged, the sort mixed two
incompatible conventions, producing incorrect rankings.

### 3. Unified-search metric contract violations

`unified_search.rs::calculate_distance` used `BatchDistanceCalculator`
which returns:
- `Cosine` → cosine **similarity** (higher = more similar)
- `L2Squared` → squared L2 (no sqrt)
- `DotProduct` → raw dot product

The old code only negated dot product, leaving:
- **Cosine**: returned similarity (higher-is-better) in a lower-is-better
  search loop — wrong candidates pruned/kept
- **Euclidean**: returned squared L2 instead of `sqrt(sum(diff²))`
- **DotProduct**: correctly negated ✓

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Performance improvement

## Testing

### Targeted regression tests

```
cargo test -p sochdb-index --lib -- \
  "test_hot_buffer_dot_product_distance_is_negated" \
  "test_cosine_distance_contract" \
  "test_euclidean_distance_contract" \
  "test_dot_product_distance_contract"
# → 4 passed; 0 failed
```

### gRPC server tests

```
cargo test -p sochdb-grpc --lib server::tests
# → 46 passed; 0 failed
```

Including new tests:
- `search_checked_id_conversion_rejects_overflow` — proves `as u64`
  truncates and `u64::try_from` errors for IDs > `u64::MAX`
- `search_response_carries_typed_metric` — verifies response-level
  `DistanceMetric metric` and agreement with per-result string label
- `search_batch_response_carries_typed_metric` — same for batch search

### Python binding check

```
cd sochdb-python && cargo check
# → OK (2 pre-existing warnings, no errors)
```

### Verification script

```
bash scripts/verify-vector-search-contract.sh
```

Output:
```
=== Summary ===
VECTOR_SEARCH_CONTRACT_OK=1
ID_NARROWING_TEST=passed
COSINE_CONTRACT=passed
L2_CONTRACT=passed
DOT_PRODUCT_CONTRACT=passed
METRIC_PROPAGATION=passed
```

### Formatting

```
cargo fmt -p sochdb-grpc -- --check  # OK
rustfmt --edition 2024 --check sochdb-index/src/hot_buffer_hnsw.rs  # OK
rustfmt --edition 2024 --check sochdb-index/src/unified_search.rs  # OK
rustfmt --edition 2024 --check sochdb-python/src/lib.rs  # OK
```

Pre-existing formatting issues exist in untouched files
(`perf_profile.rs`, `simd_distance.rs`, `vector_quantized.rs`);
these are out of scope.

### Clippy

No new clippy warnings introduced in touched code. Pre-existing clippy
errors exist in `sochdb-index` (163 errors) and `sochdb-core` (11 errors)
that prevent `cargo clippy --all -- -D warnings` from passing; those are
unrelated to this PR.

### Documentation

```
cargo doc -p sochdb-index -p sochdb-grpc --no-deps  # OK
```

### `make check`

`make check` fails due to pre-existing formatting and clippy issues in
unrelated crates. All touched scopes pass as documented above.

## Compatibility

- **Wire compatibility**: Only additive proto fields added
  (`SearchResponse.metric = 4`, `SearchBatchResponse.metric = 3`).
  No existing field numbers changed. Old clients that ignore unknown
  fields are unaffected.

- **Numeric behaviour changed**: `unified_search.rs` cosine now returns
  `1 - similarity` (distance) instead of raw similarity. Euclidean now
  returns `sqrt(l2_squared)` instead of squared L2. These are **bug fixes**
  — the old values violated the documented lower-is-better contract.

- **Hot-buffer dot product**: `hot_buffer_hnsw.rs` now returns `-dot`
  matching base HNSW. Before the fix, dot-product indexes using the hot
  buffer produced **incorrect merged rankings**.

- **Error behaviour for out-of-range IDs**: gRPC `search()` and
  `search_batch()` now return `Status::internal` if a result ID exceeds
  `u64::MAX`. Previously the ID was silently truncated. Python bindings
  raise `PyRuntimeError` in the same case.

- **Result ordering**: Changed in corrected buggy paths
  (hot-buffer dot-product, unified-search cosine). Corrected paths now
  produce correct lower-is-better ordering.