### PR TITLE
chore(release): bump version to 2.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.0.10] - 2026-06-20
+
+### Fixed
+
+- **High-dimensional recall collapse from HNSW graph fragmentation**
+  (`sochdb-index`) — under L2 distance concentration in high dimensions the
+  layer-0 mutual-kNN graph fragments into components unreachable from the entry
+  point (~1000/20000 orphans at dim 3072), making recall a build-seed coin flip.
+  `optimize()` now runs a bounded connectivity-repair pass that reconnects every
+  orphan, driving orphans to zero and stabilizing recall@10 to 0.994–1.0 across
+  seeds. The repair is **append-only**, so it can never evict another node's sole
+  inbound edge (no net-new orphans).
+- **Vector search distance & ID semantics** (`sochdb-index`, `sochdb-grpc`) —
+  results now return correct lower-is-better distances for every metric: cosine
+  `1 - similarity`, euclidean true `sqrt(Σ diff²)` (previously squared), and
+  dot-product `-dot`. Fixes a cosine result-ordering bug and squared-L2 values in
+  the unified / hot-buffer search paths. Vector IDs are converted `u128 → u64`
+  with a checked conversion that errors on overflow instead of silently
+  truncating.
+
+### Added
+
+- **Typed `DistanceMetric` on search responses** (proto) — `SearchResponse` /
+  `SearchBatchResponse` now carry a typed `DistanceMetric`; the per-result string
+  label is retained for backward compatibility (additive, wire-compatible).
+- HNSW connectivity diagnostics and distance-contract regression tests.
+
+### Performance
+
+- **Sub-quadratic `optimize()` via NN-descent** (`sochdb-index`) — the exact
+  layer-0 rebuild replaced its O(N²) all-pairs k-NN with NN-descent + exact-f32
+  rerank. `optimize()` is **2.4–7.1× faster** at high dimension (dim 3072
+  euclidean 80.6s → 11.3s, cosine 92s → 20.4s) with recall preserved (18-seed
+  sweep: orphans 0, recall@10 0.9984–0.9996).
+- `optimize()` now serializes against concurrent insert (single-writer lock), and
+  its connectivity-repair loop halves redundant graph traversal per pass.
+
 ## [2.0.6] - 2026-06-14
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "2.0.9"
+version = "2.0.10"
 edition = "2024"
 authors = ["Sushanth <sushanth@sochdb.dev>"]
 license = "AGPL-3.0-or-later"

--- a/sochdb-client/Cargo.toml
+++ b/sochdb-client/Cargo.toml
@@ -15,10 +15,10 @@ readme = "README.md"
 
 [dependencies]
 # Internal crates
