### PR TITLE
feat(memory): real fastembed semantic embedder (SOCHDB_EMBEDDER)

### DIFF
--- a/sochdb-grpc/Cargo.toml
+++ b/sochdb-grpc/Cargo.toml
@@ -19,6 +19,9 @@ readme = "README.md"
 # future-returning wrappers so the cfg is recognized rather than a phantom gate.
 default = []
 async = []
+# Real semantic embeddings for the memory layer (forwards to sochdb-memory/fastembed).
+# Build the server with `--features fastembed` to enable SOCHDB_EMBEDDER=fastembed:<model>.
+fastembed = ["sochdb-memory/fastembed"]
 
 [dependencies]
 sochdb-index = { version = "2.0.11", path = "../sochdb-index" }

--- a/sochdb-grpc/src/main.rs
+++ b/sochdb-grpc/src/main.rs
@@ -147,8 +147,24 @@ struct Args {
     pg_data_dir: Option<String>,
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Explicit runtime so we can raise the blocking-thread ceiling. Each live
+    // CDC subscription holds one blocking-pool thread for its lifetime (CDC
+    // delivery parks on a std Condvar), and pg-wire SQL + vector ops also use
+    // spawn_blocking. The default cap (512) would let a few hundred
+    // subscriptions starve all other blocking work (CWE-400). Give ample
+    // headroom; subscription counts are independently capped (global + per
+    // tenant) in the subscription service.
+    // NOTE: the ideal fix is async CDC delivery (tokio::sync::Notify) so
+    // subscriptions need no dedicated thread — tracked as a follow-up.
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .max_blocking_threads(2048)
+        .build()?
+        .block_on(run())
+}
+
+async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
     // Initialize tracing
@@ -339,7 +355,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let policy_server = Arc::new(PolicyServer::new());
     let kv_server = KvServer::with_namespace_server(namespace_server.clone())
         .with_policy_server(policy_server.clone());
-    let memory_store = Arc::new(MemoryStore::with_defaults());
+    // Embedder selected by SOCHDB_EMBEDDER (e.g. fastembed:bge-small-en with the
+    // `fastembed` feature; mock/unset otherwise).
+    let memory_store = Arc::new(MemoryStore::from_env());
     let context_server = ContextServer::with_memory_store(Arc::clone(&memory_store));
     let semantic_cache_server = SemanticCacheServer::new();
     let trace_server = TraceServer::new();

--- a/sochdb-memory/Cargo.toml
+++ b/sochdb-memory/Cargo.toml
@@ -7,6 +7,11 @@ license.workspace = true
 repository.workspace = true
 description = "Bi-temporal agent memory layer with write-time lexical recall"
 
+[features]
+default = []
+# Real semantic embeddings via fastembed (forwards to sochdb-query/fastembed).
+fastembed = ["sochdb-query/fastembed"]
+
 [dependencies]
 sochdb-core = { version = "2.0.11", path = "../sochdb-core" }
 sochdb-storage = { version = "2.0.11", path = "../sochdb-storage", features = ["embedded-sync"] }

--- a/sochdb-memory/src/store.rs
+++ b/sochdb-memory/src/store.rs
@@ -109,6 +109,17 @@ impl MemoryStore {
         Self::new(None, MemoryStoreConfig::default())
     }
 
+    /// Build with the embedder selected by the `SOCHDB_EMBEDDER` environment
+    /// variable (e.g. `fastembed:bge-small-en`, or `mock`/unset for the default
+    /// mock embedder). See [`sochdb_query::embedding_provider::embedder_from_env`].
+    pub fn from_env() -> Self {
+        Self::with_embedder(
+            None,
+            MemoryStoreConfig::default(),
+            sochdb_query::embedding_provider::embedder_from_env(),
+        )
+    }
+
     pub fn enrichment_queue(&self) -> &EnrichmentQueue {
         &self.enrichment
     }

--- a/sochdb-query/Cargo.toml
+++ b/sochdb-query/Cargo.toml
@@ -20,9 +20,13 @@ default = []
 # SELECT. Quarantined here so the default build ships a single coherent SQL
 # surface. Enable with `--features experimental` to compile/iterate on it.
 experimental = []
+# Real semantic embeddings via fastembed-rs (ONNX/ort). Heavy native dep; off by
+# default. Enables FastEmbedProvider + `SOCHDB_EMBEDDER=fastembed:<model>`.
+fastembed = ["dep:fastembed"]
 
 [dependencies]
 sochdb-core = { version = "2.0.11", path = "../sochdb-core" }
+fastembed = { version = "4", optional = true }
 sochdb-storage = { version = "2.0.11", path = "../sochdb-storage" }
 sochdb-index = { version = "2.0.11", path = "../sochdb-index" }
 ndarray = "0.15"

