### PR TITLE
fix(docker): COPY examples/rust workspace member

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,6 +40,7 @@ COPY sochdb-query ./sochdb-query
 COPY sochdb-memory ./sochdb-memory
 COPY sochdb-simulation ./sochdb-simulation
 COPY sochdb-bench ./sochdb-bench
+COPY examples/rust ./examples/rust
 COPY sochdb-fusion ./sochdb-fusion
 COPY sochdb-client ./sochdb-client
 COPY sochdb-grpc ./sochdb-grpc


### PR DESCRIPTION
Final piece after #102/#103 — `examples/rust` is also a workspace member; cargo needs all member manifests. With it COPYed, all 17 members are present and the release image builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)