### PR TITLE
fix(docker): COPY sochdb-memory into the image build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,7 @@ COPY sochdb-kernel ./sochdb-kernel
 COPY sochdb-storage ./sochdb-storage
 COPY sochdb-index ./sochdb-index
 COPY sochdb-query ./sochdb-query
+COPY sochdb-memory ./sochdb-memory
 COPY sochdb-fusion ./sochdb-fusion
 COPY sochdb-client ./sochdb-client
 COPY sochdb-grpc ./sochdb-grpc
@@ -46,7 +47,6 @@ COPY sochdb-wasm ./sochdb-wasm
 COPY sochdb-tools ./sochdb-tools
 COPY sochdb-plugin-logging ./sochdb-plugin-logging
 COPY proto ./proto
-COPY sochdb-fusion ./sochdb-fusion
 
 # Build release binary (limit jobs to avoid compiler SIGSEGV on memory-constrained hosts)
 RUN CARGO_BUILD_JOBS=4 cargo build --release --package sochdb-grpc --bin sochdb-grpc-server


### PR DESCRIPTION
The release image build failed (`failed to read /build/sochdb-memory/Cargo.toml`) — `sochdb-grpc` depends on `sochdb-memory` but the Dockerfile never COPYed it. Adds the missing `COPY sochdb-memory` + removes a duplicate `COPY sochdb-fusion`. Caught while deploying 2.0.12 to the poc box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)