### PR TITLE
fix(docker): COPY remaining workspace members (simulation, bench)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,8 @@ COPY sochdb-storage ./sochdb-storage
 COPY sochdb-index ./sochdb-index
 COPY sochdb-query ./sochdb-query
 COPY sochdb-memory ./sochdb-memory
+COPY sochdb-simulation ./sochdb-simulation
+COPY sochdb-bench ./sochdb-bench
 COPY sochdb-fusion ./sochdb-fusion
 COPY sochdb-client ./sochdb-client
 COPY sochdb-grpc ./sochdb-grpc


### PR DESCRIPTION
Follow-up to #102. The workspace also lists `sochdb-simulation` + `sochdb-bench`; cargo needs every member's manifest to load the workspace, so the image build still failed. COPY them too — now all 16 members (minus the excluded `sochdb-python`) are present and the release image builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)