### PR TITLE
chore: ignore benchmark artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ benchmarks/longmemeval/data/
 sochdb-bench/bench-results-*/
 **/embedding_cache/
 *.npy
+# Local benchmark outputs / experiment artifacts
+benchmarks/


### PR DESCRIPTION
## What happened

Benchmark artifacts was accidentally added to the core SochDB repository during local benchmark runs.

## Proposed fix

Add `benchmarks/` to `.gitignore`.

## Note

This only prevents new untracked benchmark files from being added accidentally. It does not remove any already tracked files from Git history or the current GitHub tree.

## Scope

- `.gitignore` only
- no source code changes
- no benchmark deletion
