### PR TITLE
chore(release): bump version to 2.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.0.12] - 2026-06-23
+
+### Added
+
+- **Parent/view metadata** (`sochdb-index`, gRPC, proto) — per-vector
+  `parent_id`/`view_type` stored on the index, persisted via a file trailer, and
+  returned in search results (#96).
+- **Real fastembed semantic embedder** (`sochdb-query`/memory/grpc, opt-in
+  `fastembed` feature) — `SOCHDB_EMBEDDER=fastembed:<model>` (bge-small-en,
+  all-minilm, bge-base, bge-large), replacing the mock stub, with graceful mock
+  fallback (#99).
+- **Parent-aware grouped search** (gRPC, proto) — `GroupingOptions` groups vector
+  results by `parent_id` so multiple views of one source don't consume multiple
+  top-K slots; `GroupingInfo` diagnostics (#100).
+
 ## [2.0.11] - 2026-06-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "2.0.11"
+version = "2.0.12"
 edition = "2024"
 authors = ["Sushanth <sushanth@sochdb.dev>"]
 license = "AGPL-3.0-or-later"

--- a/deploy/helm/sochdb/Chart.yaml
+++ b/deploy/helm/sochdb/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sochdb
 description: SochDB - LLM-Optimized Embedded Database for Kubernetes
 type: application
-version: 2.0.11
-appVersion: "2.0.11"
+version: 2.0.12
+appVersion: "2.0.12"
 keywords:
   - database
   - llm

--- a/deploy/helm/sochdb/values-minikube.yaml
+++ b/deploy/helm/sochdb/values-minikube.yaml
@@ -3,7 +3,7 @@
 
 image:
   repository: sochdb/sochdb-grpc
-  tag: "2.0.11"
+  tag: "2.0.12"
   pullPolicy: Never  # Use locally built image in minikube
 
 replicaCount: 1

--- a/deploy/marketplace/aws/product.yaml
+++ b/deploy/marketplace/aws/product.yaml
@@ -13,8 +13,8 @@
 # === Image Publishing ===
 # Push to AWS Marketplace ECR:
 #   aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin <marketplace-ecr>
-#   docker tag sochdb/sochdb-grpc:latest <marketplace-ecr>/sochdb-grpc:2.0.11
-#   docker push <marketplace-ecr>/sochdb-grpc:2.0.11
+#   docker tag sochdb/sochdb-grpc:latest <marketplace-ecr>/sochdb-grpc:2.0.12
+#   docker push <marketplace-ecr>/sochdb-grpc:2.0.12
 
 # === Metering Integration ===
 # For paid plans, the SochDB server integrates with AWS Marketplace Metering API:
@@ -53,7 +53,7 @@ delivery:
   container_images:
     - name: sochdb-grpc
       repository: "<marketplace-ecr>/sochdb-grpc"
-      tag: "2.0.11"
+      tag: "2.0.12"
 
 pricing_models:
   - type: free

--- a/deploy/marketplace/azure/offer.yaml
+++ b/deploy/marketplace/azure/offer.yaml
@@ -14,8 +14,8 @@
 # === Image Publishing ===
 # Push to ACR (linked to Partner Center):
 #   az acr login --name sochdbregistry
-#   docker tag sochdb/sochdb-grpc:latest sochdbregistry.azurecr.io/sochdb-grpc:2.0.11
-#   docker push sochdbregistry.azurecr.io/sochdb-grpc:2.0.11
+#   docker tag sochdb/sochdb-grpc:latest sochdbregistry.azurecr.io/sochdb-grpc:2.0.12
+#   docker push sochdbregistry.azurecr.io/sochdb-grpc:2.0.12
 
 # === CNAB Bundle Structure ===
 # The Helm chart at deploy/helm/sochdb/ is packaged as a CNAB bundle:
@@ -46,7 +46,7 @@ description: |
   - Non-root container, read-only rootfs, mTLS support
 
   Deploy on any AKS cluster with:
-    helm install sochdb oci://sochdbregistry.azurecr.io/helm/sochdb --version 2.0.11
+    helm install sochdb oci://sochdbregistry.azurecr.io/helm/sochdb --version 2.0.12
 
 plans:
   - plan_id: free

--- a/deploy/marketplace/gcp/schema.yaml
+++ b/deploy/marketplace/gcp/schema.yaml
@@ -19,18 +19,18 @@
 # === Image Publishing ===
 # Push to Artifact Registry:
 #   gcloud auth configure-docker us-docker.pkg.dev
-#   docker tag sochdb/sochdb-grpc:latest us-docker.pkg.dev/sochdb-public/sochdb/sochdb-grpc:2.0.11
-#   docker push us-docker.pkg.dev/sochdb-public/sochdb/sochdb-grpc:2.0.11
+#   docker tag sochdb/sochdb-grpc:latest us-docker.pkg.dev/sochdb-public/sochdb/sochdb-grpc:2.0.12
+#   docker push us-docker.pkg.dev/sochdb-public/sochdb/sochdb-grpc:2.0.12
 
 # === Application Schema ===
 # GCP Marketplace apps use a schema.yaml to define parameters:
 x-google-marketplace:
   schemaVersion: v2
   applicationApiVersion: v1beta1
-  publishedVersion: "2.0.11"
+  publishedVersion: "2.0.12"
   publishedVersionMetadata:
     releaseNote: >
-      SochDB 2.0.11 — MultiShardHnswIndex production readiness,
+      SochDB 2.0.12 — MultiShardHnswIndex production readiness,
       Context Queries, token budgeting, gRPC + REST API.
   images:
     sochdb-grpc:

--- a/sochdb-client/Cargo.toml
+++ b/sochdb-client/Cargo.toml
@@ -15,10 +15,10 @@ readme = "README.md"
 
 [dependencies]
 # Internal crates
-sochdb-core = { version = "2.0.11", path = "../sochdb-core", features = ["analytics"] }
-sochdb-storage = { version = "2.0.11", path = "../sochdb-storage" }
-sochdb-index = { version = "2.0.11", path = "../sochdb-index" }
-sochdb-query = { version = "2.0.11", path = "../sochdb-query" }
+sochdb-core = { version = "2.0.12", path = "../sochdb-core", features = ["analytics"] }
+sochdb-storage = { version = "2.0.12", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.12", path = "../sochdb-index" }
+sochdb-query = { version = "2.0.12", path = "../sochdb-query" }
 
 # Synchronization
 parking_lot = "0.12"

--- a/sochdb-grpc/Cargo.toml
+++ b/sochdb-grpc/Cargo.toml
@@ -24,14 +24,14 @@ async = []
 fastembed = ["sochdb-memory/fastembed"]
 
 [dependencies]
-sochdb-index = { version = "2.0.11", path = "../sochdb-index" }
-sochdb-core = { version = "2.0.11", path = "../sochdb-core", features = ["analytics"] }
-sochdb-kernel = { version = "2.0.11", path = "../sochdb-kernel" }
-sochdb-storage = { version = "2.0.11", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.12", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.12", path = "../sochdb-core", features = ["analytics"] }
+sochdb-kernel = { version = "2.0.12", path = "../sochdb-kernel" }
+sochdb-storage = { version = "2.0.12", path = "../sochdb-storage" }
 # Real SQL engine for the PostgreSQL wire protocol (DatabasePgExecutor).
-sochdb-query = { version = "2.0.11", path = "../sochdb-query" }
-sochdb-memory = { version = "2.0.11", path = "../sochdb-memory" }
-sochdb-vector = { version = "2.0.11", path = "../sochdb-vector" }
+sochdb-query = { version = "2.0.12", path = "../sochdb-query" }
+sochdb-memory = { version = "2.0.12", path = "../sochdb-memory" }
+sochdb-vector = { version = "2.0.12", path = "../sochdb-vector" }
 # Wipe the transient at-rest encryption KEK stack copy after handing it to storage.
 zeroize = "1.8"
 

--- a/sochdb-index/Cargo.toml
+++ b/sochdb-index/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 rustc-hash = "2"  # fast non-crypto hasher for hot-path integer-keyed maps
-sochdb-core = { version = "2.0.11", path = "../sochdb-core" }
+sochdb-core = { version = "2.0.12", path = "../sochdb-core" }
 dashmap = { workspace = true }
 parking_lot = { workspace = true }
 moka = { workspace = true }  # LRU cache for path resolution

--- a/sochdb-kernel/Cargo.toml
+++ b/sochdb-kernel/Cargo.toml
@@ -14,7 +14,7 @@ wasm-plugins = ["wasmtime", "toml"]
 
 [dependencies]
 # Minimal dependencies - only what's needed for ACID core
-sochdb-core = { version = "2.0.11", path = "../sochdb-core" }
+sochdb-core = { version = "2.0.12", path = "../sochdb-core" }
 thiserror = { workspace = true }
 parking_lot = "0.12"
 crossbeam-channel = "0.5"

--- a/sochdb-mcp/Cargo.toml
+++ b/sochdb-mcp/Cargo.toml
@@ -35,9 +35,9 @@ toon-format = { version = "0.4", default-features = false }
 fastembed = { version = "4", optional = true }
 
 # SochDB crates
-sochdb = { version = "2.0.11", path = "../sochdb-client", features = ["embedded"] }
-sochdb-core = { version = "2.0.11", path = "../sochdb-core" }
-sochdb-query = { version = "2.0.11", path = "../sochdb-query" }
+sochdb = { version = "2.0.12", path = "../sochdb-client", features = ["embedded"] }
+sochdb-core = { version = "2.0.12", path = "../sochdb-core" }
+sochdb-query = { version = "2.0.12", path = "../sochdb-query" }
 
 # Minimal additional deps
 tracing = "0.1"

--- a/sochdb-memory/Cargo.toml
+++ b/sochdb-memory/Cargo.toml
@@ -13,10 +13,10 @@ default = []
 fastembed = ["sochdb-query/fastembed"]
 
 [dependencies]
-sochdb-core = { version = "2.0.11", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.11", path = "../sochdb-storage", features = ["embedded-sync"] }
-sochdb-query = { version = "2.0.11", path = "../sochdb-query" }
-sochdb-vector = { version = "2.0.11", path = "../sochdb-vector" }
+sochdb-core = { version = "2.0.12", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.12", path = "../sochdb-storage", features = ["embedded-sync"] }
+sochdb-query = { version = "2.0.12", path = "../sochdb-query" }
+sochdb-vector = { version = "2.0.12", path = "../sochdb-vector" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/sochdb-plugin-logging/Cargo.toml
+++ b/sochdb-plugin-logging/Cargo.toml
@@ -6,7 +6,7 @@ description = "JSON structured logging plugin for SochDB"
 license.workspace = true
 
 [dependencies]
-sochdb-kernel = { version = "2.0.11", path = "../sochdb-kernel" }
+sochdb-kernel = { version = "2.0.12", path = "../sochdb-kernel" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"

--- a/sochdb-python/Cargo.toml
+++ b/sochdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sochdb-python"
-version = "2.0.11"
+version = "2.0.12"
 edition = "2024"
 authors = ["Sushanth <sushanth@sochdb.dev>"]
 license = "AGPL-3.0-or-later"

--- a/sochdb-python/pyproject.toml
+++ b/sochdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "sochdb"
-version = "2.0.11"
+version = "2.0.12"
 description = "SochDB - AI-native database with zero-copy vector search via PyO3"
 readme = "README.md"
 license = {text = "AGPL-3.0-or-later"}

--- a/sochdb-python/python/sochdb/__init__.py
+++ b/sochdb-python/python/sochdb/__init__.py
@@ -70,7 +70,7 @@ __all__ = [
     "bulk_build_index",
 ]
 
-__version__ = "2.0.11"
+__version__ = "2.0.12"
 
 
 def _check_native():

--- a/sochdb-query/Cargo.toml
+++ b/sochdb-query/Cargo.toml
@@ -25,10 +25,10 @@ experimental = []
 fastembed = ["dep:fastembed"]
 
 [dependencies]
-sochdb-core = { version = "2.0.11", path = "../sochdb-core" }
+sochdb-core = { version = "2.0.12", path = "../sochdb-core" }
 fastembed = { version = "4", optional = true }
-sochdb-storage = { version = "2.0.11", path = "../sochdb-storage" }
-sochdb-index = { version = "2.0.11", path = "../sochdb-index" }
+sochdb-storage = { version = "2.0.12", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.12", path = "../sochdb-index" }
 ndarray = "0.15"
 rayon = "1.10" # Parallel partitioned GROUP BY aggregation
 thiserror = { workspace = true }

--- a/sochdb-sdk/node/package.json
+++ b/sochdb-sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sochdb/sdk",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "SochDB Node.js SDK — Thin gRPC client for the LLM-optimized database",
   "main": "dist/client.js",
   "types": "dist/client.d.ts",

--- a/sochdb-sdk/python/pyproject.toml
+++ b/sochdb-sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sochdb-sdk"
-version = "2.0.11"
+version = "2.0.12"
 description = "SochDB Python SDK — Thin gRPC client for the LLM-optimized database"
 requires-python = ">=3.9"
 license = {text = "AGPL-3.0-or-later"}

--- a/sochdb-sdk/python/sochdb_sdk/__init__.py
+++ b/sochdb-sdk/python/sochdb_sdk/__init__.py
@@ -11,7 +11,7 @@ from .client import (
     NamespaceClient,
 )
 
-__version__ = "2.0.11"
+__version__ = "2.0.12"
 __all__ = [
     "SochDB",
     "VectorClient",

--- a/sochdb-sdk/python/sochdb_sdk/client.py
+++ b/sochdb-sdk/python/sochdb_sdk/client.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import grpc
 from typing import Any, Dict, List, Optional, Sequence
 
-__version__ = "2.0.11"
+__version__ = "2.0.12"
 __all__ = ["SochDB", "VectorClient", "KvClient", "GraphClient", "SqlClient"]
 
 

--- a/sochdb-storage/Cargo.toml
+++ b/sochdb-storage/Cargo.toml
@@ -40,8 +40,8 @@ encryption = []
 pitr = ["encryption"]
 
 [dependencies]
-sochdb-core = { version = "2.0.11", path = "../sochdb-core" }
-sochdb-index = { version = "2.0.11", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.12", path = "../sochdb-core" }
+sochdb-index = { version = "2.0.12", path = "../sochdb-index" }
 # Tokio is optional - only included when "async" feature is enabled
 tokio = { version = "1.35", features = ["sync", "time", "macros", "rt"], optional = true }
 serde = { workspace = true }

--- a/sochdb-tools/Cargo.toml
+++ b/sochdb-tools/Cargo.toml
@@ -19,10 +19,10 @@ name = "sochdb"
 path = "src/cli.rs"
 
 [dependencies]
-sochdb-index = { version = "2.0.11", path = "../sochdb-index" }
-sochdb-core = { version = "2.0.11", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.11", path = "../sochdb-storage" }
-sochdb-query = { version = "2.0.11", path = "../sochdb-query" }
+sochdb-index = { version = "2.0.12", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.12", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.12", path = "../sochdb-storage" }
+sochdb-query = { version = "2.0.12", path = "../sochdb-query" }
 
 # CLI
 clap = { version = "4.5", features = ["derive", "color", "env"] }

--- a/sochdb-vector/Cargo.toml
+++ b/sochdb-vector/Cargo.toml
@@ -12,9 +12,9 @@ path = "src/lib.rs"
 
 [dependencies]
 # SochDB dependencies
-sochdb-core = { version = "2.0.11", path = "../sochdb-core" }
-sochdb-storage = { version = "2.0.11", path = "../sochdb-storage" }
-sochdb-index = { version = "2.0.11", path = "../sochdb-index" }
+sochdb-core = { version = "2.0.12", path = "../sochdb-core" }
+sochdb-storage = { version = "2.0.12", path = "../sochdb-storage" }
+sochdb-index = { version = "2.0.12", path = "../sochdb-index" }
 
 # Memory mapping for segment files
 memmap2 = "0.9"


### PR DESCRIPTION
Bumps workspace to 2.0.12, capturing features merged since 2.0.11: parent/view metadata (#96), real fastembed semantic embedder (#99), parent-aware grouped search (#100). Version-only (via update_version.py; --check clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)