-sochdb-core = { version = "2.0.9", path = "../sochdb-core", features = ["analytics"] }
-sochdb-storage = { version = "2.0.9", path = "../sochdb-storage" }
-sochdb-index = { version = "2.0.9", path = "../sochdb-index" }
-sochdb-query = { version = "2.0.9", path = "../sochdb-query" }
+sochdb-core = { version = "2.0.10", path = "../sochdb-core", features = ["analytics"] }
+sochdb-storage = { version = "2.0.10", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.10", path = "../sochdb-index" }
+sochdb-query = { version = "2.0.10", path = "../sochdb-query" }
 
 # Synchronization
 parking_lot = "0.12"

--- a/sochdb-grpc/Cargo.toml
+++ b/sochdb-grpc/Cargo.toml
@@ -21,14 +21,14 @@ default = []
 async = []
 
 [dependencies]
-sochdb-index = { version = "2.0.9", path = "../sochdb-index" }
-sochdb-core = { version = "2.0.9", path = "../sochdb-core", features = ["analytics"] }
-sochdb-kernel = { version = "2.0.9", path = "../sochdb-kernel" }
-sochdb-storage = { version = "2.0.9", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.10", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.10", path = "../sochdb-core", features = ["analytics"] }
+sochdb-kernel = { version = "2.0.10", path = "../sochdb-kernel" }
+sochdb-storage = { version = "2.0.10", path = "../sochdb-storage" }
 # Real SQL engine for the PostgreSQL wire protocol (DatabasePgExecutor).
-sochdb-query = { version = "2.0.9", path = "../sochdb-query" }
-sochdb-memory = { version = "2.0.9", path = "../sochdb-memory" }
-sochdb-vector = { version = "2.0.9", path = "../sochdb-vector" }
+sochdb-query = { version = "2.0.10", path = "../sochdb-query" }
+sochdb-memory = { version = "2.0.10", path = "../sochdb-memory" }
+sochdb-vector = { version = "2.0.10", path = "../sochdb-vector" }
 # Wipe the transient at-rest encryption KEK stack copy after handing it to storage.
 zeroize = "1.8"
 

--- a/sochdb-index/Cargo.toml
+++ b/sochdb-index/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 rustc-hash = "2"  # fast non-crypto hasher for hot-path integer-keyed maps
-sochdb-core = { version = "2.0.9", path = "../sochdb-core" }
+sochdb-core = { version = "2.0.10", path = "../sochdb-core" }
 dashmap = { workspace = true }
 parking_lot = { workspace = true }
 moka = { workspace = true }  # LRU cache for path resolution

--- a/sochdb-kernel/Cargo.toml
+++ b/sochdb-kernel/Cargo.toml
@@ -14,7 +14,7 @@ wasm-plugins = ["wasmtime", "toml"]
 
 [dependencies]
 # Minimal dependencies - only what's needed for ACID core
-sochdb-core = { version = "2.0.9", path = "../sochdb-core" }
+sochdb-core = { version = "2.0.10", path = "../sochdb-core" }
 thiserror = { workspace = true }
 parking_lot = "0.12"
 crossbeam-channel = "0.5"

--- a/sochdb-mcp/Cargo.toml
+++ b/sochdb-mcp/Cargo.toml
@@ -35,9 +35,9 @@ toon-format = { version = "0.4", default-features = false }
 fastembed = { version = "4", optional = true }
 
 # SochDB crates
-sochdb = { version = "2.0.9", path = "../sochdb-client", features = ["embedded"] }
-sochdb-core = { version = "2.0.9", path = "../sochdb-core" }
-sochdb-query = { version = "2.0.9", path = "../sochdb-query" }
+sochdb = { version = "2.0.10", path = "../sochdb-client", features = ["embedded"] }
+sochdb-core = { version = "2.0.10", path = "../sochdb-core" }
+sochdb-query = { version = "2.0.10", path = "../sochdb-query" }
 
 # Minimal additional deps
 tracing = "0.1"

--- a/sochdb-memory/Cargo.toml
+++ b/sochdb-memory/Cargo.toml
@@ -8,10 +8,10 @@ repository.workspace = true
 description = "Bi-temporal agent memory layer with write-time lexical recall"
 
 [dependencies]
-sochdb-core = { version = "2.0.9", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.9", path = "../sochdb-storage", features = ["embedded-sync"] }
-sochdb-query = { version = "2.0.9", path = "../sochdb-query" }
-sochdb-vector = { version = "2.0.9", path = "../sochdb-vector" }
+sochdb-core = { version = "2.0.10", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.10", path = "../sochdb-storage", features = ["embedded-sync"] }
+sochdb-query = { version = "2.0.10", path = "../sochdb-query" }
+sochdb-vector = { version = "2.0.10", path = "../sochdb-vector" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/sochdb-plugin-logging/Cargo.toml
+++ b/sochdb-plugin-logging/Cargo.toml
@@ -6,7 +6,7 @@ description = "JSON structured logging plugin for SochDB"
 license.workspace = true
 
 [dependencies]
-sochdb-kernel = { version = "2.0.9", path = "../sochdb-kernel" }
+sochdb-kernel = { version = "2.0.10", path = "../sochdb-kernel" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"

--- a/sochdb-python/Cargo.toml
+++ b/sochdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sochdb-python"
-version = "2.0.9"
+version = "2.0.10"
 edition = "2024"
 authors = ["Sushanth <sushanth@sochdb.dev>"]
 license = "AGPL-3.0-or-later"

--- a/sochdb-python/pyproject.toml
+++ b/sochdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "sochdb"
-version = "2.0.9"
+version = "2.0.10"
 description = "SochDB - AI-native database with zero-copy vector search via PyO3"
 readme = "README.md"
 license = {text = "AGPL-3.0-or-later"}

--- a/sochdb-query/Cargo.toml
+++ b/sochdb-query/Cargo.toml
@@ -22,9 +22,9 @@ default = []
 experimental = []
 
 [dependencies]
-sochdb-core = { version = "2.0.9", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.9", path = "../sochdb-storage" }
-sochdb-index = { version = "2.0.9", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.10", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.10", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.10", path = "../sochdb-index" }
 ndarray = "0.15"
 rayon = "1.10" # Parallel partitioned GROUP BY aggregation
 thiserror = { workspace = true }

--- a/sochdb-sdk/python/pyproject.toml
+++ b/sochdb-sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sochdb-sdk"
-version = "2.0.9"
+version = "2.0.10"
 description = "SochDB Python SDK — Thin gRPC client for the LLM-optimized database"
 requires-python = ">=3.9"
 license = {text = "AGPL-3.0-or-later"}

--- a/sochdb-storage/Cargo.toml
+++ b/sochdb-storage/Cargo.toml
@@ -40,8 +40,8 @@ encryption = []
 pitr = ["encryption"]
 
 [dependencies]
-sochdb-core = { version = "2.0.9", path = "../sochdb-core" }
-sochdb-index = { version = "2.0.9", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.10", path = "../sochdb-core" }
+sochdb-index = { version = "2.0.10", path = "../sochdb-index" }
 # Tokio is optional - only included when "async" feature is enabled
 tokio = { version = "1.35", features = ["sync", "time", "macros", "rt"], optional = true }
 serde = { workspace = true }

--- a/sochdb-tools/Cargo.toml
+++ b/sochdb-tools/Cargo.toml
@@ -19,10 +19,10 @@ name = "sochdb"
 path = "src/cli.rs"
 
 [dependencies]
-sochdb-index = { version = "2.0.9", path = "../sochdb-index" }
-sochdb-core = { version = "2.0.9", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.9", path = "../sochdb-storage" }
-sochdb-query = { version = "2.0.9", path = "../sochdb-query" }
+sochdb-index = { version = "2.0.10", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.10", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.10", path = "../sochdb-storage" }
+sochdb-query = { version = "2.0.10", path = "../sochdb-query" }
 
 # CLI
 clap = { version = "4.5", features = ["derive", "color", "env"] }

--- a/sochdb-vector/Cargo.toml
+++ b/sochdb-vector/Cargo.toml
@@ -12,9 +12,9 @@ path = "src/lib.rs"
 
 [dependencies]
 # SochDB dependencies
-sochdb-core = { version = "2.0.9", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.9", path = "../sochdb-storage" }
-sochdb-index = { version = "2.0.9", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.10", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.10", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.10", path = "../sochdb-index" }
 
 # Memory mapping for segment files
 memmap2 = "0.9"


### PR DESCRIPTION
Vector-engine recall + performance release (see CHANGELOG):
- HNSW high-dim recall: connectivity-repair after optimize(), append-only.
- Sub-quadratic optimize() via NN-descent (2.4-7.1x faster @ high dim).
- Search distance/ID semantics + typed DistanceMetric on responses (PR #89).