--- a/sochdb-query/src/embedding_provider.rs
+++ b/sochdb-query/src/embedding_provider.rs
@@ -519,6 +519,144 @@ impl EmbeddingProvider for LocalOnnxProvider {
 }
 
 // ============================================================================
+// FastEmbed (ONNX) semantic provider  —  feature = "fastembed"
+// ============================================================================
+
+/// Real semantic embedding provider backed by fastembed-rs (ONNX runtime).
+///
+/// Only compiled with the `fastembed` feature (the `ort` native dep is heavy).
+/// The model is downloaded + cached on first construction. `TextEmbedding::embed`
+/// takes `&mut self`, so the model is held behind a `Mutex` to satisfy the
+/// `&self` trait contract (embedding is the bottleneck anyway, so the lock is
+/// not the limiting factor).
+#[cfg(feature = "fastembed")]
+pub struct FastEmbedProvider {
+    model: std::sync::Mutex<fastembed::TextEmbedding>,
+    model_name: String,
+    dimension: usize,
+    max_length: usize,
+}
+
+#[cfg(feature = "fastembed")]
+impl std::fmt::Debug for FastEmbedProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FastEmbedProvider")
+            .field("model_name", &self.model_name)
+            .field("dimension", &self.dimension)
+            .finish()
+    }
+}
+
+#[cfg(feature = "fastembed")]
+impl FastEmbedProvider {
+    /// Construct from a short model alias, e.g. `bge-small-en`, `all-minilm`,
+    /// `bge-base-en`, `bge-large-en`. Downloads + caches the ONNX model on first
+    /// use (set `FASTEMBED_CACHE_DIR` to control the cache location).
+    pub fn new(model_alias: &str) -> EmbeddingResult<Self> {
+        use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+        let (model, dimension) = match model_alias.to_ascii_lowercase().as_str() {
+            "bge-small-en" | "bge-small-en-v1.5" | "bge-small" => {
+                (EmbeddingModel::BGESmallENV15, 384)
+            }
+            "all-minilm" | "all-minilm-l6-v2" | "minilm" => (EmbeddingModel::AllMiniLML6V2, 384),
+            "bge-base-en" | "bge-base-en-v1.5" | "bge-base" => (EmbeddingModel::BGEBaseENV15, 768),
+            "bge-large-en" | "bge-large-en-v1.5" | "bge-large" => {
+                (EmbeddingModel::BGELargeENV15, 1024)
+            }
+            other => {
+                return Err(EmbeddingError::ModelNotAvailable(format!("fastembed:{other}")));
+            }
+        };
+        let model = TextEmbedding::try_new(
+            InitOptions::new(model).with_show_download_progress(false),
+        )
+        .map_err(|e| EmbeddingError::ProviderError(format!("fastembed init failed: {e}")))?;
+        Ok(Self {
+            model: std::sync::Mutex::new(model),
+            model_name: format!("fastembed:{model_alias}"),
+            dimension,
+            max_length: 512,
+        })
+    }
+}
+
+#[cfg(feature = "fastembed")]
+impl EmbeddingProvider for FastEmbedProvider {
+    fn model_name(&self) -> &str {
+        &self.model_name
+    }
+    fn dimension(&self) -> usize {
+        self.dimension
+    }
+    fn max_length(&self) -> usize {
+        self.max_length
+    }
+    fn embed(&self, text: &str) -> EmbeddingResult<Vec<f32>> {
+        let mut m = self
+            .model
+            .lock()
+            .map_err(|_| EmbeddingError::ProviderError("embedder mutex poisoned".into()))?;
+        let mut out = m
+            .embed(vec![text], None)
+            .map_err(|e| EmbeddingError::ProviderError(format!("fastembed embed failed: {e}")))?;
+        out.pop()
+            .ok_or_else(|| EmbeddingError::ProviderError("fastembed returned no embedding".into()))
+    }
+    fn embed_batch(&self, texts: &[&str]) -> EmbeddingResult<Vec<Vec<f32>>> {
+        let mut m = self
+            .model
+            .lock()
+            .map_err(|_| EmbeddingError::ProviderError("embedder mutex poisoned".into()))?;
+        m.embed(texts.to_vec(), None)
+            .map_err(|e| EmbeddingError::ProviderError(format!("fastembed batch failed: {e}")))
+    }
+}
+
+/// Build an embedding provider from the `SOCHDB_EMBEDDER` environment variable.
+///
+/// Accepted values:
+/// * `fastembed:<model>` — real semantic embeddings (requires the `fastembed`
+///   feature; e.g. `fastembed:bge-small-en`).
+/// * `mock` / `hash` / unset — deterministic [`MockEmbeddingProvider`] (384-d).
+///
+/// Falls back to the mock provider (with a warning) when `fastembed` is requested
+/// but the binary was built without the feature, or the model fails to load — so
+/// the server always boots rather than hard-failing on the embedder.
+pub fn embedder_from_env() -> std::sync::Arc<dyn EmbeddingProvider> {
+    let spec = std::env::var("SOCHDB_EMBEDDER").unwrap_or_default();
+    embedder_from_spec(&spec)
+}
+
+/// Like [`embedder_from_env`] but from an explicit spec string.
+pub fn embedder_from_spec(spec: &str) -> std::sync::Arc<dyn EmbeddingProvider> {
+    let spec = spec.trim();
+    if let Some(model) = spec.strip_prefix("fastembed:") {
+        #[cfg(feature = "fastembed")]
+        {
+            match FastEmbedProvider::new(model) {
+                Ok(p) => {
+                    tracing::info!("memory embedder: fastembed:{model} (dim={})", p.dimension());
+                    return std::sync::Arc::new(p);
+                }
+                Err(e) => {
+                    tracing::warn!("fastembed:{model} unavailable ({e}); using mock embedder");
+                }
+            }
+        }
+        #[cfg(not(feature = "fastembed"))]
+        {
+            tracing::warn!(
+                "SOCHDB_EMBEDDER=fastembed:{model} but this binary was built without the \
+                 `fastembed` feature; using mock embedder"
+            );
+        }
+    } else {
+        tracing::info!("memory embedder: mock (384-d) [SOCHDB_EMBEDDER={spec:?}]");
+    }
+    std::sync::Arc::new(MockEmbeddingProvider::new(384))
+}
+
+// ============================================================================
 // Embedding-Enabled Vector Index
 // ============================================================================
 
@@ -750,5 +888,36 @@ mod tests {
 
         let result = provider.embed("this is a very long text that exceeds the limit");
         assert!(matches!(result, Err(EmbeddingError::TextTooLong { .. })));
+    }
+
+    #[cfg(feature = "fastembed")]
+    #[test]
+    fn fastembed_provider_real_semantic_embeddings() {
+        // Downloads + caches bge-small-en on first run. Validates: correct dim,
+        // non-trivial (non-zero) vectors, and real semantics (synonyms rank more
+        // similar than unrelated text) — i.e. NOT the mock fallback.
+        let p = FastEmbedProvider::new("bge-small-en").expect("load bge-small-en");
+        assert_eq!(p.dimension(), 384);
+        let cat = p.embed("a cat sat on the mat").unwrap();
+        let feline = p.embed("a feline rested on the rug").unwrap();
+        let finance = p.embed("quarterly financial earnings report").unwrap();
+        assert_eq!(cat.len(), 384);
+        assert!(cat.iter().any(|&x| x.abs() > 1e-6), "embedding must be non-zero");
+        let cos = |x: &[f32], y: &[f32]| {
+            let d: f32 = x.iter().zip(y).map(|(a, b)| a * b).sum();
+            let nx: f32 = x.iter().map(|a| a * a).sum::<f32>().sqrt();
+            let ny: f32 = y.iter().map(|a| a * a).sum::<f32>().sqrt();
+            d / (nx * ny + 1e-9)
+        };
+        assert!(
+            cos(&cat, &feline) > cos(&cat, &finance),
+            "synonyms ({}) should outrank unrelated text ({})",
+            cos(&cat, &feline),
+            cos(&cat, &finance)
+        );
+
+        // factory path must yield a real provider (not mock) under the feature
+        let from_spec = embedder_from_spec("fastembed:bge-small-en");
+        assert!(from_spec.model_name().starts_with("fastembed:"));
     }
 }


### PR DESCRIPTION
Replaces the mock-stub embedder with a real **fastembed-rs (ONNX)** `EmbeddingProvider`, behind a new opt-in **`fastembed`** feature (heavy `ort` dep, off by default).

- `FastEmbedProvider` (bge-small-en / all-minilm / bge-base / bge-large)
- `embedder_from_env()` / `embedder_from_spec()` mapping `SOCHDB_EMBEDDER=fastembed:<model>`, with graceful mock fallback when the feature is off or a model can't load (server always boots)
- `MemoryStore::from_env()` + gRPC server wired to use it
- Feature chain grpc→memory→query→dep:fastembed

This makes the engine **permanently** capable of real semantic memory retrieval (previously only a lost server-side backport). Validated: builds with+without the feature; functional test asserts real 384-d embeddings with correct semantics (synonyms > unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)